### PR TITLE
attach RabbitMQ service to dokploy-network for backend connectivity

### DIFF
--- a/blueprints/rabbitmq/docker-compose.yml
+++ b/blueprints/rabbitmq/docker-compose.yml
@@ -10,8 +10,14 @@ services:
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq
     ports:
-      - 15672
-      - 5672
+      - "15672:15672"   # management UI
+      - "5672:5672"     # AMQP broker
+    networks:
+      - dokploy-network
 
 volumes:
   rabbitmq-data: {}
+
+networks:
+  dokploy-network:
+    external: true   # use the existing dokploy-network created by Dokploy


### PR DESCRIPTION
## Description  
This update ensures that the RabbitMQ service is accessible to the backend container by attaching it to the existing `dokploy-network`.  

Previously, RabbitMQ was running on a separate network , which prevented the backend from resolving `rabbitmq` as a hostname and resulted in "unknown host" errors.  

## Changes  
- Added explicit `networks` section for RabbitMQ in `docker-compose.yml`.  
- Configured `dokploy-network` as an external network to reuse the existing Dokploy-managed network.  
- Mapped ports `5672` (AMQP) and `15672` (management UI) explicitly for consistency.  

## Impact  
- Backend services can now connect to RabbitMQ using:  
  ```bash
  amqp://<user>:<pass>@rabbitmq:5672