### PR TITLE
Publish port 8090 to the host machine for Pocketbase template

### DIFF
--- a/blueprints/pocketbase/docker-compose.yml
+++ b/blueprints/pocketbase/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: adrianmusante/pocketbase:latest
     restart: always
     ports:
-      - 8090:8090
+      - 8090
     expose:
       - 8090
     volumes:


### PR DESCRIPTION

## What is this PR about?

New PR of PocketBase. This template can't be accessed from the URL after deployment without this change. 

## More Details

Unlike `ports` directive, `expose` does not map container ports to host ports, meaning external access from the host or outside networks is not possible using the directive `expose`. Thus, directive `ports` is needed.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.
