### PR TITLE
refactor: update RustFS configuration in docker-compose and template files

### DIFF
--- a/blueprints/rustfs/docker-compose.yml
+++ b/blueprints/rustfs/docker-compose.yml
@@ -3,18 +3,22 @@ version: "3.8"
 services:
   rustfs:
     image: rustfs/rustfs:latest
+    restart: unless-stopped
     volumes:
       - rustfs-data:/data
     environment:
       - RUSTFS_ACCESS_KEY
       - RUSTFS_SECRET_KEY
-      - RUSTFS_ADDRESS=0.0.0.0:9000
-      - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001
-      - RUSTFS_CONSOLE_ENABLE=true
-      - RUSTFS_CORS_ALLOWED_ORIGINS=*
-      - RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS=*
+      - RUSTFS_ADDRESS
+      - RUSTFS_CONSOLE_ADDRESS
+      - RUSTFS_EXTERNAL_URL
+      - RUSTFS_CONSOLE_EXTERNAL_URL
+      - RUSTFS_CONSOLE_ENABLE
+      - RUSTFS_CORS_ALLOWED_ORIGINS
+      - RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS
+      - RUSTFS_REGION
+      - RUSTFS_LOG_LEVEL
     command: /data
-    restart: unless-stopped
 
 volumes:
-  rustfs-data:
+  rustfs-data: {}

--- a/blueprints/rustfs/template.toml
+++ b/blueprints/rustfs/template.toml
@@ -3,14 +3,27 @@ console_domain = "${domain}"
 api_domain = "${domain}"
 access_key = "rustfsadmin"
 secret_key = "${password:16}"
+console_enable = "true"
+cors_allowed_origins = "*"
+console_cors_allowed_origins = "*"
+address = "0.0.0.0:9000"
+console_address = "0.0.0.0:9001"
+region = "us-east-1"
+log_level = "debug"
 
 [config]
 env = [
   "RUSTFS_ACCESS_KEY=${access_key}",
   "RUSTFS_SECRET_KEY=${secret_key}",
-  "",
-  "## SET THE API URL IN CONSOLE CONFIG BY CLICKING THE COG",
-  "## API URL: ${api_domain}",
+  "RUSTFS_EXTERNAL_URL=${api_domain}",
+  "RUSTFS_CONSOLE_EXTERNAL_URL=${console_domain}",
+  "RUSTFS_CONSOLE_ENABLE=${console_enable}",
+  "RUSTFS_CORS_ALLOWED_ORIGINS=${cors_allowed_origins}",
+  "RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS=${console_cors_allowed_origins}",
+  "RUSTFS_ADDRESS=${address}",
+  "RUSTFS_CONSOLE_ADDRESS=${console_address}",
+  "RUSTFS_REGION=${region}",
+  "RUSTFS_LOG_LEVEL=${log_level}",
 ]
 mounts = []
 


### PR DESCRIPTION
This pull request updates the RustFS blueprint configuration to improve environment variable management and make the service setup more flexible and explicit. The changes mainly focus on how environment variables are defined and passed to the Docker container, as well as providing more sensible defaults in the template.

Key configuration improvements:

**Environment variable handling:**

* In `docker-compose.yml`, environment variables are now listed without hardcoded values, making it easier to override them via external configuration or secrets. Additional variables like `RUSTFS_EXTERNAL_URL`, `RUSTFS_CONSOLE_EXTERNAL_URL`, `RUSTFS_REGION`, and `RUSTFS_LOG_LEVEL` have been added for greater flexibility.
* In `template.toml`, default values for key environment variables (such as `address`, `console_address`, `region`, and `log_level`) are now explicitly set, ensuring a consistent setup out of the box.

**Blueprint template enhancements:**

* The `[config].env` array in `template.toml` now includes all relevant environment variables, dynamically populated from the template variables, making configuration more transparent and easier to maintain.
* CORS and console settings are now explicitly enabled by default in the template, improving the out-of-the-box developer experience.

These changes help standardize and clarify the configuration process for deploying RustFS using Docker Compose and the blueprint template.