### PR TITLE
refactor(bigcapital): improve docker-compose reliability

### DIFF
--- a/blueprints/bigcapital/docker-compose.yml
+++ b/blueprints/bigcapital/docker-compose.yml
@@ -4,23 +4,23 @@ services:
     restart: unless-stopped
     depends_on:
       - server
-    ports:
-      - '80'
-
+    expose:
+      - "80"
 
   server:
     image: bigcapitalhq/server:latest
     restart: unless-stopped
     depends_on:
-      mysql:
-        condition: service_healthy
+      database_migration:
+        condition: service_completed_successfully
       mongo:
         condition: service_started
       redis:
         condition: service_started
-    ports:
-      - '3000'
-
+      minio:
+        condition: service_healthy
+    expose:
+      - "3000"
     environment:
       # Mail
       - MAIL_HOST=${MAIL_HOST}
@@ -55,7 +55,7 @@ services:
       # Sign-up email confirmation
       - SIGNUP_EMAIL_CONFIRMATION=${SIGNUP_EMAIL_CONFIRMATION}
       # Gotenberg (Pdf generator)
-      - GOTENBERG_URL=${GOTENBERG_URL}
+      - GOTENBERG_URL=http://gotenberg:3000
       - GOTENBERG_DOCS_URL=${GOTENBERG_DOCS_URL}
       # Exchange Rate
       - EXCHANGE_RATE_SERVICE=${EXCHANGE_RATE_SERVICE}
@@ -80,12 +80,28 @@ services:
       - NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED=${NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED}
       - NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY}
       - NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME}
-      # S3
+      # S3 (MinIO)
       - S3_REGION=${S3_REGION}
       - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
       - S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
       - S3_ENDPOINT=${S3_ENDPOINT}
       - S3_BUCKET=${S3_BUCKET}
+
+  # Database migration - runs once then exits
+  database_migration:
+    image: bigcapitalhq/server:latest
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      - DB_HOST=mysql
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_CHARSET=${DB_CHARSET}
+      - SYSTEM_DB_NAME=${SYSTEM_DB_NAME}
+      - TENANT_DB_NAME_PERFIX=${TENANT_DB_NAME_PERFIX}
+      - MONGODB_DATABASE_URL=mongodb://mongo/bigcapital
+    command: ["node", "packages/server/build/commands.js", "system:migrate:latest"]
 
   mysql:
     image: mariadb:10.11
@@ -97,9 +113,8 @@ services:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
     volumes:
       - mysql:/var/lib/mysql
-    ports:
-      - '3306'
-
+    expose:
+      - "3306"
     healthcheck:
       test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD || exit 1"]
       interval: 10s
@@ -110,20 +125,18 @@ services:
   mongo:
     image: mongo:7
     restart: unless-stopped
-    ports:
-      - '27017'
+    expose:
+      - "27017"
     volumes:
       - mongo:/data/db
-
 
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    ports:
-      - '6379'
+    expose:
+      - "6379"
     volumes:
       - redis:/data
-
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -133,9 +146,40 @@ services:
   gotenberg:
     image: gotenberg/gotenberg:7
     restart: unless-stopped
-    ports:
-      - '9000'
+    expose:
+      - "3000"
 
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=${S3_ACCESS_KEY_ID}
+      - MINIO_ROOT_PASSWORD=${S3_SECRET_ACCESS_KEY}
+    volumes:
+      - minio:/data
+    expose:
+      - "9000"
+      - "9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Creates the S3 bucket on startup
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set myminio http://minio:9000 ${S3_ACCESS_KEY_ID} ${S3_SECRET_ACCESS_KEY};
+      mc mb myminio/${S3_BUCKET} --ignore-existing;
+      mc anonymous set download myminio/${S3_BUCKET};
+      exit 0;
+      "
 
 volumes:
   mysql:
@@ -147,6 +191,6 @@ volumes:
   redis:
     name: bigcapital_redis
     driver: local
-
-
-
+  minio:
+    name: bigcapital_minio
+    driver: local

--- a/blueprints/bigcapital/docker-compose.yml
+++ b/blueprints/bigcapital/docker-compose.yml
@@ -177,7 +177,6 @@ services:
       /bin/sh -c "
       mc alias set myminio http://minio:9000 ${S3_ACCESS_KEY_ID} ${S3_SECRET_ACCESS_KEY};
       mc mb myminio/${S3_BUCKET} --ignore-existing;
-      mc anonymous set download myminio/${S3_BUCKET};
       exit 0;
       "
 


### PR DESCRIPTION
## Summary
Improves the Bigcapital docker-compose template for better reliability and Dokploy compatibility.

## Changes
- **\ports\ → \expose\**: All services now use \expose\ since Traefik handles external routing
- **Database migrations**: Added \database_migration\ init container that runs migrations before the server starts (prevents race conditions)
- **MinIO for S3**: Added \minio\ + \minio-init\ services for self-contained S3-compatible storage
- **Gotenberg URL**: Hardcoded to \http://gotenberg:3000\ (internal Docker DNS) instead of env var
- **Healthchecks**: Added healthcheck for MinIO
- **Cleanup**: Removed trailing whitespace and empty lines

## Context
Clean resubmission of #578 (closed for inactivity). No review feedback was given on the original — changes are identical.

## Testing
- Verified docker-compose syntax with \docker compose config\
- Services start in correct dependency order: mysql → migration → server

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored Bigcapital template to improve reliability by replacing `ports` with `expose`, adding database migration init container, and integrating self-contained MinIO for S3 storage.

**Major improvements:**
- Database migration race condition eliminated via init container pattern
- MinIO + minio-init services enable self-contained S3-compatible storage
- Proper use of `expose` instead of `ports` (Traefik handles external routing)
- Healthchecks ensure correct service startup order

**Issues requiring attention:**
- Missing `version: "3.8"` declaration violates Dokploy style guide requirements
- Gotenberg port configuration mismatch: hardcoded as 3000 in docker-compose but template.toml specifies 9000
- MinIO bucket set to public download - verify this is intentional for your security requirements

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge with moderate risk - requires minor fixes before production use
- Score reflects solid architectural improvements (init containers, MinIO integration, proper expose usage) but requires critical fixes: missing version declaration violates Dokploy requirements, Gotenberg port mismatch between docker-compose and template.toml could break PDF generation, and public S3 bucket needs security review
- Pay attention to `docker-compose.yml` (missing version, port conflicts) and verify `template.toml` Gotenberg configuration matches

<sub>Last reviewed commit: 127b049</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->