### PR TITLE
Update Pocketbase docker-compose.yml

### DIFF
--- a/blueprints/pocketbase/docker-compose.yml
+++ b/blueprints/pocketbase/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   pocketbase:
-    image: docker.io/bakirg/pocketbase-docker:0.28.0
+    image: ghcr.io/muchobien/pocketbase:latest
     restart: unless-stopped
     ports:
       - "8090"


### PR DESCRIPTION
This pull request updates the Docker image used for the `pocketbase` service in the `docker-compose.yml` file to a new repository and tag.

* [`blueprints/pocketbase/docker-compose.yml`](diffhunk://#diff-ad9bfe816b50dd6599dca88c3c5130e80aa8153ed872e45c8734c8f91e1d573cL4-R4): Changed the `pocketbase` service image from `docker.io/bakirg/pocketbase-docker:0.28.0` to `ghcr.io/muchobien/pocketbase:latest`.Change the Pocketbase Docker image to a working version in the compose file.