### PR TITLE
fix(habitica): add user to mongodb replicaset to enable Dokploy DB backups

### DIFF
--- a/blueprints/habitica/docker-compose.yml
+++ b/blueprints/habitica/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       EMAIL_SERVER_PORT: "${EMAIL_SERVER_PORT}"
       EMAIL_SERVER_AUTH_USER: "${EMAIL_SERVER_AUTH_USER}"
       EMAIL_SERVER_AUTH_PASSWORD: "${EMAIL_SERVER_AUTH_PASSWORD}"
+      ADMIN_EMAIL: "${ADMIN_EMAIL}"
 
   client:
     image: docker.io/awinterstein/habitica-client:latest

--- a/blueprints/habitica/docker-compose.yml
+++ b/blueprints/habitica/docker-compose.yml
@@ -36,30 +36,53 @@ services:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_ADMIN_USER}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ADMIN_PASSWORD}
       MONGO_KEYFILE_CONTENT: ${MONGO_KEYFILE_CONTENT}
+      MONGO_HABITICA_USER: ${MONGO_HABITICA_USER}
+      MONGO_HABITICA_PASSWORD: ${MONGO_HABITICA_PASSWORD}
     # ---------------------------------------------------------
     # SMART HEALTHCHECK: Auto-fixes Hostname Mismatches for replicaSet
     # ---------------------------------------------------------
     healthcheck:
       test: |
-        mongosh --port 27017 --quiet -u \"${MONGO_ADMIN_USER}\" -p \"${MONGO_ADMIN_PASSWORD}\" --authenticationDatabase admin --eval "
+        mongosh --port 27017 --quiet -u "${MONGO_ADMIN_USER}" -p "${MONGO_ADMIN_PASSWORD}" --authenticationDatabase admin --eval "
           try {
+            // 1. Hostname Fix
             const config = rs.conf();
-            const currentHost = require("os").hostname();
-
-            // If the config has the WRONG hostname (from a previous container), update it.
+            const currentHost = require('os').hostname() + ':27017';
             if (config.members[0].host !== currentHost) {
-              print('Hostname mismatch detected. Updating config from ' + config.members[0].host + ' to ' + currentHost);
               config.members[0].host = currentHost;
               rs.reconfig(config, { force: true });
             }
+
+            // 2. User Creation Logic
+            const targetDb = db.getSiblingDB('habitica');
+            const hUser = process.env.MONGO_HABITICA_USER;
+            const hPass = process.env.MONGO_HABITICA_PASSWORD;
+
+            // We can only check/create users if we are Primary
+            if (rs.isMaster().ismaster) {
+              if (!targetDb.getUser(hUser)) {
+                print('Creating missing user ' + hUser + '...');
+                targetDb.createUser({ user: hUser, pwd: hPass, roles: ['readWrite'] });
+              }
+              // SUCCESS: User exists and we are Primary
+              quit(0);
+            } else {
+              // We are not Primary yet (still electing), so we cannot confirm user exists.
+              // Fail the check so the dependent app waits.
+              print('Waiting for Primary state...');
+              quit(1);
+            }
           } catch (err) {
-            // If rs.conf() fails, it means we haven't been initiated yet.
-            rs.initiate();
+            // If not initialized, initiate and FAIL this check so we wait for the next cycle
+            try { 
+              rs.initiate({ _id: 'rs', members: [{ _id: 0, host: require('os').hostname() + ':27017' }] }); 
+            } catch (e) {}
+            quit(1);
           }
         "
-      interval: 10s
-      timeout: 30s
-      retries: 3
+      interval: 5s
+      timeout: 10s
+      retries: 20
     volumes:
       - habitica-mongo-data:/data/db
 

--- a/blueprints/habitica/docker-compose.yml
+++ b/blueprints/habitica/docker-compose.yml
@@ -7,7 +7,6 @@ services:
         condition: service_healthy
     environment:
       NODE_DB_URI: "mongodb://${MONGO_HABITICA_USER}:${MONGO_HABITICA_PASSWORD}@mongo/habitica?authSource=habitica"
-      BASE_URL: "${BASE_URL}"
       INVITE_ONLY: "${INVITE_ONLY}"
       EMAIL_SERVER_URL: "${EMAIL_SERVER_URL}"
       EMAIL_SERVER_PORT: "${EMAIL_SERVER_PORT}"

--- a/blueprints/habitica/docker-compose.yml
+++ b/blueprints/habitica/docker-compose.yml
@@ -58,7 +58,7 @@ services:
         "
       interval: 10s
       timeout: 30s
-      retries: 30
+      retries: 3
     volumes:
       - habitica-mongo-data:/data/db
 

--- a/blueprints/habitica/docker-compose.yml
+++ b/blueprints/habitica/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   server:
     image: docker.io/awinterstein/habitica-server:latest
@@ -7,7 +5,13 @@ services:
     depends_on:
       - mongo
     environment:
-      - NODE_DB_URI=mongodb://mongo/habitica
+      NODE_DB_URI: "mongodb://${MONGO_HABITICA_USER}:${MONGO_HABITICA_PASSWORD}@mongo/habitica?authSource=habitica"
+      BASE_URL: "${BASE_URL}"
+      INVITE_ONLY: "${INVITE_ONLY}"
+      EMAIL_SERVER_URL: "${EMAIL_SERVER_URL}"
+      EMAIL_SERVER_PORT: "${EMAIL_SERVER_PORT}"
+      EMAIL_SERVER_AUTH_USER: "${EMAIL_SERVER_AUTH_USER}"
+      EMAIL_SERVER_AUTH_PASSWORD: "${EMAIL_SERVER_AUTH_PASSWORD}"
 
   client:
     image: docker.io/awinterstein/habitica-client:latest

--- a/blueprints/habitica/docker-compose.yml
+++ b/blueprints/habitica/docker-compose.yml
@@ -3,7 +3,8 @@ services:
     image: docker.io/awinterstein/habitica-server:latest
     restart: unless-stopped
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     environment:
       NODE_DB_URI: "mongodb://${MONGO_HABITICA_USER}:${MONGO_HABITICA_PASSWORD}@mongo/habitica?authSource=habitica"
       BASE_URL: "${BASE_URL}"

--- a/blueprints/habitica/docker-compose.yml
+++ b/blueprints/habitica/docker-compose.yml
@@ -24,9 +24,38 @@ services:
   mongo:
     image: docker.io/mongo:latest
     restart: unless-stopped
-    command: ["--replSet", "rs", "--bind_ip_all", "--port", "27017"]
+    command: >
+      bash -c "
+        echo \"${MONGO_KEYFILE_CONTENT}\" > /etc/mongo-keyfile &&
+        chown 999:999 /etc/mongo-keyfile &&
+        chmod 400 /etc/mongo-keyfile &&
+        exec docker-entrypoint.sh mongod --replSet rs --bind_ip_all --port 27017 --keyFile /etc/mongo-keyfile
+      "
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ADMIN_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ADMIN_PASSWORD}
+      MONGO_KEYFILE_CONTENT: ${MONGO_KEYFILE_CONTENT}
+    # ---------------------------------------------------------
+    # SMART HEALTHCHECK: Auto-fixes Hostname Mismatches for replicaSet
+    # ---------------------------------------------------------
     healthcheck:
-      test: echo "try { rs.status() } catch (err) { rs.initiate() }" | mongosh --port 27017 --quiet
+      test: |
+        mongosh --port 27017 --quiet -u \"${MONGO_ADMIN_USER}\" -p \"${MONGO_ADMIN_PASSWORD}\" --authenticationDatabase admin --eval "
+          try {
+            const config = rs.conf();
+            const currentHost = require("os").hostname();
+
+            // If the config has the WRONG hostname (from a previous container), update it.
+            if (config.members[0].host !== currentHost) {
+              print('Hostname mismatch detected. Updating config from ' + config.members[0].host + ' to ' + currentHost);
+              config.members[0].host = currentHost;
+              rs.reconfig(config, { force: true });
+            }
+          } catch (err) {
+            // If rs.conf() fails, it means we haven't been initiated yet.
+            rs.initiate();
+          }
+        "
       interval: 10s
       timeout: 30s
       retries: 30

--- a/blueprints/habitica/template.toml
+++ b/blueprints/habitica/template.toml
@@ -1,6 +1,9 @@
 [variables]
 main_domain = "${domain}"
 mail_password = "${password:32}"
+mongo_key = "${base64:756}"
+mongo_admin_password = "${password}"
+mongo_habitica_password = "${password}"
 
 [config]
 [[config.domains]]
@@ -9,16 +12,21 @@ port = 80
 host = "habitica.${main_domain}"
 
 [config.env]
-
-BASE_URL="https://habitica.${main_domain}"
-INVITE_ONLY="false"
-EMAIL_SERVER_URL="mail.example.com"
-EMAIL_SERVER_PORT="587"
-EMAIL_SERVER_AUTH_USER="mail_user"
-EMAIL_SERVER_AUTH_PASSWORD="${mail_password}"
+BASE_URL = "https://habitica.${main_domain}"
+INVITE_ONLY = "false"
+EMAIL_SERVER_URL = "mail.example.com"
+EMAIL_SERVER_PORT = "587"
+EMAIL_SERVER_AUTH_USER = "mail_user"
+EMAIL_SERVER_AUTH_PASSWORD = "${mail_password}"
+MONGO_KEYFILE_CONTENT = "${mongo_key}"
+MONGO_ADMIN_USER = "admin"
+MONGO_ADMIN_PASSWORD = "${mongo_admin_password}"
+MONGO_HABITICA_USER = "habitica"
+MONGO_HABITICA_PASSWORD = "${mongo_habitica_password}"
 
 [[config.mounts]]
 serviceName = "mongo"
 type = "volume"
 source = "habitica-mongo-data"
 target = "/data/db"
+

--- a/blueprints/habitica/template.toml
+++ b/blueprints/habitica/template.toml
@@ -23,10 +23,10 @@ MONGO_ADMIN_USER = "admin"
 MONGO_ADMIN_PASSWORD = "${mongo_admin_password}"
 MONGO_HABITICA_USER = "habitica"
 MONGO_HABITICA_PASSWORD = "${mongo_habitica_password}"
+ADMIN_EMAIL = "no-reply@${main_domain}"
 
 [[config.mounts]]
 serviceName = "mongo"
 type = "volume"
 source = "habitica-mongo-data"
 target = "/data/db"
-


### PR DESCRIPTION
# What is this PR about?
Updates existing Habitica deployment to add user authentication via admin + habitica users on the MongoDB replicaSet via keyfile.

My main motivation was that I wanted to add DB backups, and Dokploy requires 1 user for this functionality to work.

# Checklist
Before submitting this PR, please make sure that:

- [x]  I have read the suggestions in the [README.md file](https://github.com/Dokploy/templates?tab=readme-ov-file#general-suggestions-when-creating-a-template)
- [x]  I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.