### PR TITLE
Fix: Bump version of Formbricks template

### DIFF
--- a/blueprints/formbricks/docker-compose.yml
+++ b/blueprints/formbricks/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   formbricks:
     restart: always
-    image: ghcr.io/formbricks/formbricks:v3.1.3
+    image: ghcr.io/formbricks/formbricks:v3.1.5
     depends_on:
       - postgres
     ports:


### PR DESCRIPTION
This fix bumps the version of the Formbricks template to `3.1.5` from `3.1.3` to resolve #114 

The root cause of the issue is documented here: https://github.com/formbricks/formbricks/issues/4704