### PR TITLE
Setup defaults according to obsidian-livesync requirements

### DIFF
--- a/blueprints/obsidian-livesync/template.toml
+++ b/blueprints/obsidian-livesync/template.toml
@@ -17,6 +17,21 @@ COUCHDB_PASSWORD = "${COUCHDB_PASSWORD}"
 [[config.mounts]]
 filePath = "local.ini"
 content = """
+[couchdb]
+single_node = true
+max_document_size = 50000000
+
+[httpd]
+WWW-Authenticate = Basic realm="couchdb"
+enable_cors = true
+
 [chttpd]
 bind_address = 0.0.0.0
+enable_cors = true
+require_valid_user = true
+max_http_request_size = 4294967296
+
+[cors]
+credentials = true
+origins = app://obsidian.md,capacitor://localhost,http://localhost,
 """


### PR DESCRIPTION
Updating the `local.ini` template to align with LiveSync's config requirements. This streamlines setup, removing the manual UI configuration steps.

Deployment logs:
<img width="1000" height="571" alt="image" src="https://github.com/user-attachments/assets/cc965327-5197-4a51-b85d-e7fd997eb648" />

Config requirements check:
<img width="702" height="561" alt="image" src="https://github.com/user-attachments/assets/65722484-327e-4151-8068-b78bcdfd39eb" />
 