### PR TITLE
chore: update Beszel template to v0.10.2

### DIFF
--- a/blueprints/beszel/docker-compose.yml
+++ b/blueprints/beszel/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   beszel:
-    image: henrygd/beszel:0.9.1
+    image: henrygd/beszel:0.10.2
     restart: unless-stopped
     ports:
       - 8090

--- a/meta.json
+++ b/meta.json
@@ -1842,7 +1842,7 @@
   {
     "id": "beszel",
     "name": "Beszel",
-    "version": "0.9.1",
+    "version": "0.10.2",
     "description": "A lightweight server monitoring hub with historical data, docker stats, and alerts.",
     "logo": "logo.svg",
     "links": {


### PR DESCRIPTION
Update Beszel version to 0.10.2 in meta.json and docker-compose.yml

See changes for v0.10.2 -> [https://github.com/henrygd/beszel/releases/tag/v0.10.2](url)