### PR TITLE
Fix : Bad Gateway error in Automatisch template - port mismatch -#2870

### DIFF
--- a/blueprints/automatisch/docker-compose.yml
+++ b/blueprints/automatisch/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     image: dockeriddonuts/automatisch:2.0
     restart: unless-stopped
     ports:
-      - 443
+      - 3000
     environment:
       - HOST=${DOMAIN}
       - PROTOCOL=http
-      - PORT=443
+      - PORT=3000
       - APP_ENV=production
       - REDIS_HOST=automatisch-redis
       - REDIS_USERNAME=default


### PR DESCRIPTION
**Problem:** Bad Gateway error due to port mismatch between Traefik (3000) and app (443)

**Fix:** 
- Changed exposed port from 443 to 3000
- Updated PORT env var from 443 to 3000

<img width="1704" height="987" alt="Screenshot 2025-10-23 at 12 53 21 PM" src="https://github.com/user-attachments/assets/c55901ad-dcfe-4d82-ab01-154a29bda0b7" />


Fixes #2870