### PR TITLE
Update docker-compose.yml

### DIFF
--- a/blueprints/pgadmin/docker-compose.yml
+++ b/blueprints/pgadmin/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   pgadmin:
     image: dpage/pgadmin4:latest
@@ -7,7 +5,7 @@ services:
     environment:
       - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL}
       - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD}
-      - PGADMIN_CONFIG_SERVER_MODE=False
+      - PGADMIN_CONFIG_SERVER_MODE=True
       - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
     volumes:
       - pgadmin-data:/var/lib/pgadmin


### PR DESCRIPTION
## PR for PGAdmin4

1. remove docker-compose version; it is now facultative.
2. Enforce Server Mde since environment `username` + `password` are generated.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes two changes to the PGAdmin4 template: removes the Docker Compose version field and enforces Server Mode by setting `PGADMIN_CONFIG_SERVER_MODE=True`.

**Critical Issue:**
- The removal of `version: '3.8'` violates the project's coding standards defined in AGENTS.md. All templates must include `version: "3.8"` as stated in the style guide.

**Logical Change:**
- Setting `PGADMIN_CONFIG_SERVER_MODE=True` appears reasonable given that `PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD` are configured, which are server mode credentials. However, this changes the user experience from desktop mode to server mode.

<h3>Confidence Score: 2/5</h3>

- This PR contains a critical standards violation that must be fixed before merging
- Score reflects the violation of mandatory project coding standards (Docker Compose version field requirement). While the Server Mode change appears logical, the version field removal breaks consistency across all 200+ templates in the repository.
- blueprints/pgadmin/docker-compose.yml requires the version 3.8 field to be restored

<sub>Last reviewed commit: b9ec11d</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->