### PR TITLE
feat(uptime-kuma): add Docker socket mount for container management

### DIFF
--- a/blueprints/uptime-kuma/docker-compose.yml
+++ b/blueprints/uptime-kuma/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     restart: always
     volumes:
       - uptime-kuma-data:/app/data
+      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   uptime-kuma-data:


### PR DESCRIPTION
## What is this PR about?

New PR of Mount the Docker socket into the Uptime Kuma container to enable Docker API access, allowing the service to monitor and interact with other Docker containers for enhanced uptime tracking.


## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-suggestions-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.
