### PR TITLE
fix: superset template fixed versions, postgres volume mount and network instructions

### DIFF
--- a/blueprints/superset/docker-compose.yml
+++ b/blueprints/superset/docker-compose.yml
@@ -15,23 +15,14 @@
 # ## NETWORK INSTRUCTIONS
 #
 # If you want to connect superset with other internal databases managed by
-# Dokploy (on dokploy-network) using internal hostnames, you will need to
-# uncomment the `networks` section, both for the superset container and
-# at the very bottom of this docker-compose template.
+# Dokploy using internal hostnames, you will need to connect the `superset`
+# container to those networks.
 #
-# Note that the `superset` service name/hostname will not be unique on the
-# global `dokploy-network`. If you plan to:
-#
-# 1. deploy a second instance of superset on dokploy-network, and
-# 2. have other containers on dokploy-network utilise the second instance's
-#    Superset API (https://superset.apache.org/docs/api)
-#
-# Please change the service name of the second instance.
 
 services:
   superset:
-    image: amancevice/superset
-    restart: always
+    image: amancevice/superset:5.0.0
+    restart: unless-stopped
     #networks:
     #  - dokploy-network
     depends_on:
@@ -52,14 +43,14 @@ services:
       REDIS_HOST: superset_redis
 
   superset_postgres:
-    image: postgres
-    restart: always
+    image: postgres:18
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
-      - superset_postgres_data:/var/lib/postgresql/data
+      - superset_postgres_data:/var/lib/postgresql/18/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 30s
@@ -67,8 +58,8 @@ services:
       retries: 3
 
   superset_redis:
-    image: redis
-    restart: always
+    image: redis:8
+    restart: unless-stopped
     volumes:
       - superset_redis_data:/data
     command: redis-server --requirepass ${REDIS_PASSWORD}
@@ -77,10 +68,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-
-#networks:
-#  dokploy-network:
-#    external: true
 
 volumes:
   superset_postgres_data:

--- a/blueprints/superset/docker-compose.yml
+++ b/blueprints/superset/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
-      - superset_postgres_data:/var/lib/postgresql/18/data
+      - superset_postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 30s

--- a/blueprints/superset/docker-compose.yml
+++ b/blueprints/superset/docker-compose.yml
@@ -21,7 +21,7 @@
 
 services:
   superset:
-    image: amancevice/superset:5.0.0
+    image: amancevice/superset:6.0.0
     restart: unless-stopped
     #networks:
     #  - dokploy-network

--- a/blueprints/superset/template.toml
+++ b/blueprints/superset/template.toml
@@ -3,7 +3,6 @@ main_domain = "${domain}"
 secret_key = "${password:30}"
 postgres_password = "${password:30}"
 redis_password = "${password:30}"
-mapbox_api_key = ""
 
 [[config.domains]]
 serviceName = "superset"
@@ -12,7 +11,7 @@ host = "${main_domain}"
 
 [config.env]
 SECRET_KEY = "${secret_key}"
-MAPBOX_API_KEY = "${mapbox_api_key}"
+MAPBOX_API_KEY = ""
 POSTGRES_DB = "superset"
 POSTGRES_USER = "superset"
 POSTGRES_PASSWORD = "${postgres_password}"

--- a/meta.json
+++ b/meta.json
@@ -5503,7 +5503,7 @@
   {
     "id": "superset",
     "name": "Superset (Unofficial)",
-    "version": "latest",
+    "version": "5.0.0",
     "description": "Data visualization and data exploration platform.",
     "logo": "superset.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -5503,7 +5503,7 @@
   {
     "id": "superset",
     "name": "Superset (Unofficial)",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "description": "Data visualization and data exploration platform.",
     "logo": "superset.svg",
     "links": {


### PR DESCRIPTION
## What is this PR about?

Updating postgres template - fixed version.

Also fixed postgres volume mount which changed in v18, and simplified network instructions.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

