### PR TITLE
add debugger UI to browserless template

### DIFF
--- a/blueprints/browserless/docker-compose.yml
+++ b/blueprints/browserless/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/browserless/chromium:v2.23.0
     environment:
       TOKEN: ${BROWSERLESS_TOKEN}
+      ENABLE_DEBUG_VIEWER: "true"
     expose:
       - 3000
     healthcheck:
@@ -14,3 +15,14 @@ services:
       interval: 2s
       timeout: 10s
       retries: 15
+
+  browserless-debugger:
+    image: ghcr.io/browserless/debugger:latest
+    environment:
+      BROWSERLESS_URL: http://browserless:3000
+      BROWSERLESS_TOKEN: ${BROWSERLESS_TOKEN}
+    expose:
+      - 3001
+    depends_on:
+      browserless:
+        condition: service_healthy

--- a/blueprints/browserless/template.toml
+++ b/blueprints/browserless/template.toml
@@ -1,15 +1,22 @@
 [variables]
 main_domain = "${domain}"
+debugger_domain = "${domain}"
 browserless_token = "${password:16}"
 
 [config]
 env = [
-  "BROWERLESS_HOST=${main_domain}",
+  "BROWSERLESS_HOST=${main_domain}",
   "BROWSERLESS_TOKEN=${browserless_token}",
+  "BROWSERLESS_DEBUGGER_HOST=${debugger_domain}",
 ]
-mounts = []
 
 [[config.domains]]
 serviceName = "browserless"
-port = 3_000
+port = 3000
 host = "${main_domain}"
+
+[[config.domains]]
+serviceName = "browserless-debugger"
+port = 3001
+host = "${debugger_domain}"
+path = "/"


### PR DESCRIPTION
## What is this PR about?

- add a debugger UI so user can see browserless instance in web browser

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-suggestions-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

