### PR TITLE
fix: tailscale exitnode authkey env

### DIFF
--- a/blueprints/tailscale-exitnode/template.toml
+++ b/blueprints/tailscale-exitnode/template.toml
@@ -1,4 +1,4 @@
 
 [config.env]
 TAILSCALE_HOSTNAME = ""
-TAILSCALE_APIKEY = ""
+TAILSCALE_AUTHKEY = ""


### PR DESCRIPTION
## What is this PR about?

The environment name in the Tailscale Exitnode has been changed from `TAILSCALE_APIKEY` to `TAILSCALE_AUTHKEY`.

## Checklist

Before submitting this PR, please make sure that:

- [X] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [X] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [X] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

## Screenshots or Videos
