### PR TITLE
fix(browserless): update image to latest and fix configuration issues

### DIFF
--- a/blueprints/browserless/docker-compose.yml
+++ b/blueprints/browserless/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   browserless:
-    image: ghcr.io/browserless/chromium:v2.23.0
+    image: ghcr.io/browserless/chromium:latest
     environment:
       TOKEN: ${BROWSERLESS_TOKEN}
     expose:

--- a/blueprints/browserless/template.toml
+++ b/blueprints/browserless/template.toml
@@ -4,12 +4,12 @@ browserless_token = "${password:16}"
 
 [config]
 env = [
-  "BROWERLESS_HOST=${main_domain}",
+  "BROWSERLESS_HOST=${main_domain}",
   "BROWSERLESS_TOKEN=${browserless_token}",
 ]
 mounts = []
 
 [[config.domains]]
 serviceName = "browserless"
-port = 3_000
+port = 3000
 host = "${main_domain}"


### PR DESCRIPTION
Updates browserless template with:
- Docker image: v2.23.0 → latest
- Fix typo: BROWERLESS_HOST → BROWSERLESS_HOST  
- Standardize port: 3_000 → 3000


Fix -#418