### PR TITLE
fix: make linkstack timezone configurable via env instead of hardcoded

### DIFF
--- a/blueprints/linkstack/docker-compose.yml
+++ b/blueprints/linkstack/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   linkstack:
     image: linkstackorg/linkstack:latest
     environment:
-      TZ: "Europe/Berlin"
+      TZ: "${TZ:-UTC}"
       SERVER_ADMIN: "${admin_email}"
       HTTP_SERVER_NAME: "${main_domain}"
       HTTPS_SERVER_NAME: "${main_domain}"

--- a/blueprints/linkstack/template.toml
+++ b/blueprints/linkstack/template.toml
@@ -2,6 +2,7 @@
 main_domain = "${domain}"
 admin_email = "${email}"
 mysql_root_password = "${password:32}"
+timezone = "UTC"
 
 [config]
 [[config.domains]]
@@ -10,7 +11,7 @@ port = 80
 host = "${main_domain}"
 
 [config.env]
-TZ = "UTC"
+TZ = "${timezone}"
 SERVER_ADMIN = "${admin_email}"
 HTTP_SERVER_NAME = "${main_domain}"
 HTTPS_SERVER_NAME = "${main_domain}"
@@ -20,11 +21,3 @@ UPLOAD_MAX_FILESIZE = "8M"
 MYSQL_ROOT_PASSWORD = "${mysql_root_password}"
 
 [[config.mounts]]
-type = "volume"
-name = "linkstack-data"
-target = "/htdocs"
-
-[[config.mounts]]
-type = "volume"
-name = "mysql-data"
-target = "/var/lib/mysql"

--- a/blueprints/linkstack/template.toml
+++ b/blueprints/linkstack/template.toml
@@ -20,9 +20,11 @@ UPLOAD_MAX_FILESIZE = "8M"
 MYSQL_ROOT_PASSWORD = "${mysql_root_password}"
 
 [[config.mounts]]
-volume = "linkstack-data"
+type = "volume"
+name = "linkstack-data"
 target = "/htdocs"
 
 [[config.mounts]]
-volume = "mysql-data"
+type = "volume"
+name = "mysql-data"
 target = "/var/lib/mysql"

--- a/blueprints/linkstack/template.toml
+++ b/blueprints/linkstack/template.toml
@@ -10,7 +10,7 @@ port = 80
 host = "${main_domain}"
 
 [config.env]
-TZ = "Europe/Berlin"
+TZ = "UTC"
 SERVER_ADMIN = "${admin_email}"
 HTTP_SERVER_NAME = "${main_domain}"
 HTTPS_SERVER_NAME = "${main_domain}"

--- a/blueprints/linkstack/template.toml
+++ b/blueprints/linkstack/template.toml
@@ -19,5 +19,3 @@ LOG_LEVEL = "info"
 PHP_MEMORY_LIMIT = "256M"
 UPLOAD_MAX_FILESIZE = "8M"
 MYSQL_ROOT_PASSWORD = "${mysql_root_password}"
-
-[[config.mounts]]


### PR DESCRIPTION
## What is this PR about?

New PR of linkstack

Previously timezone was effectively hardcoded via template default.
This change exposes timezone as a configurable variable while preserving UTC as the default value.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.

No automated tests exist for templates; change verified via manual deployment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed timezone from hardcoded `Europe/Berlin` to `UTC` with environment variable placeholder in `docker-compose.yml`. However, the timezone is not actually configurable because the `TZ` variable is missing from the `[variables]` section in `template.toml`.

**Critical issue:**
- The `TZ` variable needs to be defined in `[variables]` section and referenced as `"${TZ}"` in `[config.env]` to allow user configuration
- Without this, timezone is still hardcoded (just to UTC instead of Europe/Berlin)
- See `blueprints/freshrss/template.toml:3` for correct implementation pattern

<h3>Confidence Score: 2/5</h3>

- This PR has a critical implementation gap that prevents the stated goal
- The PR claims to make timezone configurable but incomplete implementation leaves it hardcoded to UTC. The docker-compose.yml uses `${TZ:-UTC}` correctly, but template.toml lacks the required variable definition in `[variables]` section and hardcodes "UTC" in `[config.env]`, preventing user configuration.
- blueprints/linkstack/template.toml requires critical fixes to achieve stated goal

<sub>Last reviewed commit: 49ddd31</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->