### PR TITLE
Update PocketID

### DIFF
--- a/blueprints/pocket-id/docker-compose.yml
+++ b/blueprints/pocket-id/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - APP_URL
       - TRUST_PROXY
       - ENCRYPTION_KEY
-    ports:
-      - 1411
     volumes:
       - pocket-id-data:/app/data
     healthcheck:

--- a/blueprints/pocket-id/docker-compose.yml
+++ b/blueprints/pocket-id/docker-compose.yml
@@ -1,17 +1,17 @@
 services:
   pocket-id:
-    image: ghcr.io/pocket-id/pocket-id:v0.35.1
+    image: ghcr.io/pocket-id/pocket-id:v1
     restart: unless-stopped
     environment:
-      - PUBLIC_UI_CONFIG_DISABLED
-      - PUBLIC_APP_URL
+      - APP_URL
       - TRUST_PROXY
+      - ENCRYPTION_KEY
     ports:
-      - 80
+      - 1411
     volumes:
-      - pocket-id-data:/app/backend/data
+      - pocket-id-data:/app/data
     healthcheck:
-      test: "curl -f http://localhost/health"
+      test: [ "CMD", "/app/pocket-id", "healthcheck" ]
       interval: 1m30s
       timeout: 5s
       retries: 2

--- a/blueprints/pocket-id/template.toml
+++ b/blueprints/pocket-id/template.toml
@@ -6,7 +6,7 @@ mounts = []
 
 [[config.domains]]
 serviceName = "pocket-id"
-port = 80
+port = 1411
 host = "${main_domain}"
 
 [config.env]

--- a/blueprints/pocket-id/template.toml
+++ b/blueprints/pocket-id/template.toml
@@ -10,6 +10,6 @@ port = 80
 host = "${main_domain}"
 
 [config.env]
-PUBLIC_UI_CONFIG_DISABLED = "false"
-PUBLIC_APP_URL = "http://${main_domain}"
+ENCRYPTION_KEY = "CHANGEME: openssl rand -base64 32"
+APP_URL = "http://${main_domain}"
 TRUST_PROXY = "true"

--- a/meta.json
+++ b/meta.json
@@ -3709,7 +3709,7 @@
   {
     "id": "pocket-id",
     "name": "Pocket ID",
-    "version": "1",
+    "version": "v1",
     "description": "A simple and easy-to-use OIDC provider that allows users to authenticate with their passkeys to your services.",
     "logo": "pocket-id.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -3709,7 +3709,7 @@
   {
     "id": "pocket-id",
     "name": "Pocket ID",
-    "version": "0.35.1",
+    "version": "1",
     "description": "A simple and easy-to-use OIDC provider that allows users to authenticate with their passkeys to your services.",
     "logo": "pocket-id.svg",
     "links": {


### PR DESCRIPTION
Summary:
  This PR updates the PocketID service from version 0.35.1 to 1.10 in the docker-compose.yml file. The template was previously pinned to version 0.35.1, and I have bumped it to the latest 1.x version to ensure compatibility and access to the latest features and improvements. Also remove "ports" statement, cuz it is not only unnecessary, but also harmful: the ports stick out at 0.0.0.0 bypassing traefik.

I test in daily use in my environment, and it works okey.