### PR TITLE
Update to new Evolution API image source and pin it to the latest version

### DIFF
--- a/blueprints/evolutionapi/docker-compose.yml
+++ b/blueprints/evolutionapi/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   evolution-api:
-    image: atendai/evolution-api:v2.1.2
+    image: evoapicloud/evolution-api:latest
     restart: always
     volumes:
       - evolution-instances:/evolution/instances


### PR DESCRIPTION
The Evolution API Docker image is no longer located at atendai/evolution-api. It is now located at [evoapicloud/evolution-api](https://hub.docker.com/r/evoapicloud/evolution-api).

The currently pinned version is v2.1.2. This version does not work correctly and contains vulnerabilities that have already been fixed in more recent versions.

I updated the image to the new source and pinned the version to latest.

closes #428 #430

### related:
- #429
- #540

