### PR TITLE
changed image to mornedhels/enshrouded-server

### DIFF
--- a/blueprints/enshrouded/docker-compose.yml
+++ b/blueprints/enshrouded/docker-compose.yml
@@ -1,18 +1,25 @@
 services:
   enshrouded:
-    image: sknnr/enshrouded-dedicated-server:latest
+    image: mornedhels/enshrouded-server:latest
+    container_name: enshrouded
+    hostname: enshrouded
     restart: unless-stopped
+    stop_grace_period: 90s
     ports:
       - "15637:15637/udp"
       - "27015:27015/udp"
+    volumes:
+      - enshrouded-persistent-data:/opt/enshrouded
+    # only add ntsync device if your kernel supports it (6.14 or newer)
+    # devices:
+    #   - /dev/ntsync:/dev/ntsync
     environment:
       - SERVER_NAME=${SERVER_NAME}
       - SERVER_PASSWORD=${SERVER_PASSWORD}
-      - PORT=15637
-      - SERVER_SLOTS=6
-      - SERVER_IP=0.0.0.0
-    volumes:
-      - enshrouded-persistent-data:/home/steam/enshrouded/savegame
+      - SERVER_SLOT_COUNT=6
+      - UPDATE_CRON=0 3 * * *
+      - PUID=4711
+      - PGID=4711
 
 volumes:
   enshrouded-persistent-data:

--- a/meta.json
+++ b/meta.json
@@ -1998,7 +1998,7 @@
     "description": "Enshrouded steam dedicated server.",
     "logo": "enshrouded.png",
     "links": {
-      "github": "https://github.com/jsknnr/enshrouded-server",
+      "github": "https://github.com/mornedhels/enshrouded-server",
       "website": "",
       "docs": ""
     },


### PR DESCRIPTION
Hello, I want to update the enshrouded template, I assumed feat/update-template branch is made for that. I changed the docker image from sknnr/enshrouded-dedicated-server to mornedhels/enshrouded-server and easier config


changed image from [jsknnr/enshrouded-dedicated-server](https://github.com/jsknnr/enshrouded-server) to [mornedhels/enshrouded-server](https://github.com/mornedhels/enshrouded-server) for auto-update and easier config of the enshrouded server.