### PR TITLE
fix(blueprint): disable healthcheck logging for gotenberg

### DIFF
--- a/blueprints/gotenberg/docker-compose.yml
+++ b/blueprints/gotenberg/docker-compose.yml
@@ -6,13 +6,13 @@ services:
       #       make sure to also change the credentials in Dokploy environment
       GOTENBERG_API_BASIC_AUTH_USERNAME: ${GOTENBERG_API_BASIC_AUTH_USERNAME}
       GOTENBERG_API_BASIC_AUTH_PASSWORD: ${GOTENBERG_API_BASIC_AUTH_PASSWORD}
-    command: [
-      "gotenberg",
+    command:
+      - gotenberg
       # See the full list of options at https://gotenberg.dev/docs/configuration
-      
+
       # Examples:
-      "--api-enable-basic-auth"
-      #"--api-timeout=60s",
-      #"--chromium-auto-start"
-    ]
+      # - --api-timeout=60s
+      # - --chromium-auto-start
+      - --api-enable-basic-auth
+      - --api-disable-health-check-logging
     restart: unless-stopped


### PR DESCRIPTION
Too verbose + takes up space when enabled