### PR TITLE
fix(blueprint): generate required 32-byte hex secret_key with hash:64

### DIFF
--- a/blueprints/outline/template.toml
+++ b/blueprints/outline/template.toml
@@ -1,7 +1,7 @@
 [variables]
 main_domain = "${domain}"
 dex_domain = "${domain}"
-secret_key = "${base64:32}"
+secret_key = "${hash:64}"
 utils_secret = "${base64:32}"
 client_secret = "${base64:32}"
 postgres_password = "${password}"


### PR DESCRIPTION
Outline expects a hex-encoded 32-byte random `SECRET_KEY` value, but currently a `base64:32` value is generated, making authentication impossible. 

[outline/.env.sample](https://github.com/outline/outline/blob/6a16dc07c154712fbe0ff2cf254a8f8ee97ad4f6/.env.sample#L25-L27)

```
# Generate a hex-encoded 32-byte random key. Use `openssl rand -hex 32` in your
# terminal to generate a random value.
SECRET_KEY=generate_a_new_key
```

```json
{"error":"Invalid key length","level":"error","message":"Failed to encrypt database column (accessToken). The SECRET_KEY environment variable is not the correct length.","stack":"RangeError: Invalid key length\n    at Cipheriv.createCipherBase (node:internal/crypto/cipher:121:19)\n    at Cipheriv.createCipherWithIV (node:internal/crypto/cipher:140:3)\n    at new Cipheriv (node:internal/crypto/cipher:243:3)\n    at Object.createCipheriv (node:crypto:147:10)\n    at Object.createCipheriv (/opt/outline/node_modules/dd-trace/packages/datadog-instrumentations/src/crypto.js:29:27)\n    at UserAuthentication.set (/opt/outline/node_modules/sequelize-encrypted/index.js:48:33)\n    at UserAuthentication.set (/opt/outline/build/server/models/decorators/Encrypted.js:55:59)\n    at UserAuthentication.set (/opt/outline/node_modules/sequelize/lib/model.js:2256:32)\n    at UserAuthentication.set (/opt/outline/node_modules/sequelize/lib/model.js:2241:18)\n    at UserAuthentication._initValues (/opt/outline/node_modules/sequelize/lib/model.js:156:10)\n    at new Model (/opt/outline/node_modules/sequelize/lib/model.js:116:10)\n    at new Model (/opt/outline/node_modules/sequelize-typescript/dist/model/model/model.js:14:9)\n    at new Model (/opt/outline/build/server/models/base/Model.js:24:5)\n    at new IdModel (/opt/outline/build/server/models/base/IdModel.js:20:5)\n    at new UserAuthentication (/opt/outline/build/server/models/UserAuthentication.js:29:5)\n    at new user_authentication (/opt/outline/build/server/models/decorators/Fix.js:21:7)\n    at user_authentication.build (/opt/outline/node_modules/sequelize/lib/model.js:1344:12)\n    at Model.<computed> (/opt/outline/node_modules/sequelize-typescript/dist/model/model/model.js:128:28)\n    at Model.<computed> [as build] (/opt/outline/node_modules/sequelize-typescript/dist/model/model/model.js:138:28)\n    at /opt/outline/node_modules/sequelize/lib/model.js:1358:43\n    at Array.map (<anonymous>)\n    at user_authentication.bulkBuild (/opt/outline/node_modules/sequelize/lib/model.js:1358:22)"}
``` 

Replacing the helper with `hash:64` in `template.toml` generates an appropriate hex key (64-chars = 32-bytes), making the template usable immediately.