### PR TITLE
feat: add Moltbot template

### DIFF
--- a/blueprints/moltbot/docker-compose.yml
+++ b/blueprints/moltbot/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  moltbot-gateway:
+    image: ghcr.io/moltbot/moltbot:latest
+    environment:
+      HOME: /home/node
+      TERM: xterm-256color
+      CLAWDBOT_GATEWAY_TOKEN: ${CLAWDBOT_GATEWAY_TOKEN}
+      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
+      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
+      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+    volumes:
+      - moltbot-config:/home/node/.clawdbot
+      - moltbot-workspace:/home/node/clawd
+    ports:
+      - 18789
+      - 18790
+    restart: unless-stopped
+    command:
+      [
+        "node",
+        "dist/index.js",
+        "gateway-daemon",
+        "--bind",
+        "lan",
+        "--port",
+        "18789"
+      ]
+
+volumes:
+  moltbot-config: {}
+  moltbot-workspace: {}

--- a/blueprints/moltbot/moltbot.svg
+++ b/blueprints/moltbot/moltbot.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 16 16" role="img" aria-label="Pixel lobster">
+  <rect width="16" height="16" fill="none"/>
+  <!-- outline -->
+  <g fill="#3a0a0d">
+    <rect x="1" y="5" width="1" height="3"/>
+    <rect x="2" y="4" width="1" height="1"/>
+    <rect x="2" y="8" width="1" height="1"/>
+    <rect x="3" y="3" width="1" height="1"/>
+    <rect x="3" y="9" width="1" height="1"/>
+    <rect x="4" y="2" width="1" height="1"/>
+    <rect x="4" y="10" width="1" height="1"/>
+    <rect x="5" y="2" width="6" height="1"/>
+    <rect x="11" y="2" width="1" height="1"/>
+    <rect x="12" y="3" width="1" height="1"/>
+    <rect x="12" y="9" width="1" height="1"/>
+    <rect x="13" y="4" width="1" height="1"/>
+    <rect x="13" y="8" width="1" height="1"/>
+    <rect x="14" y="5" width="1" height="3"/>
+    <rect x="5" y="11" width="6" height="1"/>
+    <rect x="4" y="12" width="1" height="1"/>
+    <rect x="11" y="12" width="1" height="1"/>
+    <rect x="3" y="13" width="1" height="1"/>
+    <rect x="12" y="13" width="1" height="1"/>
+    <rect x="5" y="14" width="6" height="1"/>
+  </g>
+
+  <!-- body -->
+  <g fill="#ff4f40">
+    <rect x="5" y="3" width="6" height="1"/>
+    <rect x="4" y="4" width="8" height="1"/>
+    <rect x="3" y="5" width="10" height="1"/>
+    <rect x="3" y="6" width="10" height="1"/>
+    <rect x="3" y="7" width="10" height="1"/>
+    <rect x="4" y="8" width="8" height="1"/>
+    <rect x="5" y="9" width="6" height="1"/>
+    <rect x="5" y="12" width="6" height="1"/>
+    <rect x="6" y="13" width="4" height="1"/>
+  </g>
+
+  <!-- claws -->
+  <g fill="#ff775f">
+    <rect x="1" y="6" width="2" height="1"/>
+    <rect x="2" y="5" width="1" height="1"/>
+    <rect x="2" y="7" width="1" height="1"/>
+    <rect x="13" y="6" width="2" height="1"/>
+    <rect x="13" y="5" width="1" height="1"/>
+    <rect x="13" y="7" width="1" height="1"/>
+  </g>
+
+  <!-- eyes -->
+  <g fill="#081016">
+    <rect x="6" y="5" width="1" height="1"/>
+    <rect x="9" y="5" width="1" height="1"/>
+  </g>
+  <g fill="#f5fbff">
+    <rect x="6" y="4" width="1" height="1"/>
+    <rect x="9" y="4" width="1" height="1"/>
+  </g>
+</svg>
+

--- a/blueprints/moltbot/template.toml
+++ b/blueprints/moltbot/template.toml
@@ -1,0 +1,11 @@
+[variables]
+gateway_token = "${password:32}"
+
+[config]
+[[config.domains]]
+serviceName = "moltbot-gateway"
+port = 18789
+host = "${domain}"
+
+[config.env]
+CLAWDBOT_GATEWAY_TOKEN = "${gateway_token}"

--- a/meta.json
+++ b/meta.json
@@ -6185,5 +6185,26 @@
       "saml",
       "multi-tenant"
     ]
+  },
+  {
+    "id": "moltbot",
+    "name": "Moltbot",
+    "version": "2026.1.25",
+    "description": "WhatsApp gateway CLI with Pi RPC agent - self-hosted AI-powered messaging platform",
+    "logo": "moltbot.svg",
+    "links": {
+      "github": "https://github.com/moltbot/moltbot",
+      "website": "https://molt.bot",
+      "docs": "https://docs.molt.bot"
+    },
+    "tags": [
+      "whatsapp",
+      "ai",
+      "messaging",
+      "chatbot",
+      "gateway",
+      "self-hosted",
+      "automation"
+    ]
   }
 ]


### PR DESCRIPTION
## Overview
Adds a template for [Moltbot](https://github.com/moltbot/moltbot) - a WhatsApp gateway CLI with Pi RPC agent and AI-powered messaging platform.

## What is Moltbot?
Moltbot is a self-hosted personal AI assistant that works across different operating systems. It provides:
- WhatsApp integration via Baileys web
- Pi RPC agent for AI capabilities
- Multi-platform support (WhatsApp, Telegram, Slack, Discord, iMessage, Signal, and more)
- Gateway daemon for persistent connections
- CLI tools for automation and control

## Template Details
- **Image**: `ghcr.io/moltbot/moltbot:latest`
- **Ports**: 18789 (gateway), 18790 (bridge)
- **Volumes**: Config and workspace persistence
- **Auto-generated**: Gateway token for authentication
- **Optional**: Claude AI integration

## Configuration
- Gateway token auto-generated (32 chars)
- Optional Claude AI credentials
- Domain configuration for web access

## Testing
- Template tested for Dokploy compatibility
- Follows Dokploy template conventions
- No `container_name`, explicit networks, or host port bindings

## Links
- GitHub: https://github.com/moltbot/moltbot
- Website: https://molt.bot
- Docs: https://docs.molt.bot

---

Co-Authored-By: Claude <noreply@anthropic.com>