### PR TITLE
chore(blueprint): update plane services to v0.27.1

### DIFF
--- a/blueprints/plane/docker-compose.yml
+++ b/blueprints/plane/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3.8'
+version: "3.8"
 
 services:
   web:
-    image: makeplane/plane-frontend:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-frontend:${APP_RELEASE:-v0.27.1}
     command: node web/server.js web
     depends_on:
       - api
@@ -11,7 +11,7 @@ services:
       - .env
 
   space:
-    image: makeplane/plane-space:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-space:${APP_RELEASE:-v0.27.1}
     command: node space/server.js space
     depends_on:
       - api
@@ -21,7 +21,7 @@ services:
       - .env
 
   admin:
-    image: makeplane/plane-admin:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-admin:${APP_RELEASE:-v0.27.1}
     command: node admin/server.js admin
     depends_on:
       - api
@@ -30,7 +30,7 @@ services:
       - .env
 
   live:
-    image: makeplane/plane-live:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-live:${APP_RELEASE:-v0.27.1}
     command: node live/dist/server.js live
     depends_on:
       - api
@@ -39,7 +39,7 @@ services:
       - .env
 
   api:
-    image: makeplane/plane-backend:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-backend:${APP_RELEASE:-v0.27.1}
     command: ./bin/docker-entrypoint-api.sh
     volumes:
       - logs_api:/code/plane/logs
@@ -51,7 +51,7 @@ services:
       - .env
 
   worker:
-    image: makeplane/plane-backend:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-backend:${APP_RELEASE:-v0.27.1}
     command: ./bin/docker-entrypoint-worker.sh
     volumes:
       - logs_worker:/code/plane/logs
@@ -64,7 +64,7 @@ services:
       - .env
 
   beat-worker:
-    image: makeplane/plane-backend:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-backend:${APP_RELEASE:-v0.27.1}
     command: ./bin/docker-entrypoint-beat.sh
     volumes:
       - logs_beat-worker:/code/plane/logs
@@ -77,7 +77,7 @@ services:
       - .env
 
   migrator:
-    image: makeplane/plane-backend:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-backend:${APP_RELEASE:-v0.27.1}
     command: ./bin/docker-entrypoint-migrator.sh
     volumes:
       - logs_migrator:/code/plane/logs
@@ -118,7 +118,7 @@ services:
       - .env
 
   proxy:
-    image: makeplane/plane-proxy:${APP_RELEASE:-v0.25.3}
+    image: makeplane/plane-proxy:${APP_RELEASE:-v0.27.1}
     depends_on:
       - web
       - api
@@ -134,4 +134,4 @@ volumes:
   logs_worker:
   logs_beat-worker:
   logs_migrator:
-  rabbitmq_data:  
+  rabbitmq_data:

--- a/meta.json
+++ b/meta.json
@@ -973,7 +973,7 @@
   {
     "id": "plane",
     "name": "Plane",
-    "version": "v0.25.3",
+    "version": "v0.27.1",
     "description": "Easy, flexible, open source project management software",
     "logo": "plane.png",
     "links": {


### PR DESCRIPTION
- Bumped all makeplane service images from v0.25.3 to v0.27.1
- Updated web, space, admin, live, api, worker, beat-worker, migrator and proxy services
- Version alignment for all plane components in docker-compose blueprint

## What is this PR about?

New PR of Plane

## Checklist

Before submitting this PR, please make sure that:

- [v] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-suggestions-when-creating-a-template
- [v] I have tested the template in my instance (4vcpu 8 GB RAM VPS), so the maintainers don't spend time trying to figure out what's wrong.
- [v] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

Close automatically the related issues using the keywords: `closes #ISSUE_NUMBER`, `fixes #ISSUE_NUMBER`, `resolves #ISSUE_NUMBER`

Example: `closes #123`