### PR TITLE
Update Notifuse template: replace PASETO with SECRET_KEY auth

### DIFF
--- a/blueprints/notifuse/docker-compose.yml
+++ b/blueprints/notifuse/docker-compose.yml
@@ -3,11 +3,11 @@ services:
     image: postgres:17-alpine
     restart: unless-stopped
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql/data
     environment:
-      - POSTGRES_DB=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -21,38 +21,36 @@ services:
       - db
     environment:
       # Root user configuration
-      - ROOT_EMAIL=${ROOT_EMAIL}
+      ROOT_EMAIL: ${ROOT_EMAIL}
 
       # API configuration
-      - API_ENDPOINT=${API_ENDPOINT}
+      API_ENDPOINT: ${API_ENDPOINT}
 
       # Database configuration
-      - DB_HOST=db
-      - DB_PORT=5432
-      - DB_USER=postgres
-      - DB_PASSWORD=postgres
-      - DB_PREFIX=notifuse
-      - DB_NAME=notifuse_system
-      - DB_SSLMODE=disable
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_PREFIX: notifuse
+      DB_NAME: notifuse_system
+      DB_SSLMODE: disable
 
-      # PASETO keys for authentication
-      # Default keys for testing - GENERATE YOUR OWN for production at https://paseto.notifuse.com/
-      - PASETO_PRIVATE_KEY=${PASETO_PRIVATE_KEY}
-      - PASETO_PUBLIC_KEY=${PASETO_PUBLIC_KEY}
-
-      # SMTP configuration
-      - SMTP_HOST=${SMTP_HOST}
-      - SMTP_PORT=${SMTP_PORT}
-      - SMTP_USERNAME=${SMTP_USERNAME}
-      - SMTP_PASSWORD=${SMTP_PASSWORD}
-      - SMTP_FROM_EMAIL=${SMTP_FROM_EMAIL}
-      - SMTP_FROM_NAME=${SMTP_FROM_NAME}
+      # Secret key for authentication (auto-generated)
+      SECRET_KEY: ${SECRET_KEY}
 
       # Server configuration
-      - SERVER_PORT=8080
-      - SERVER_HOST=0.0.0.0
-      - ENVIRONMENT=production
+      SERVER_PORT: 8080
+      SERVER_HOST: 0.0.0.0
+      ENVIRONMENT: production
+    volumes:
+      - notifuse_data:/app/data
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
 volumes:
-  db-data:
-    driver: local
+  db_data: {}
+  notifuse_data: {}

--- a/blueprints/notifuse/docker-compose.yml
+++ b/blueprints/notifuse/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       DB_USER: postgres
       DB_PASSWORD: postgres
       DB_PREFIX: notifuse
-      DB_NAME: notifuse_system
+      DB_NAME: postgres
       DB_SSLMODE: disable
 
       # Secret key for authentication (auto-generated)

--- a/blueprints/notifuse/template.toml
+++ b/blueprints/notifuse/template.toml
@@ -1,7 +1,6 @@
 [variables]
 main_domain = "${domain}"
-paseto_private_key = "d04zCk3Fa45oOjDWHpAvc1AZxnLdGffOnNWK+Jt2yXf37+FTfuMMHb8flcfPMqLluRR3rvhbr555r6j1DEigrA=="
-paseto_public_key = "9+/hU37jDB2/H5XHzzKi5bkUd674W6+eea+o9QxIoKw="
+secret_key = "${base64:64}"
 
 [config]
 [[config.domains]]
@@ -12,18 +11,4 @@ host = "${main_domain}"
 [config.env]
 ROOT_EMAIL = "${email}"
 API_ENDPOINT = "https://${main_domain}"
-
-# PASETO keys for authentication
-# Default keys for testing - GENERATE YOUR OWN for production at https://paseto.notifuse.com/
-PASETO_PRIVATE_KEY = "${paseto_private_key}"
-PASETO_PUBLIC_KEY = "${paseto_public_key}"
-
-# SMTP Configuration (users need to configure these)
-SMTP_HOST = "smtp.gmail.com"
-SMTP_PORT = "587"
-SMTP_USERNAME = "your-email@gmail.com"
-SMTP_PASSWORD = "your-smtp-password"
-SMTP_FROM_EMAIL = "noreply@yourdomain.com"
-SMTP_FROM_NAME = "Notifuse"
-
-[[config.mounts]]
+SECRET_KEY = "${secret_key}"


### PR DESCRIPTION
## Summary
- Replace deprecated PASETO authentication with SECRET_KEY
- Remove SMTP environment variables (now configured via Setup Wizard)
- Add healthcheck for notifuse service
- Add data volume for persistent storage

## Changes
- **Authentication**: `PASETO_PRIVATE_KEY`/`PASETO_PUBLIC_KEY` replaced with `SECRET_KEY`
- **Kept**: `ROOT_EMAIL`, `API_ENDPOINT` (required at deploy)
- **Removed**: `SMTP_*` variables (configured via Setup Wizard on first launch)
- **Added**: Healthcheck on notifuse service, data volume mount
- **Updated**: Environment variable syntax and volume definitions to match other templates

## Test plan
- Deploy template via Dokploy
- Verify app starts with ROOT_EMAIL and API_ENDPOINT configured
- Configure SMTP via Setup Wizard
- Verify email functionality