### PR TITLE
chore: bump kimai version to 2.31.0

### DIFF
--- a/blueprints/kimai/docker-compose.yml
+++ b/blueprints/kimai/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: kimai/kimai2:apache-2.26.0
+    image: kimai/kimai2:apache-2.31.0
     restart: unless-stopped
     environment:
       APP_ENV: prod

--- a/meta.json
+++ b/meta.json
@@ -1221,7 +1221,7 @@
     {
       "id": "kimai",
       "name": "Kimai",
-      "version": "2.26.0",
+      "version": "2.31.0",
       "description": "Kimai is a web-based multi-user time-tracking application. Works great for everyone: freelancers, companies, organizations - everyone can track their times, generate reports, create invoices and do so much more.",
       "logo": "kimai.svg",
       "links": {


### PR DESCRIPTION
This pull request includes updates to the Kimai application version in both the Docker configuration and the metadata file.

Version updates:

* [`blueprints/kimai/docker-compose.yml`](diffhunk://#diff-a8c7f6562d76f8710e883260456e7c9aca26a902dbf0816ab748510cf5a4b37aL3-R3): Updated the Kimai Docker image from version `2.26.0` to `2.31.0`.
* [`meta.json`](diffhunk://#diff-61e02d96a75c79ab075606e62395cfebf1fc27a12f685dbd6acf7c9b108bb377L1224-R1224): Updated the Kimai version from `2.26.0` to `2.31.0`.