### PR TITLE
chore: bump n8n version to 1.83.2

### DIFF
--- a/blueprints/n8n/docker-compose.yml
+++ b/blueprints/n8n/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   n8n:
-    image: docker.n8n.io/n8nio/n8n:1.70.3
+    image: docker.n8n.io/n8nio/n8n:1.83.2
     restart: always
     environment:
       - N8N_HOST=${N8N_HOST}

--- a/meta.json
+++ b/meta.json
@@ -212,7 +212,7 @@
     {
       "id": "n8n",
       "name": "n8n",
-      "version": "1.70.3",
+      "version": "1.83.2",
       "description": "n8n is an open source low-code platform for automating workflows and integrations.",
       "logo": "n8n.png",
       "links": {


### PR DESCRIPTION
This pull request includes updates to the `n8n` service version in the `docker-compose.yml` and `meta.json` files to ensure the use of the latest version.

Version updates:

* [`blueprints/n8n/docker-compose.yml`](diffhunk://#diff-8aec1d9f3a3ca0314b3d5940a5bf44fe932ec3b208e88e56c4128d0db0c4336fL4-R4): Updated the `n8n` service image version from `1.70.3` to `1.83.2`.
* [`meta.json`](diffhunk://#diff-61e02d96a75c79ab075606e62395cfebf1fc27a12f685dbd6acf7c9b108bb377L215-R215): Updated the `n8n` version from `1.70.3` to `1.83.2`.