### PR TITLE
Fix Formbricks template

### DIFF
--- a/blueprints/formbricks/template.toml
+++ b/blueprints/formbricks/template.toml
@@ -1,7 +1,7 @@
 [variables]
 main_domain = "${domain}"
 secret_base = "${base64:64}"
-encryption_key = "${base64:48}"
+encryption_key = "${password:32}"
 cron_secret = "${base64:32}"
 
 [config]


### PR DESCRIPTION
See https://github.com/Dokploy/templates/issues/122

the idea is to generate a 32-char string [a-z][0-9] but not sure if there's a helper for that? perhaps we could add something like "randomString([a-z][0-9], 32)" or equivalent ?