### PR TITLE
fix:modify TemplateDialog.tsx to make the dialog support Chinese

### DIFF
--- a/app/src/components/TemplateDialog.tsx
+++ b/app/src/components/TemplateDialog.tsx
@@ -55,7 +55,7 @@ const TemplateDialog: React.FC<TemplateDialogProps> = ({
       config: templateFiles.config || "",
     };
 
-    return btoa(JSON.stringify(configObj, null, 2));
+    return btoa(encodeURIComponent(JSON.stringify(configObj, null, 2)));
   };
 
   return (


### PR DESCRIPTION
Dear author
      I use Chinese to describe   template ,however the browser output an error . Then I found the param of btoa need to be encoded . Now I have wrapped the param and encoded them , to  make sure the function goes well .
      Pls accept my PR
thanks 