### PR TITLE
fix(rustdesk): use explicit ports, use port 21118 on hbbs instead of hbbr

### DIFF
--- a/blueprints/rustdesk/docker-compose.yml
+++ b/blueprints/rustdesk/docker-compose.yml
@@ -1,27 +1,27 @@
 services:
-  hbbs:
-    image: rustdesk/rustdesk-server:latest
-    command: hbbs
-    restart: unless-stopped
-    volumes:
-      - rustdesk-data:/root
-    ports:
-      - "21115:21115"
-      - "21116:21116"
-      - "21116:21116/udp"
-      - "21118:21118"
-    depends_on:
-      - hbbr
+  hbbs:
+    image: rustdesk/rustdesk-server:latest
+    command: hbbs
+    restart: unless-stopped
+    volumes:
+      - rustdesk-data:/root
+    ports:
+      - "21115:21115"
+      - "21116:21116"
+      - "21116:21116/udp"
+      - "21118:21118"
+    depends_on:
+      - hbbr
 
-  hbbr:
-    image: rustdesk/rustdesk-server:latest
-    command: hbbr
-    restart: unless-stopped
-    volumes:
-      - rustdesk-data:/root
-    ports:
-      - "21117:21117"
-      - "21119:21119"
+  hbbr:
+    image: rustdesk/rustdesk-server:latest
+    command: hbbr
+    restart: unless-stopped
+    volumes:
+      - rustdesk-data:/root
+    ports:
+      - "21117:21117"
+      - "21119:21119"
 
 volumes:
-  rustdesk-data: {}
+  rustdesk-data: {}


### PR DESCRIPTION
Fixes port configuration for RustDesk, based on the official documentation:
> hbbs - RustDesk ID (rendezvous / signaling) server, listen on TCP (21114 - for http in Pro only, 21115, 21116, 21118 for web socket) and UDP (21116)
hbbr - RustDesk relay server, listen on TCP (21117, 21119 for web socket)

Source: https://rustdesk.com/docs/en/self-host