### PR TITLE
fix: add signoz alertmanager provider in the template

### DIFF
--- a/blueprints/signoz/docker-compose.yml
+++ b/blueprints/signoz/docker-compose.yml
@@ -150,6 +150,7 @@ services:
       schema-migrator-sync:
         condition: service_completed_successfully
     environment:
+      - SIGNOZ_ALERTMANAGER_PROVIDER=signoz
       - STORAGE=clickhouse
       - SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN=tcp://clickhouse:9000
       - SIGNOZ_ANALYTICS_ENABLED=false


### PR DESCRIPTION
Signoz template are missing this environment variable:
`      - SIGNOZ_ALERTMANAGER_PROVIDER=signoz`
