### PR TITLE
Update Bugsink: Add BEHIND_HTTPS_PROXY env var to docker-compose

### DIFF
--- a/blueprints/bugsink/docker-compose.yml
+++ b/blueprints/bugsink/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       PORT: 8000
       DATABASE_URL: mysql://root:${DB_PASSWORD}@mysql:3306/bugsink
       BASE_URL: http://${MAIN_DOMAIN}
+      BEHIND_HTTPS_PROXY: "false"  # Change this for setups behind a proxy w/ ssl enabled
     healthcheck:
       test: ["CMD-SHELL", "python -c 'import requests; requests.get(\"http://localhost:8000/\").raise_for_status()'"]
       interval: 5s


### PR DESCRIPTION
Summary

This PR introduces a new environment variable, BEHIND_HTTPS_PROXY, to the Bugsink service in docker-compose.yml.

- Default value: false
- Purpose: Allows configuration for deployments running behind an HTTPS proxy.
- Usage: Set to true when deploying in environments with an SSL-enabled proxy.

Addresses CSRF failures caused by scheme mismatch behind proxies. When not set, deployments may see:

- CSRF verification failed, request aborted
- Origin header does not match (deduced) Host: 'https://domain.com/' != 'http://domain.com/' (wrong scheme); fix your proxy's X-Forwarded-Proto and/or the settings SECURE_PROXY_SSL_HEADER/BEHIND_HTTPS_PROXY