### PR TITLE
Fix invoiceshelf docker image tag

### DIFF
--- a/blueprints/invoiceshelf/docker-compose.yml
+++ b/blueprints/invoiceshelf/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   invoiceshelf-app:
-    image: invoiceshelf/invoiceshelf:latest
+    image: invoiceshelf/invoiceshelf:nightly
 
     volumes:
       - invoiceshelf-app-data:/data

--- a/blueprints/invoiceshelf/template.toml
+++ b/blueprints/invoiceshelf/template.toml
@@ -9,7 +9,7 @@ mounts = []
 
 [[config.domains]]
 serviceName = "invoiceshelf-app"
-port = 80
+port = 8080
 host = "${main_domain}"
 
 [config.env]


### PR DESCRIPTION
Invoice shelf docker images dont have the `latest` tag for some reason which the current template references, the closest to it is `nightly`, so we can switch to it
https://hub.docker.com/r/invoiceshelf/invoiceshelf/tags