### PR TITLE
fix(docker): update Booklore image path to new GHCR repository

### DIFF
--- a/blueprints/booklore/docker-compose.yml
+++ b/blueprints/booklore/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   booklore:
-    image: ghcr.io/adityachandelgit/booklore-app:${BOOKLORE_IMAGE_TAG}
+    image: ghcr.io/booklore-app/booklore:${BOOKLORE_IMAGE_TAG}
     environment:
       - DATABASE_URL=jdbc:mariadb://mariadb:3306/${MYSQL_DATABASE}
       - DATABASE_USERNAME=${MYSQL_USER}


### PR DESCRIPTION
This pull request updates the Docker image reference for the `booklore` service in the `docker-compose.yml` file to use the new container registry location.

Container registry update:

* Changed the `image` property for the `booklore` service to use `ghcr.io/booklore-app/booklore` instead of `ghcr.io/adityachandelgit/booklore-app`.