### PR TITLE
Update image versions in docker-compose for AList, Appsmith, and Budibase

### DIFF
--- a/blueprints/alist/docker-compose.yml
+++ b/blueprints/alist/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   alist:
-    image: xhofe/alist:v3.41.0
+    image: xhofe/alist:v3.55.0
     volumes:
       - alist-data:/opt/alist/data
     environment:

--- a/blueprints/appsmith/docker-compose.yml
+++ b/blueprints/appsmith/docker-compose.yml
@@ -1,6 +1,10 @@
 version: "3.8"
 services:
   appsmith:
-    image: index.docker.io/appsmith/appsmith-ee:v1.29
+    image: appsmith/appsmith-ee:v1.94
     volumes:
-      - ../files/stacks:/appsmith-stacks
+      - appsmith-data:/appsmith-stacks
+    restart: unless-stopped
+
+volumes:
+  appsmith-data:

--- a/blueprints/budibase/docker-compose.yml
+++ b/blueprints/budibase/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       start_period: 10s
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: unless-stopped
     volumes:
       - 'minio_data:/data'

--- a/blueprints/budibase/docker-compose.yml
+++ b/blueprints/budibase/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
-  apps:
-    image: budibase.docker.scarf.sh/budibase/apps:3.5.3
-    restart: unless-stopped
 
+  apps:
+    image: budibase/apps:3.23.47
+    restart: unless-stopped
     environment:
       SELF_HOSTED: 1
       LOG_LEVEL: info
@@ -39,10 +39,10 @@ services:
       timeout: 15s
       retries: 5
       start_period: 10s
-  worker:
-    image: budibase.docker.scarf.sh/budibase/worker:3.2.25
-    restart: unless-stopped
 
+  worker:
+    image: budibase/worker:3.23.47
+    restart: unless-stopped
     environment:
       SELF_HOSTED: 1
       LOG_LEVEL: info
@@ -78,10 +78,10 @@ services:
       timeout: 15s
       retries: 5
       start_period: 10s
-  minio:
-    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
-    restart: unless-stopped
 
+  minio:
+    image: minio/minio
+    restart: unless-stopped
     volumes:
       - 'minio_data:/data'
     environment:
@@ -98,10 +98,10 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
-  proxy:
-    image: budibase/proxy:3.2.25
-    restart: unless-stopped
 
+  proxy:
+    image: budibase/proxy:3.23.47
+    restart: unless-stopped
     environment:
       PROXY_RATE_LIMIT_WEBHOOKS_PER_SECOND: 10
       PROXY_RATE_LIMIT_API_PER_SECOND: 20
@@ -130,10 +130,10 @@ services:
       timeout: 15s
       retries: 5
       start_period: 10s
+
   couchdb:
     image: budibase/couchdb:v3.3.3
     restart: unless-stopped
-
     environment:
       COUCHDB_USER: budibase
       COUCHDB_PASSWORD: ${BB_COUCHDB_PASSWORD}
@@ -150,9 +150,9 @@ services:
       start_period: 10s
     volumes:
       - 'couchdb3_data:/opt/couchdb/data'
-  redis:
-    image: redis:7.2-alpine
 
+  redis:
+    image: redis:8.4-alpine
     restart: unless-stopped
     command: 'redis-server --requirepass "${BB_REDIS_PASSWORD}"'
     volumes:
@@ -168,19 +168,6 @@ services:
       timeout: 15s
       retries: 5
       start_period: 10s
-  watchtower:
-    restart: unless-stopped   
- 
-    image: containrrr/watchtower:1.7.1
-    volumes:
-      - '/var/run/docker.sock:/var/run/docker.sock'
-    command: '--debug --http-api-update bbapps bbworker bbproxy'
-    environment:
-      WATCHTOWER_HTTP_API: true
-      WATCHTOWER_HTTP_API_TOKEN: ${BB_WATCHTOWER_PASSWORD}
-      WATCHTOWER_CLEANUP: true
-    labels:
-      - com.centurylinklabs.watchtower.enable=false
 
 
 volumes:

--- a/meta.json
+++ b/meta.json
@@ -164,13 +164,13 @@
   {
     "id": "alist",
     "name": "AList",
-    "version": "v3.41.0",
+    "version": "v3.55.0",
     "description": "🗂️A file list/WebDAV program that supports multiple storages, powered by Gin and Solidjs.",
     "logo": "alist.svg",
     "links": {
       "github": "https://github.com/AlistGo/alist",
-      "website": "https://alist.nn.ci",
-      "docs": "https://alist.nn.ci/guide/install/docker.html"
+      "website": "https://alistgo.com/",
+      "docs": "https://alistgo.com/guide/install/docker.html"
     },
     "tags": [
       "file",
@@ -350,7 +350,7 @@
   {
     "id": "appsmith",
     "name": "Appsmith",
-    "version": "v1.29",
+    "version": "v1.94",
     "description": "Appsmith is a free and open source platform for building internal tools and applications.",
     "logo": "appsmith.png",
     "links": {
@@ -894,7 +894,7 @@
   {
     "id": "budibase",
     "name": "Budibase",
-    "version": "3.5.3",
+    "version": "3.23.47",
     "description": "Budibase is an open-source low-code platform that saves engineers 100s of hours building forms, portals, and approval apps, securely.",
     "logo": "budibase.svg",
     "links": {


### PR DESCRIPTION
…List, Appsmith, and Budibase.

## What is this PR about?

New PR of AList, Appsmith, and Budibase

## Checklist

Before submitting this PR, please make sure that:

- [✅] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [✅] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.

## Change log

- appsmith: updated to stable version v1.94. Added "restart: unless-stopped" as recommended in the documentation, and reorganized the volume configuration for better clarity.  

- alist: updated to stable version v3.55.0, which includes new features.  

- budibase: updated to stable version 3.23.47. This release fixes several app issues. The watchtower service was removed because it used a deprecated image and is not included in the official docker-compose file.  

