### PR TITLE
Reload causing wp-app to be removed because of the folder path. [Wordpress Template]

### DIFF
--- a/blueprints/wordpress/docker-compose.yml
+++ b/blueprints/wordpress/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   wordpress:
     image: wordpress:latest
     volumes:
-      - ./wp-app:/var/www/html
+      - ../files/wp-app:/var/www/html
       - ../files/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
     environment:
       WORDPRESS_DB_HOST: wp_db


### PR DESCRIPTION
volumes:
      **_- ./wp-app:/var/www/html_**
      - ../files/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
  
when you use the volume like this, wp-app folder is generated inside /code folder. The code folder is wiped out after reloading but not deploying/redeploying.

After reloading since the wp-app folder is gone there is no way to access the app.