### PR TITLE
fix: SearXNG template

### DIFF
--- a/blueprints/searxng/docker-compose.yml
+++ b/blueprints/searxng/docker-compose.yml
@@ -1,20 +1,18 @@
-version: "3.8"
 services:
-  redis:
+  valkey:
     image: valkey/valkey:8-alpine
     command: valkey-server --save 30 1 --loglevel warning
     restart: unless-stopped
     volumes:
-      - redis-data:/data
+      - valkey-data:/data
 
   searxng:
     image: searxng/searxng:latest
     restart: unless-stopped
     volumes:
-      - searxng-config:/etc/searxng
+      - ../files/searxng:/etc/searxng
       - searxng-data:/var/cache/searxng
 
 volumes:
-  redis-data: {}
-  searxng-config: {}
+  valkey-data: {}
   searxng-data: {}

--- a/blueprints/searxng/template.toml
+++ b/blueprints/searxng/template.toml
@@ -12,11 +12,15 @@ env = [
 ]
 
 [[config.mounts]]
-filePath = "/etc/searxng/settings.yml"
+filePath = "/searxng/settings.yml"
 content = """
 use_default_settings: true
+
 server:
   secret_key: \"${secret_key}\"
   limiter: false
   image_proxy: false
+
+valkey:
+  url: valkey://valkey:6379/0
 """


### PR DESCRIPTION
Main things:
- fixes the searxng config mount as it was previously broken
- connects the searxng instance to valkey as it (redis) was previously completely unused

Chore:
- replaced `redis` naming with `valkey` everywhere (service, volume, etc.)
- removed the obsolete top-level compose `version` property
- modified config file mount default path