### PR TITLE
refactor: update docker-compose.yml to include version and restart policy

### DIFF
--- a/blueprints/excalidraw/docker-compose.yml
+++ b/blueprints/excalidraw/docker-compose.yml
@@ -1,5 +1,8 @@
+version: "3.8"
+
 services:
   excalidraw:
+    restart: unless-stopped
     image: excalidraw/excalidraw:latest
     healthcheck:
       test:


### PR DESCRIPTION
This pull request introduces a minor update to the `docker-compose.yml` file for the Excalidraw blueprint. The change ensures that the `excalidraw` service will automatically restart unless it is explicitly stopped, improving service reliability.

- Added the `restart: unless-stopped` policy to the `excalidraw` service in `docker-compose.yml` to enhance container uptime.