### PR TITLE
feat: add Payload CMS 3.0 template

### DIFF
--- a/blueprints/payload/docker-compose.yml
+++ b/blueprints/payload/docker-compose.yml
@@ -1,0 +1,60 @@
+services:
+  payload:
+    image: sugarlin/payload:3.0
+    environment:
+      - DATABASE_URI=postgresql://payload:${POSTGRES_PASSWORD}@postgres:5432/payload
+      - PAYLOAD_SECRET=${PAYLOAD_SECRET}
+      - NEXT_PUBLIC_SERVER_URL=https://${PAYLOAD_DOMAIN}
+      - S3_ENABLED=true
+      - S3_ENDPOINT=http://minio:9000
+      - S3_BUCKET=payload-uploads
+      - S3_ACCESS_KEY=${MINIO_ACCESS_KEY}
+      - S3_SECRET_KEY=${MINIO_SECRET_KEY}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_started
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=payload
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=payload
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U payload"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ACCESS_KEY}
+      - MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY}
+    volumes:
+      - minio_data:/data
+    restart: unless-stopped
+
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5;
+      mc alias set myminio http://minio:9000 $${MINIO_ACCESS_KEY} $${MINIO_SECRET_KEY};
+      mc mb myminio/payload-uploads --ignore-existing;
+      mc anonymous set download myminio/payload-uploads;
+      exit 0;
+      "
+
+volumes:
+  postgres_data:
+  minio_data:

--- a/blueprints/payload/payload.svg
+++ b/blueprints/payload/payload.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <rect width="512" height="512" rx="64" fill="#0F0F0F"/>
+  <path d="M150 128h120c55.228 0 100 44.772 100 100s-44.772 100-100 100H200v56c0 11.046-8.954 20-20 20h-30V128z" fill="#FFFFFF"/>
+  <path d="M200 178h50c27.614 0 50 22.386 50 50s-22.386 50-50 50h-50V178z" fill="#0F0F0F"/>
+</svg>

--- a/blueprints/payload/template.toml
+++ b/blueprints/payload/template.toml
@@ -1,0 +1,27 @@
+[variables]
+main_domain = "${domain}"
+minio_domain = "minio-${domain}"
+postgres_password = "${password:32}"
+payload_secret = "${password:64}"
+minio_access_key = "${password:20}"
+minio_secret_key = "${password:40}"
+
+[config]
+env = [
+  "PAYLOAD_DOMAIN=${main_domain}",
+  "POSTGRES_PASSWORD=${postgres_password}",
+  "PAYLOAD_SECRET=${payload_secret}",
+  "MINIO_ACCESS_KEY=${minio_access_key}",
+  "MINIO_SECRET_KEY=${minio_secret_key}"
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "payload"
+port = 3000
+host = "${main_domain}"
+
+[[config.domains]]
+serviceName = "minio"
+port = 9001
+host = "${minio_domain}"


### PR DESCRIPTION
## Summary

- Add one-click deployment template for **Payload CMS 3.0**
- Includes PostgreSQL database and MinIO S3-compatible storage
- Uses runtime initialization approach for flexibility

## Services

| Service | Image | Purpose |
|---------|-------|---------|
| payload | sugarlin/payload:3.0 | Payload CMS application |
| postgres | postgres:16-alpine | Database |
| minio | minio/minio:latest | S3-compatible object storage |
| minio-init | minio/mc:latest | Bucket initialization |

## Test plan

- [ ] Deploy template in Dokploy instance
- [ ] Verify Payload admin panel loads
- [ ] Test media upload with MinIO storage
- [ ] Confirm database connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)