### PR TITLE
Add Open Journal Systems (OJS) template #348

### DIFF
--- a/app/public/blueprints
+++ b/app/public/blueprints
@@ -1,0 +1,1 @@
+../../blueprints

--- a/blueprints/ojs/docker-compose.yml
+++ b/blueprints/ojs/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.8"
+
+services:
+  db:
+    image: mariadb:11.4
+    environment:
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_DATABASE: "${OJS_DB_NAME}"
+      MYSQL_USER: "${OJS_DB_USER}"
+      MYSQL_PASSWORD: "${OJS_DB_PASSWORD}"
+    volumes:
+      - ojs-db-data:/var/lib/mysql
+    restart: unless-stopped
+
+  ojs:
+    image: "pkpofficial/ojs:3_3_0-21"
+    hostname: "${COMPOSE_PROJECT_NAME}"
+    ports:
+      - 80
+      - 443
+    volumes:
+      - /etc/localtime:/etc/localtime
+      - ojs-private-files:/var/www/files
+      - ojs-public-files:/var/www/html/public
+    depends_on:
+      - db
+    restart: unless-stopped
+
+volumes:
+  ojs-db-data: {}
+  ojs-private-files: {}
+  ojs-public-files: {}

--- a/blueprints/ojs/ojs.svg
+++ b/blueprints/ojs/ojs.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="8" fill="#1E40AF"/>
+  <rect x="8" y="8" width="48" height="48" rx="4" fill="white"/>
+  <rect x="12" y="12" width="40" height="4" rx="2" fill="#1E40AF"/>
+  <rect x="12" y="20" width="32" height="3" rx="1.5" fill="#6B7280"/>
+  <rect x="12" y="27" width="36" height="3" rx="1.5" fill="#6B7280"/>
+  <rect x="12" y="34" width="28" height="3" rx="1.5" fill="#6B7280"/>
+  <rect x="12" y="41" width="24" height="3" rx="1.5" fill="#6B7280"/>
+  <circle cx="48" cy="48" r="8" fill="#1E40AF"/>
+  <path d="M44 48L46 50L52 44" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/blueprints/ojs/template.toml
+++ b/blueprints/ojs/template.toml
@@ -1,0 +1,25 @@
+[variables]
+main_domain = "${domain}"
+ojs_password = "${password:16}"
+mysql_root_password = "${password:16}"
+ojs_db_password = "${password:16}"
+
+[config]
+env = [
+    "COMPOSE_PROJECT_NAME=ojs",
+    "MYSQL_ROOT_PASSWORD=${mysql_root_password}",
+    "OJS_DB_NAME=ojs",
+    "OJS_DB_USER=ojs",
+    "OJS_DB_PASSWORD=${ojs_db_password}",
+    "OJS_DB_HOST=db",
+    "OJS_DB_DRIVER=mysqli",
+    "OJS_CLI_INSTALL=0"
+]
+
+[[config.domains]]
+serviceName = "ojs"
+port = 80
+host = "${main_domain}"
+
+# OJS will create its own config.inc.php during installation
+# No custom mounts needed - OJS handles configuration through the web installer

--- a/meta.json
+++ b/meta.json
@@ -3624,6 +3624,24 @@
     ]
   },
   {
+    "id": "ojs",
+    "name": "Open Journal Systems",
+    "version": "3.3.0-21",
+    "description": "Open Journal Systems (OJS) is a journal management and publishing system that has been developed by the Public Knowledge Project through its federally funded efforts to expand and improve access to research.",
+    "logo": "ojs.svg",
+    "links": {
+      "github": "https://github.com/pkp/docker-ojs",
+      "website": "https://pkp.sfu.ca/ojs/",
+      "docs": "https://pkp.sfu.ca/ojs/docs/"
+    },
+    "tags": [
+      "publishing",
+      "journal",
+      "research",
+      "academic"
+    ]
+  },
+  {
     "id": "omni-tools",
     "name": "Omni-Tools",
     "version": "latest",
@@ -3688,24 +3706,6 @@
     },
     "tags": [
       "event"
-    ]
-  },
-  {
-    "id": "ojs",
-    "name": "Open Journal Systems",
-    "version": "3.3.0-21",
-    "description": "Open Journal Systems (OJS) is a journal management and publishing system that has been developed by the Public Knowledge Project through its federally funded efforts to expand and improve access to research.",
-    "logo": "ojs.svg",
-    "links": {
-      "github": "https://github.com/pkp/docker-ojs",
-      "website": "https://pkp.sfu.ca/ojs/",
-      "docs": "https://pkp.sfu.ca/ojs/docs/"
-    },
-    "tags": [
-      "publishing",
-      "journal",
-      "research",
-      "academic"
     ]
   },
   {

--- a/meta.json
+++ b/meta.json
@@ -3691,6 +3691,24 @@
     ]
   },
   {
+    "id": "ojs",
+    "name": "Open Journal Systems",
+    "version": "3.3.0-21",
+    "description": "Open Journal Systems (OJS) is a journal management and publishing system that has been developed by the Public Knowledge Project through its federally funded efforts to expand and improve access to research.",
+    "logo": "ojs.svg",
+    "links": {
+      "github": "https://github.com/pkp/docker-ojs",
+      "website": "https://pkp.sfu.ca/ojs/",
+      "docs": "https://pkp.sfu.ca/ojs/docs/"
+    },
+    "tags": [
+      "publishing",
+      "journal",
+      "research",
+      "academic"
+    ]
+  },
+  {
     "id": "open-fiesta",
     "name": "Open Fiesta",
     "version": "latest",


### PR DESCRIPTION
## 📝 Description
Adds a complete Open Journal Systems (OJS) template for researchers, educational institutes, and journal publishers.

## ✨ Features
- **OJS 3.3.0-21** with MariaDB 11.4 database
- **Custom SVG logo** and proper template metadata
- **Environment variables** for secure database configuration
- **Domain setup** ready for custom domains
- **Persistent storage** for database, files, and configuration

## 🔧 Technical Details
- Uses official `pkpofficial/ojs:3_3_0-21` Docker image
- Auto-generated secure passwords for database
- Proper volume management for data persistence
- Follows Dokploy template best practices

## 🏷️ Tags
- publishing, journal, research, academic

## 🔗 Links
- GitHub: https://github.com/pkp/docker-ojs
- Website: https://pkp.sfu.ca/ojs/
- Docs: https://pkp.sfu.ca/ojs/docs/

## ✅ Testing
- Template deploys successfully without Docker errors
- Logo displays correctly in template browser
- Ready for OJS web installer configuration

<img width="1011" height="787" alt="Screenshot 2025-09-29 at 6 40 47 PM" src="https://github.com/user-attachments/assets/58deb89c-fbb6-4277-8fd0-79c793af5843" />


Closes #348