### PR TITLE
Change group ID from 998 to 988 in docker-compose

### DIFF
--- a/blueprints/coder/docker-compose.yml
+++ b/blueprints/coder/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     group_add:
-      - "998"
+      - "988"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
"988" is the correct one to install coder on dokploy and have the coder templates be able to use docker