### PR TITLE
add: restart policy to MinIO service

### DIFF
--- a/blueprints/minio/docker-compose.yml
+++ b/blueprints/minio/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "3.8"
 services:
   minio:
     # after RELEASE.2025-04-22T22-12-26Z, minio removed most of the admin UI, if you want to use the admin UI, uncomment the line below
     # image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     # if you uncommented the line above, comment the line below
     image: minio/minio
+    restart: unless-stopped
     volumes:
       # by default, the MinIO container will use a volume named minio-data
       # to store its data. This volume is created automatically by Docker.


### PR DESCRIPTION
restart: unless-stopped is a Docker restart policy that automatically restarts a container if it stops due to an error or Docker daemon restart