### PR TITLE
[Colanode] Wrong env names

### DIFF
--- a/blueprints/colanode/docker-compose.yml
+++ b/blueprints/colanode/docker-compose.yml
@@ -90,22 +90,22 @@ services:
       # ---------------------------------------------------------------
       # S3 Configuration for Avatars
       # ---------------------------------------------------------------
-      S3_AVATARS_ENDPOINT: "http://minio:9000"
-      S3_AVATARS_ACCESS_KEY: ${MINIO_ROOT_USER}
-      S3_AVATARS_SECRET_KEY: ${MINIO_ROOT_PASSWORD}
-      S3_AVATARS_BUCKET_NAME: "colanode-avatars"
-      S3_AVATARS_REGION: "us-east-1"
-      S3_AVATARS_FORCE_PATH_STYLE: "true"
+      STORAGE_S3_ENDPOINT: "http://minio:9000"
+      STORAGE_S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+      STORAGE_S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD}
+      STORAGE_S3_BUCKET: "colanode-avatars"
+      STORAGE_S3_REGION: "us-east-1"
+      STORAGE_S3_FORCE_PATH_STYLE: "true"
 
       # ---------------------------------------------------------------
       # S3 Configuration for Files
       # ---------------------------------------------------------------
-      S3_FILES_ENDPOINT: "http://minio:9000"
-      S3_FILES_ACCESS_KEY: ${MINIO_ROOT_USER}
-      S3_FILES_SECRET_KEY: ${MINIO_ROOT_PASSWORD}
-      S3_FILES_BUCKET_NAME: "colanode-files"
-      S3_FILES_REGION: "us-east-1"
-      S3_FILES_FORCE_PATH_STYLE: "true"
+      STORAGE_S3_ENDPOINT: "http://minio:9000"
+      STORAGE_S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+      STORAGE_S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD}
+      STORAGE_S3_BUCKET: "colanode-files"
+      STORAGE_S3_REGION: "us-east-1"
+      STORAGE_S3_FORCE_PATH_STYLE: "true"
 
       # ---------------------------------------------------------------
       # SMTP configuration


### PR DESCRIPTION
server was crashing because:
```
  Configuration validation error:
  - storage.endpoint: STORAGE_S3_ENDPOINT is required
  - storage.accessKey: STORAGE_S3_ACCESS_KEY is required
  - storage.secretKey: STORAGE_S3_SECRET_KEY is required
  - storage.bucket: STORAGE_S3_BUCKET is required
  - storage.region: STORAGE_S3_REGION is required
```