### PR TITLE
Fix(Documenso): Upgrade to v1.12.10 and add automatic signing certificate generation (fixes #1767)

### DIFF
--- a/blueprints/documenso/docker-compose.yml
+++ b/blueprints/documenso/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       start_period: 10s
 
   documenso:
-    image: documenso/documenso:v1.5.6-rc.2
+    image: documenso/documenso:v1.12.10
     depends_on:
       postgres:
         condition: service_healthy
@@ -32,11 +32,94 @@ services:
       - NEXT_PRIVATE_DIRECT_DATABASE_URL=postgres://documenso:password@postgres:5432/documenso
       - NEXT_PUBLIC_UPLOAD_TRANSPORT=database
       - NEXT_PRIVATE_SMTP_TRANSPORT=smtp-auth
-      - NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH=/opt/documenso/cert.p12
+      - NEXT_PRIVATE_SIGNING_TRANSPORT=local
+      - NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH=/app/certs/cert.p12
+      - NEXT_PRIVATE_SIGNING_LOCAL_FILE_PASSPHRASE=${NEXT_PRIVATE_SIGNING_LOCAL_FILE_PASSPHRASE}
+      - CERT_VALID_DAYS=${CERT_VALID_DAYS:-365}
+      - CERT_INFO_COUNTRY_NAME=${CERT_INFO_COUNTRY_NAME:-US}
+      - CERT_INFO_STATE_OR_PROVIDENCE=${CERT_INFO_STATE_OR_PROVIDENCE:-State}
+      - CERT_INFO_LOCALITY_NAME=${CERT_INFO_LOCALITY_NAME:-City}
+      - CERT_INFO_ORGANIZATION_NAME=${CERT_INFO_ORGANIZATION_NAME:-Organization}
+      - CERT_INFO_ORGANIZATIONAL_UNIT=${CERT_INFO_ORGANIZATIONAL_UNIT:-IT Department}
+      - CERT_INFO_EMAIL=${CERT_INFO_EMAIL:-admin@example.com}
+      - DOCUMENSO_HOST=${DOCUMENSO_HOST}
     ports:
       - ${DOCUMENSO_PORT}
-    volumes:
-      - /opt/documenso/cert.p12:/opt/documenso/cert.p12
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        CERT_PASSPHRASE="$${NEXT_PRIVATE_SIGNING_LOCAL_FILE_PASSPHRASE}"
+        
+        # Save original working directory
+        ORIGINAL_DIR="$$(pwd)"
+        
+        # Find openssl binary (should be available in v1.12.10+)
+        OPENSSL_CMD="$$(which openssl 2>/dev/null || command -v openssl 2>/dev/null || echo '/usr/bin/openssl')"
+        
+        # Verify openssl is available
+        if ! $$OPENSSL_CMD version >/dev/null 2>&1; then
+          echo "Error: OpenSSL not found. Please use Documenso image v1.12.10 or later."
+          exit 1
+        fi
+        
+        # Create certificate directory - use /app/certs (writable by user 1001)
+        CERT_DIR="/app/certs"
+        mkdir -p "$$CERT_DIR" || {
+          # Fallback to tmp if app directory not writable
+          CERT_DIR="/tmp/certs"
+          mkdir -p "$$CERT_DIR"
+          echo "Warning: Using fallback directory: $$CERT_DIR"
+        }
+        
+        touch /tmp/cert_info_path
+        cat <<EOF > /tmp/cert_info_path
+        [ req ]
+        distinguished_name = req_distinguished_name
+        prompt = no
+        [ req_distinguished_name ]
+        C            = $${CERT_INFO_COUNTRY_NAME}
+        ST           = $${CERT_INFO_STATE_OR_PROVIDENCE}
+        L            = $${CERT_INFO_LOCALITY_NAME}
+        O            = $${CERT_INFO_ORGANIZATION_NAME}
+        OU           = $${CERT_INFO_ORGANIZATIONAL_UNIT}
+        CN           = $${DOCUMENSO_HOST}
+        emailAddress = $${CERT_INFO_EMAIL}
+        EOF
+
+        cd "$$CERT_DIR"
+        
+        $$OPENSSL_CMD genrsa -out private.key 2048
+        
+        $$OPENSSL_CMD req \
+          -new \
+          -x509 \
+          -key private.key \
+          -out certificate.crt \
+          -days $${CERT_VALID_DAYS} \
+          -config /tmp/cert_info_path
+        
+        $$OPENSSL_CMD pkcs12 \
+          -export \
+          -out cert.p12 \
+          -inkey private.key \
+          -in certificate.crt \
+          -legacy \
+          -passout pass:"$$CERT_PASSPHRASE"
+        
+        # Set permissions (may fail if not root, but will work in Coolify)
+        chown 1001:1001 cert.p12 private.key certificate.crt 2>/dev/null || true
+        chmod 400 cert.p12 private.key certificate.crt
+        
+        # Update environment variable if directory changed
+        if [ "$$CERT_DIR" != "/app/certs" ]; then
+          export NEXT_PRIVATE_SIGNING_LOCAL_FILE_PATH="$$CERT_DIR/cert.p12"
+        fi
+        
+        # Return to original directory before starting application
+        cd "$$ORIGINAL_DIR"
+        
+        ./start.sh
 
 volumes:
   documenso-data:


### PR DESCRIPTION
Fix(Documenso): Upgrade to v1.12.10 and add automatic signing certificate generation (fixes #1767)

## Summary
This PR addresses the issue where Documenso deployments were stuck with a "Pending" status after both parties signed, as reported in [GitHub Issue #1767](https://github.com/documenso/documenso/issues/1767). The root cause was identified as a missing or misconfigured signing certificate within the Documenso container's environment.

## Changes
- Upgraded Documenso image from v1.5.6-rc.2 to v1.12.10 (includes OpenSSL pre-installed)
- Added automatic signing certificate generation in entrypoint script
- Certificate generated at /app/certs/cert.p12 on container startup
- Removed root user requirement (runs as user 1001 for security)
- Uses pre-installed OpenSSL from v1.12.10 image
- Added environment variables for certificate configuration with defaults
- Resolves pending status issue after both parties sign

## Testing
- Tested locally with docker-compose up
- Certificate generation verified working
- All files created with correct permissions
- Container runs without root privileges

## Issues
- Fixes [documenso/documenso#1767](https://github.com/documenso/documenso/issues/1767)