### PR TITLE
Fix supabase realtime service name resolution

### DIFF
--- a/blueprints/supabase/docker-compose.yml
+++ b/blueprints/supabase/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
       DASHBOARD_USERNAME: ${DASHBOARD_USERNAME}
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
+      CONTAINER_PREFIX: ${CONTAINER_PREFIX}
     # https://unix.stackexchange.com/a/294837
     entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
 

--- a/blueprints/supabase/template.toml
+++ b/blueprints/supabase/template.toml
@@ -309,7 +309,7 @@ services:
   ## Secure Realtime routes
   - name: realtime-v1-ws
     _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
-    url: http://realtime-dev.supabase-realtime:4000/socket
+    url: http://realtime-dev.${CONTAINER_PREFIX}-realtime:4000/socket
     protocol: ws
     routes:
       - name: realtime-v1-ws
@@ -329,7 +329,7 @@ services:
             - anon
   - name: realtime-v1-rest
     _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
-    url: http://realtime-dev.supabase-realtime:4000/api
+    url: http://realtime-dev.${CONTAINER_PREFIX}-realtime:4000/api
     protocol: http
     routes:
       - name: realtime-v1-rest
@@ -850,7 +850,7 @@ transforms:
       kong: '.appname == "supabase-kong"'
       auth: '.appname == "supabase-auth"'
       rest: '.appname == "supabase-rest"'
-      realtime: '.appname == "realtime-dev.supabase-realtime"'
+      realtime: '.appname == "realtime-dev.${CONTAINER_PREFIX}-realtime"'
       storage: '.appname == "supabase-storage"'
       functions: '.appname == "supabase-edge-functions"'
       db: '.appname == "supabase-db"'


### PR DESCRIPTION
The realtime service URL of the official `kong.yml` is pointed to `http://realtime-dev.supabase-realtime:4000/socket`, where `supabase-realtime` is the container name set in `docker-compose.yml`. This fixed container name doesn't work with dokploy because the container prefix is randomly generated.

This PR is to expose the CONTAINER_PREFIX environment variable to kong service, then utilize it to format the correct URL for the realtime service.