### PR TITLE
Push chatwoot to 4.0.3

### DIFF
--- a/blueprints/chatwoot/docker-compose.yml
+++ b/blueprints/chatwoot/docker-compose.yml
@@ -23,6 +23,8 @@ x-base-config: &base-config
     - REDIS_URL=${REDIS_URL}
     - ENABLE_ACCOUNT_SIGNUP=${ENABLE_ACCOUNT_SIGNUP}
     - ACTIVE_STORAGE_SERVICE=${ACTIVE_STORAGE_SERVICE}
+  labels:
+    - "traefik.enable=true"
 
 services:
   chatwoot-rails:
@@ -35,6 +37,11 @@ services:
     entrypoint: docker/entrypoints/rails.sh
     command: ['bundle', 'exec', 'sh', '-c', 'rails db:chatwoot_prepare && rails s -p 3000 -b 0.0.0.0']
     restart: always
+    labels:
+      - "traefik.http.routers.chatwoot-web.rule=Host(`${FRONTEND_URL_HOST}`)"
+      - "traefik.http.routers.chatwoot-web.entrypoints=websecure"
+      - "traefik.http.routers.chatwoot-web.tls.certresolver=letsencrypt"
+      - "traefik.http.services.chatwoot-web-service.loadbalancer.server.port=3000"
 
   chatwoot-sidekiq:
     <<: *base-config
@@ -47,22 +54,25 @@ services:
     restart: always
 
   chatwoot-postgres:
-    image: postgres:12
+    image: pgvector/pgvector:pg14
     restart: always
     volumes:
       - chatwoot-postgres-data:/var/lib/postgresql/data
-
+      - ./init-vector.sql:/docker-entrypoint-initdb.d/init-vector.sql
     environment:
       - POSTGRES_DB=${POSTGRES_DATABASE}
       - POSTGRES_USER=${POSTGRES_USERNAME}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    networks:
+      - dokploy-network
 
   chatwoot-redis:
     image: redis:alpine
     restart: always
     volumes:
       - chatwoot-redis-data:/data
-
+    networks:
+      - dokploy-network
 
 networks:
   dokploy-network:
@@ -71,4 +81,4 @@ networks:
 volumes:
   chatwoot-storage:
   chatwoot-postgres-data:
-  chatwoot-redis-data: 
+  chatwoot-redis-data:

--- a/blueprints/chatwoot/docker-compose.yml
+++ b/blueprints/chatwoot/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 x-base-config: &base-config
-  image: chatwoot/chatwoot:v3.14.1
+  image: chatwoot/chatwoot:v4.0.3
   volumes:
     - chatwoot-storage:/app/storage
   networks:

--- a/blueprints/chatwoot/docker-compose.yml
+++ b/blueprints/chatwoot/docker-compose.yml
@@ -23,8 +23,6 @@ x-base-config: &base-config
     - REDIS_URL=${REDIS_URL}
     - ENABLE_ACCOUNT_SIGNUP=${ENABLE_ACCOUNT_SIGNUP}
     - ACTIVE_STORAGE_SERVICE=${ACTIVE_STORAGE_SERVICE}
-  labels:
-    - "traefik.enable=true"
 
 services:
   chatwoot-rails:
@@ -37,11 +35,6 @@ services:
     entrypoint: docker/entrypoints/rails.sh
     command: ['bundle', 'exec', 'sh', '-c', 'rails db:chatwoot_prepare && rails s -p 3000 -b 0.0.0.0']
     restart: always
-    labels:
-      - "traefik.http.routers.chatwoot-web.rule=Host(`${FRONTEND_URL_HOST}`)"
-      - "traefik.http.routers.chatwoot-web.entrypoints=websecure"
-      - "traefik.http.routers.chatwoot-web.tls.certresolver=letsencrypt"
-      - "traefik.http.services.chatwoot-web-service.loadbalancer.server.port=3000"
 
   chatwoot-sidekiq:
     <<: *base-config
@@ -63,16 +56,12 @@ services:
       - POSTGRES_DB=${POSTGRES_DATABASE}
       - POSTGRES_USER=${POSTGRES_USERNAME}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-    networks:
-      - dokploy-network
 
   chatwoot-redis:
     image: redis:alpine
     restart: always
     volumes:
       - chatwoot-redis-data:/data
-    networks:
-      - dokploy-network
 
 networks:
   dokploy-network:


### PR DESCRIPTION
Necessary upgrade to support linux/arm64, because the current (outdated) template doesn't support this architecture.

Makes the necessary changes to PostgreSQL to address breaking changes with Chatwoot. This is likely breaking for existing deployments. Unsure if Dokploy has a feature for template updates?

Tested on an arm64 instance with Dokploy v0.20.4. 