### PR TITLE
Update Keycloak deployment for Dokploy with reverse proxy support

### DIFF
--- a/blueprints/keycloak/docker-compose.yml
+++ b/blueprints/keycloak/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.5
-    container_name: keycloak
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
This PR updates the Keycloak Docker Compose configuration to ensure compatibility with Dokploy’s reverse proxy setup.

- Upgraded Keycloak to quay.io/keycloak/keycloak:26.3.5.
- Replaced deprecated KEYCLOAK_ADMIN environment variables with KC_BOOTSTRAP_ADMIN_USERNAME and KC_BOOTSTRAP_ADMIN_PASSWORD.
- Added KC_HOSTNAME to align with the configured domain.
- Enabled KC_HTTP_ENABLED and KC_HEALTH_ENABLED for easier monitoring.
- Configured KC_PROXY_HEADERS=xforwarded to properly handle HTTPS and forwarded headers behind a proxy.
- Simplified networking by removing unnecessary hostname v1 options.
- Add healthcheck for postgres
- remove version from docker compose since this is not needed anymore

This ensures that Keycloak runs reliably behind Dokploy’s reverse proxy without mixed content or CSP errors.