### PR TITLE
Fix Garage S3 storage separation

### DIFF
--- a/blueprints/garage-with-ui/docker-compose.yml
+++ b/blueprints/garage-with-ui/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     image: dxflrs/garage:v1.0.1
     volumes:
       - ../files/garage.toml:/etc/garage.toml
-      - /etc/dokploy/templates/${HASH}/meta:/var/lib/garage/meta
-      - /etc/dokploy/templates/${HASH}/data:/var/lib/garage/data
+      - garage-storage:/var/lib/garage
+      - garage-storage:/var/lib/garage
     restart: unless-stopped
     ports:
       - 3900
@@ -23,3 +23,6 @@ services:
       - AUTH_USER_PASS
       - API_BASE_URL
       - S3_ENDPOINT_URL
+
+volumes:
+  garage-storage: {}

--- a/blueprints/garage-with-ui/template.toml
+++ b/blueprints/garage-with-ui/template.toml
@@ -4,7 +4,6 @@ webui_domain = "web-ui.${domain}"
 ht_username = "${username}"
 ht_password = "${password:16}"
 
-
 [config]
 env = [
     "AUTH_USER_PASS=",
@@ -21,8 +20,6 @@ host = "${main_domain}"
 serviceName = "garage-webui"
 port = 3909
 host = "${webui_domain}"
-
-
 
 [[config.mounts]]
 filePath = "garage.toml"


### PR DESCRIPTION
## What is this PR about?

After testing with multiple instances I noticed that they shared their data and meta directories. 

This PR fixes that by using volumes instead.

---

### Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the [README.md file](https://github.com/Dokploy/templates?tab=readme-ov-file#general-suggestions-when-creating-a-template)
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
---