### PR TITLE
Fix Plane env URLs

### DIFF
--- a/blueprints/plane/template.toml
+++ b/blueprints/plane/template.toml
@@ -9,7 +9,7 @@ secret_key = "${base64:48}"
 [config]
 env = [
 "Domain=${domain}",
-"WEB_URL=${Domain}",
+"WEB_URL=https://${Domain}",
 "PGHOST=plane-db",
 "PGDATABASE=plane",
 "POSTGRES_USER=${username}",
@@ -36,7 +36,7 @@ env = [
 "RABBITMQ_DEFAULT_PASS=${rabbitmq_pass}",
 "RABBITMQ_DEFAULT_VHOST=plane",
 "RABBITMQ_VHOST=plane",
-"API_BASE_URL=http://api:8000",
+"API_BASE_URL=https://${Domain}/api",
 "DEBUG=0",
 "SENTRY_DSN=",
 "SENTRY_ENVIRONMENT=production",


### PR DESCRIPTION
## Summary
- set Plane WEB_URL to include https scheme
- point API_BASE_URL to the public proxy endpoint using https

## Testing
- not run (not needed for env template changes)