### PR TITLE
chore: bump n8n version to 1.104.0

### DIFF
--- a/blueprints/n8n/docker-compose.yml
+++ b/blueprints/n8n/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   n8n:
-    image: docker.n8n.io/n8nio/n8n:1.83.2
+    image: docker.n8n.io/n8nio/n8n:1.104.0
     restart: always
     environment:
       - N8N_HOST=${N8N_HOST}

--- a/meta.json
+++ b/meta.json
@@ -345,7 +345,7 @@
   {
     "id": "n8n",
     "name": "n8n",
-    "version": "1.83.2",
+    "version": "1.104.0",
     "description": "n8n is an open source low-code platform for automating workflows and integrations.",
     "logo": "n8n.png",
     "links": {


### PR DESCRIPTION
## What is this PR about?

This pull request includes updates to the n8n service version in the docker-compose.yml and meta.json files to ensure the use of the latest version.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-suggestions-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works.