### PR TITLE
chore: bump budibase to 3.5.3

### DIFF
--- a/blueprints/budibase/docker-compose.yml
+++ b/blueprints/budibase/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   apps:
-    image: budibase.docker.scarf.sh/budibase/apps:3.2.25
+    image: budibase.docker.scarf.sh/budibase/apps:3.5.3
     restart: unless-stopped
 
     environment:

--- a/meta.json
+++ b/meta.json
@@ -164,7 +164,7 @@
     {
       "id": "budibase",
       "name": "Budibase",
-      "version": "3.2.25",
+      "version": "3.5.3",
       "description": "Budibase is an open-source low-code platform that saves engineers 100s of hours building forms, portals, and approval apps, securely.",
       "logo": "budibase.svg",
       "links": {


### PR DESCRIPTION
This pull request updates the Budibase application to a newer version in both the Docker configuration and the metadata file.

Version updates:

* [`blueprints/budibase/docker-compose.yml`](diffhunk://#diff-ea31c0f0430334063e2b9f98028556fd365d3c78a0a1563e90f63d8f191c50f6L3-R3): Updated the Budibase apps image version from `3.2.25` to `3.5.3`.
* [`meta.json`](diffhunk://#diff-61e02d96a75c79ab075606e62395cfebf1fc27a12f685dbd6acf7c9b108bb377L167-R167): Updated the Budibase version from `3.2.25` to `3.5.3`.