### PR TITLE
⬆️ Upgrate Penpot to 2.6.1

### DIFF
--- a/blueprints/penpot/docker-compose.yml
+++ b/blueprints/penpot/docker-compose.yml
@@ -33,7 +33,7 @@ volumes:
 services:
 
   penpot-frontend:
-    image: "penpotapp/frontend:2.3.2"
+    image: "penpotapp/frontend:2.6.1"
     restart: always
     ports:
       - 8080
@@ -52,7 +52,7 @@ services:
       PENPOT_FLAGS: disable-email-verification enable-smtp enable-prepl-server disable-secure-session-cookies
 
   penpot-backend:
-    image: "penpotapp/backend:2.3.2"
+    image: "penpotapp/backend:2.6.1"
     restart: always
 
     volumes:
@@ -139,7 +139,7 @@ services:
       PENPOT_SMTP_SSL: false
 
   penpot-exporter:
-    image: "penpotapp/exporter:2.3.2"
+    image: "penpotapp/exporter:2.6.1"
     restart: always
 
 

--- a/blueprints/penpot/template.toml
+++ b/blueprints/penpot/template.toml
@@ -6,7 +6,7 @@ mounts = []
 
 [[config.domains]]
 serviceName = "penpot-frontend"
-port = 80
+port = 8080
 host = "${main_domain}"
 
 [config.env]


### PR DESCRIPTION
after version **2.4.0** Penpot's frontend docker image base on **Nginx-unprivileged** instead of **nginx** frontend port changed to 8080 so domain should point to port 8080 instead of 80. update your service port in domain section if you update current running deployment.