### PR TITLE
feat: add Qdrant template

### DIFF
--- a/blueprints/qdrant/docker-compose.yml
+++ b/blueprints/qdrant/docker-compose.yml
@@ -1,15 +1,14 @@
-version: "3.8"
 services:
   qdrant:
     image: qdrant/qdrant:latest
     restart: unless-stopped
     ports:
-      - "6333"
-      - "6334"
+      - "6333:6333"
     volumes:
       - qdrant_data:/qdrant/storage
     environment:
       - RUN_MODE=production
+      - QDRANT__LOG_LEVEL=DEBUG
       - QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:6333/health"]

--- a/blueprints/qdrant/docker-compose.yml
+++ b/blueprints/qdrant/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.8"
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    restart: unless-stopped
+    volumes:
+      - qdrant_data:/qdrant/storage
+    environment:
+      - RUN_MODE=production
+      - QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+volumes:
+  qdrant_data: {}

--- a/blueprints/qdrant/docker-compose.yml
+++ b/blueprints/qdrant/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   qdrant:
     image: qdrant/qdrant:latest
     restart: unless-stopped
+    expose:
+      - "6333"
     volumes:
       - qdrant_data:/qdrant/storage
     environment:

--- a/blueprints/qdrant/docker-compose.yml
+++ b/blueprints/qdrant/docker-compose.yml
@@ -3,8 +3,9 @@ services:
   qdrant:
     image: qdrant/qdrant:latest
     restart: unless-stopped
-    expose:
+    ports:
       - "6333"
+      - "6334"
     volumes:
       - qdrant_data:/qdrant/storage
     environment:

--- a/blueprints/qdrant/qdrant.svg
+++ b/blueprints/qdrant/qdrant.svg
@@ -1,0 +1,22 @@
+<svg width="49" height="56" viewBox="0 0 49 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4688_32465)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M38.4886 51.4767L37.3719 20.6899L35.3496 12.5732L48.848 14.0022V51.2437L40.6024 56.0026L38.4886 51.4767Z" fill="#24386C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M48.8468 14L40.6011 18.7622L23.5851 15.0296L3.66794 23.139L0.349609 14L12.4719 7L24.5979 0L36.7206 7L48.8468 14Z" fill="#7589BE"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0.349609 13.9994L8.59528 18.7616L13.3751 32.9769L29.5141 45.89L24.5983 55.9994L12.4723 48.999L0.349609 41.999V13.9994Z" fill="#B2BFE8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M30.0662 38.4209L24.5996 46.4799V56.0006L32.3566 51.525L36.3534 45.5569" fill="#24386C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M24.6021 36.9622L16.8418 23.5262L18.5133 19.0731L24.8677 15.9922L32.3557 23.5265L24.6021 36.9622Z" fill="#7589BE"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.8428 23.5254L24.5997 28.001V36.9595L17.4256 37.2682L13.0859 31.727L16.8428 23.5254Z" fill="#B2BFE8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M24.5996 27.9996L32.3566 23.5244L37.6358 32.3147L31.2472 37.5931L24.5996 36.9585V27.9996Z" fill="#24386C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M32.3553 51.524L40.601 56V18.7622L32.5978 14.1433L24.5983 9.52441L16.5952 14.1433L8.5957 18.7622V37.2411L16.5952 41.86L24.5983 46.4793L32.3553 41.9996V51.524ZM32.3553 32.4789L24.5983 36.9582L16.8414 32.4789V23.524L24.5983 19.0448L32.3553 23.524V32.4789Z" fill="#DC244C"/>
+<path d="M24.6033 46.4828V36.9606L16.8867 32.5195V42.0259L24.6033 46.4828Z" fill="url(#paint0_linear_4688_32465)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_4688_32465" x1="23.1805" y1="38.7809" x2="15.4911" y2="38.7809" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF3364"/>
+<stop offset="1" stop-color="#C91540" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_4688_32465">
+<rect width="48.3" height="56" fill="white" transform="translate(0.349609)"/>
+</clipPath>
+</defs>
+</svg>

--- a/blueprints/qdrant/template.toml
+++ b/blueprints/qdrant/template.toml
@@ -1,0 +1,13 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+mounts = []
+
+[[config.domains]]
+serviceName = "qdrant"
+port = 6333
+host = "${main_domain}"
+
+[config.env]
+QDRANT__SERVICE__API_KEY = "${password:32}"

--- a/blueprints/qdrant/template.toml
+++ b/blueprints/qdrant/template.toml
@@ -6,7 +6,7 @@ mounts = []
 
 [[config.domains]]
 serviceName = "qdrant"
-port = 6_333
+port = 6333
 host = "${main_domain}"
 
 [config.env]

--- a/blueprints/qdrant/template.toml
+++ b/blueprints/qdrant/template.toml
@@ -10,4 +10,4 @@ port = 6333
 host = "${main_domain}"
 
 [config.env]
-QDRANT__SERVICE__API_KEY = "${password:32}"
+QDRANT_API_KEY = "${password:32}"

--- a/blueprints/qdrant/template.toml
+++ b/blueprints/qdrant/template.toml
@@ -6,7 +6,7 @@ mounts = []
 
 [[config.domains]]
 serviceName = "qdrant"
-port = 6333
+port = 6_333
 host = "${main_domain}"
 
 [config.env]

--- a/meta.json
+++ b/meta.json
@@ -2193,5 +2193,22 @@
       "docs": "https://www.bugsink.com/docs/"
     },
     "tags": ["hosting", "self-hosted", "development"]
+  },
+  {
+    "id": "qdrant",
+    "name": "Qdrant",
+    "version": "latest",
+    "description": "A lightning-fast vector database & similarity search engine.",
+    "logo": "qdrant.svg",
+    "links": {
+      "github": "https://github.com/qdrant/qdrant",
+      "website": "https://qdrant.tech/",
+      "docs": "https://qdrant.tech/documentation/"
+    },
+    "tags": [
+      "vector-db",
+      "database",
+      "search"
+    ]
   }
 ]


### PR DESCRIPTION
This PR adds a new template for [Qdrant](https://qdrant.tech/) – a blazing-fast vector search engine, perfect for powering semantic search, LLMs, and AI-driven apps.

### 🏷 Tags
`vector-db`, `database`, `search`, `AI-ready`