### PR TITLE
upgrade nextcloud img version

### DIFF
--- a/blueprints/nextcloud-aio/docker-compose.yml
+++ b/blueprints/nextcloud-aio/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   nextcloud:
-    image: nextcloud:30.0.2
+    image: nextcloud:32.0.5
     restart: always
 
     ports:


### PR DESCRIPTION
Current version is the file is no longer maintained. Upgraded to 32.0.5 (latest as of Feb 9 2026)