### PR TITLE
Update Umami to version v2.20.2

### DIFF
--- a/blueprints/umami/docker-compose.yml
+++ b/blueprints/umami/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   umami:
-    image: ghcr.io/umami-software/umami:postgresql-v2.19.0
+    image: ghcr.io/umami-software/umami:postgresql-v2.20.2
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:3000/api/heartbeat"]

--- a/meta.json
+++ b/meta.json
@@ -5846,7 +5846,7 @@
   {
     "id": "umami",
     "name": "Umami",
-    "version": "v2.19.0",
+    "version": "v2.20.2",
     "description": "Umami is a simple, fast, privacy-focused alternative to Google Analytics.",
     "logo": "umami.png",
     "links": {


### PR DESCRIPTION
## What is this PR about?

Umami v2.19.0 is vulnerable to [CVE-2025-55182](https://www.cve.org/CVERecord?id=CVE-2025-55182) (React2Shell), [CVE-2025-55183](https://www.cve.org/CVERecord?id=CVE-2025-55183), [CVE-2025-55184](https://www.cve.org/CVERecord?id=CVE-2025-55184). More info here: https://github.com/umami-software/umami/issues/3839.

This PR updates the template to use the patched Umami version.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] ~I have added tests that demonstrate that my correction works or that my new feature works.~

## Issues related (if applicable)

I haven't found any related issues.