### PR TITLE
feat: add Fizzy template blueprint

### DIFF
--- a/blueprints/fizzy/docker-compose.yml
+++ b/blueprints/fizzy/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  web:
+    image: ghcr.io/basecamp/fizzy:main
+    restart: unless-stopped
+
+    environment:
+      # Rails
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: "1"
+
+      # Secrets
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:?set SECRET_KEY_BASE}
+      VAPID_PUBLIC_KEY: ${VAPID_PUBLIC_KEY:?set VAPID_PUBLIC_KEY}
+      VAPID_PRIVATE_KEY: ${VAPID_PRIVATE_KEY:?set VAPID_PRIVATE_KEY}
+
+      # Mail
+      MAILER_FROM_ADDRESS: ${MAILER_FROM_ADDRESS:?set MAILER_FROM_ADDRESS}
+      SMTP_ADDRESS: ${SMTP_ADDRESS:?set SMTP_ADDRESS}
+      SMTP_PORT: ${SMTP_PORT:-2525}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+
+      # Fizzy behavior
+      MULTI_TENANT: ${MULTI_TENANT:-false}
+      SOLID_QUEUE_IN_PUMA: ${SOLID_QUEUE_IN_PUMA:-true}
+
+    volumes:
+      # Contains SQLite DB + ActiveStorage
+      - fizzy_storage:/rails/storage
+
+    expose:
+      - "3000"
+
+volumes:
+  fizzy_storage:

--- a/blueprints/fizzy/docker-compose.yml
+++ b/blueprints/fizzy/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   fizzy:
-    image: ghcr.io/basecamp/fizzy:main
+    image: ghcr.io/basecamp/fizzy:1.0.0
     restart: unless-stopped
 
     environment:

--- a/blueprints/fizzy/docker-compose.yml
+++ b/blueprints/fizzy/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3.8"
 services:
   fizzy:
     image: ghcr.io/basecamp/fizzy:main

--- a/blueprints/fizzy/docker-compose.yml
+++ b/blueprints/fizzy/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  web:
+  fizzy:
     image: ghcr.io/basecamp/fizzy:main
     restart: unless-stopped
 

--- a/blueprints/fizzy/fizzy.svg
+++ b/blueprints/fizzy/fizzy.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-label="Fizzy logo">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4b9cff"/>
+      <stop offset="100%" stop-color="#6dd5fa"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="28" fill="url(#g)"/>
+  <circle cx="52" cy="68" r="12" fill="#ffffff" opacity="0.9"/>
+  <circle cx="88" cy="52" r="10" fill="#ffffff" opacity="0.85"/>
+  <circle cx="112" cy="82" r="14" fill="#ffffff" opacity="0.9"/>
+  <path d="M46 110c18-18 44-18 68-4" fill="none" stroke="#ffffff" stroke-width="10" stroke-linecap="round"/>
+  <path d="M54 104c2-20 14-40 32-48" fill="none" stroke="#ffffff" stroke-width="9" stroke-linecap="round" opacity="0.85"/>
+  <path d="M70 108l-22 12" fill="none" stroke="#ffffff" stroke-width="9" stroke-linecap="round" opacity="0.8"/>
+</svg>

--- a/blueprints/fizzy/template.toml
+++ b/blueprints/fizzy/template.toml
@@ -1,0 +1,33 @@
+[variables]
+main_domain = "${domain}"
+secret_key_base = "${base64:64}"
+vapid_public_key = "${base64:64}"
+vapid_private_key = "${base64:64}"
+mailer_from_address = "fizzy@${main_domain}"
+smtp_address = "smtp.example.com"
+smtp_port = "2525"
+smtp_username = ""
+smtp_password = ""
+multi_tenant = "false"
+solid_queue_in_puma = "true"
+
+[config]
+mounts = []
+
+env = [
+  "SECRET_KEY_BASE=${secret_key_base}",
+  "VAPID_PUBLIC_KEY=${vapid_public_key}",
+  "VAPID_PRIVATE_KEY=${vapid_private_key}",
+  "MAILER_FROM_ADDRESS=${mailer_from_address}",
+  "SMTP_ADDRESS=${smtp_address}",
+  "SMTP_PORT=${smtp_port}",
+  "SMTP_USERNAME=${smtp_username}",
+  "SMTP_PASSWORD=${smtp_password}",
+  "MULTI_TENANT=${multi_tenant}",
+  "SOLID_QUEUE_IN_PUMA=${solid_queue_in_puma}",
+]
+
+[[config.domains]]
+serviceName = "web"
+port = 3_000
+host = "${main_domain}"

--- a/blueprints/fizzy/template.toml
+++ b/blueprints/fizzy/template.toml
@@ -28,6 +28,6 @@ env = [
 ]
 
 [[config.domains]]
-serviceName = "web"
+serviceName = "fizzy"
 port = 3_000
 host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -2346,6 +2346,25 @@
       "server"
     ]
   },
+    {
+    "id": "fizzy",
+    "name": "Fizzy",
+    "version": "main",
+    "description": "Fizzy is a Kanban-style tracker for issues and ideas from 37signals.",
+    "logo": "fizzy.svg",
+    "links": {
+      "github": "https://github.com/basecamp/fizzy",
+      "website": "https://fizzy.do/",
+      "docs": "https://github.com/basecamp/fizzy"
+    },
+    "tags": [
+      "kanban",
+      "project-management",
+      "issues",
+      "ideas",
+      "self-hosted"
+    ]
+  },
   {
     "id": "flagsmith",
     "name": "Flagsmith",

--- a/meta.json
+++ b/meta.json
@@ -2349,7 +2349,7 @@
   {
     "id": "fizzy",
     "name": "Fizzy",
-    "version": "main",
+    "version": "0.1.0",
     "description": "Fizzy is a Kanban-style tracker for issues and ideas from 37signals.",
     "logo": "fizzy.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -2346,7 +2346,7 @@
       "server"
     ]
   },
-    {
+  {
     "id": "fizzy",
     "name": "Fizzy",
     "version": "main",


### PR DESCRIPTION
## Summary
Adds [Fizzy](https://github.com/basecamp/fizzy), a Kanban-style issue and idea tracker by 37signals (Basecamp).

## Changes
- \lueprints/fizzy/docker-compose.yml\ — Single-service setup with SQLite storage
- \lueprints/fizzy/template.toml\ — SMTP, VAPID keys, Rails config
- \lueprints/fizzy/fizzy.svg\ — Logo
- \meta.json\ — Added Fizzy entry (alphabetical order)

## Context
Clean resubmission of #581 (closed for inactivity). This PR only contains the Fizzy blueprint — no CI/workflow changes.

## Docker Compose
- \ghcr.io/basecamp/fizzy:main\
- Expose port 3000 (no \ports:\ — uses Traefik)
- SQLite volume for persistence
- SMTP for emails, VAPID for push notifications

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Fizzy, a Kanban-style issue and idea tracker by 37signals (Basecamp), as a new template blueprint.

**Key changes:**
- New blueprint with single-service Docker Compose setup using SQLite for persistence
- Template configuration with SMTP for emails and VAPID keys for push notifications
- Proper logo and metadata integration

**Issues found:**
- **Critical**: Service name in `docker-compose.yml` is `web` but must be `fizzy` to match the blueprint folder name (per AGENTS.md line 46)
- **Required**: Missing `version: "3.8"` declaration in `docker-compose.yml` (per AGENTS.md line 149)
- **Required**: Service name in `template.toml` must also be updated to `fizzy` to match
- **Formatting**: Extra indentation on opening brace in `meta.json` entry

These are straightforward fixes that maintain consistency with project conventions.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing service naming convention violations
- The template is well-structured and follows most conventions correctly, but has critical naming convention violations that will cause deployment issues. Service name must match blueprint folder name (`fizzy` not `web`) in both `docker-compose.yml` and `template.toml`, missing required `version: "3.8"` declaration, and minor formatting issue in `meta.json`. Once these syntax issues are resolved, the template will be production-ready.
- `blueprints/fizzy/docker-compose.yml` and `blueprints/fizzy/template.toml` need service name corrections, `meta.json` needs indentation fix

<sub>Last reviewed commit: f1cd2ae</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->