### PR TITLE
fix(plane): add http scheme to WEB_URL

### DIFF
--- a/blueprints/plane/template.toml
+++ b/blueprints/plane/template.toml
@@ -9,7 +9,7 @@ secret_key = "${base64:48}"
 [config]
 env = [
 "Domain=${domain}",
-"WEB_URL=${Domain}",
+"WEB_URL=http://${Domain}",
 "PGHOST=plane-db",
 "PGDATABASE=plane",
 "POSTGRES_USER=${username}",

--- a/blueprints/plane/template.toml
+++ b/blueprints/plane/template.toml
@@ -9,7 +9,7 @@ secret_key = "${base64:48}"
 [config]
 env = [
 "Domain=${domain}",
-"WEB_URL=http://${Domain}",
+"WEB_URL=https://${Domain}",
 "PGHOST=plane-db",
 "PGDATABASE=plane",
 "POSTGRES_USER=${username}",


### PR DESCRIPTION
## Summary
- Add \http://\ scheme to \WEB_URL\ so Plane can generate valid links (emails, redirects, etc.)
- Uses \http://\ instead of \https://\ since Traefik handles SSL termination

## Changes
- \lueprints/plane/template.toml\: \WEB_URL=\\ → \WEB_URL=http://\\

## Context
Follows up on #582 (closed for inactivity). Addresses review feedback from @Siumauricio — removed \https://\ and kept \API_BASE_URL\ as internal \http://api:8000\.

## Testing
Verified template.toml syntax is valid.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `http://` scheme to `WEB_URL` environment variable so Plane can generate valid absolute URLs for emails, redirects, and other features. The change correctly uses `http://` instead of `https://` since Traefik handles SSL termination at the proxy level.

- Fixed `WEB_URL` to include `http://` scheme prefix (was missing protocol entirely)
- Change follows repository conventions - many templates use `http://${domain}` pattern for internal URLs
- One potential issue: `CORS_ALLOWED_ORIGINS` still uses `https://` which may cause CORS errors

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one CORS configuration issue to verify
- The change is minimal, well-justified, and follows repository conventions for handling SSL termination. Score is 4 instead of 5 due to potential CORS mismatch between `WEB_URL` (http) and `CORS_ALLOWED_ORIGINS` (https) that should be verified in testing
- Verify `CORS_ALLOWED_ORIGINS` configuration in production to ensure no CORS errors occur

<sub>Last reviewed commit: 36194c6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->