### PR TITLE
fix(linkstack): make timezone configurable and remove invalid mounts

### DIFF
--- a/blueprints/linkstack/docker-compose.yml
+++ b/blueprints/linkstack/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   linkstack:
     image: linkstackorg/linkstack:latest
     environment:
-      TZ: "Europe/Berlin"
+      TZ: "${TZ:-UTC}"
       SERVER_ADMIN: "${admin_email}"
       HTTP_SERVER_NAME: "${main_domain}"
       HTTPS_SERVER_NAME: "${main_domain}"

--- a/blueprints/linkstack/template.toml
+++ b/blueprints/linkstack/template.toml
@@ -2,6 +2,7 @@
 main_domain = "${domain}"
 admin_email = "${email}"
 mysql_root_password = "${password:32}"
+timezone = "UTC"
 
 [config]
 [[config.domains]]
@@ -10,7 +11,7 @@ port = 80
 host = "${main_domain}"
 
 [config.env]
-TZ = "Europe/Berlin"
+TZ = "${timezone}"
 SERVER_ADMIN = "${admin_email}"
 HTTP_SERVER_NAME = "${main_domain}"
 HTTPS_SERVER_NAME = "${main_domain}"
@@ -18,11 +19,3 @@ LOG_LEVEL = "info"
 PHP_MEMORY_LIMIT = "256M"
 UPLOAD_MAX_FILESIZE = "8M"
 MYSQL_ROOT_PASSWORD = "${mysql_root_password}"
-
-[[config.mounts]]
-volume = "linkstack-data"
-target = "/htdocs"
-
-[[config.mounts]]
-volume = "mysql-data"
-target = "/var/lib/mysql"


### PR DESCRIPTION
## What is this PR about?

New PR of linkstack

This PR improves the Linkstack template by:

- Exposing timezone as a configurable variable instead of a static default
- Removing invalid volume mounts from `template.toml` that caused validation failures

The Docker Compose configuration already defines volumes, so removing the mounts from
`template.toml` aligns the template with repository conventions.


## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

No automated tests exist for templates; change verified via manual deployment.

## Issues related (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Made timezone configurable and fixed template validation issues

- Replaced hardcoded `Europe/Berlin` timezone with configurable `timezone` variable (defaults to UTC)
- Removed invalid mount configurations from `template.toml` that lacked required `serviceName` field
- Volumes remain properly configured in `docker-compose.yml`

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes validation issues and improves configurability
- Changes correctly address template validation failures by removing invalid mount configurations, make timezone user-configurable with a sensible default, and maintain all existing functionality. Volumes are properly defined in docker-compose.yml.
- No files require special attention

<sub>Last reviewed commit: 8f84dc8</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->