### PR TITLE
chore: update stalwart mail server image to resolve an issue

### DIFF
--- a/blueprints/stalwart/docker-compose.yml
+++ b/blueprints/stalwart/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stalwart-mail:
-    image: stalwartlabs/mail-server:latest-alpine
+    image: stalwartlabs/stalwart:latest-alpine # for production choose specific version from https://hub.docker.com/r/stalwartlabs/stalwart/tags
     ports:
       - "443"    # HTTPS
       - "8080"   # HTTP API


### PR DESCRIPTION
### fix(stalwart): Correct Docker image to `stalwartlabs/stalwart`

This commit updates the Docker image for the **stalwart** service.

Previously, the service was configured to use:
`stalwartlabs/mail-server:latest-alpine`

This has been changed to the correct image:
`stalwartlabs/stalwart:latest-alpine`

This change resolves an issue where the incorrect image name was being used, ensuring the service utilizes the intended Stalwart mail server image.

Also add a comment recommending to use specific version tags for production environments.