### PR TITLE
feat(blueprint): add Verdaccio - private node.js package registry

### DIFF
--- a/blueprints/verdaccio/docker-compose.yml
+++ b/blueprints/verdaccio/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+
+services:
+  verdaccio:
+    image: verdaccio/verdaccio:6
+    environment:
+      - VERDACCIO_PORT=4873
+    ports:
+      - 4873
+    volumes:
+      - verdaccio_storage:/verdaccio/storage
+      - verdaccio_plugins:/verdaccio/plugins
+      - ../files/conf:/verdaccio/conf
+
+volumes:
+  verdaccio_storage:
+  verdaccio_plugins:

--- a/blueprints/verdaccio/template.toml
+++ b/blueprints/verdaccio/template.toml
@@ -1,0 +1,259 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+[[config.domains]]
+serviceName = "verdaccio"
+port = 4873
+host = "${main_domain}"
+
+[[config.mounts]]
+filePath = "/conf/config.yaml"
+content = """
+#
+# This is the default configuration file. It allows all users to do anything,
+# please read carefully the documentation and best practices to
+# improve security.
+#
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/blob/master/docker-examples/README.md
+#
+# Read about the best practices
+# https://verdaccio.org/docs/best
+
+# Path to a directory with all packages
+storage: /verdaccio/storage/data
+
+# Path to a directory with plugins to include, the plugins folder has the higher priority for loading plugins
+# Disable this folder to avoid warnings if is not used
+plugins: /verdaccio/plugins
+
+# Web UI settings
+# https://verdaccio.org/docs/webui
+web:
+  title: Verdaccio
+  # Disable complete web UI
+  # enabled: false
+  # Custom colors for header background and font
+  # primaryColor: "#4b5e40"
+  # Custom logos and favicon
+  # logo: ./path/to/logo.png
+  # logoDark: ./path/to/logoDark.png
+  # favicon: ./path/to/favicon.ico
+  # Disable gravatar support
+  # gravatar: false
+  # By default, packages are ordered ascending
+  # sort_packages: asc | desc
+  # Convert your UI to the dark side
+  # darkMode: true
+  # html_cache: true
+  # By default, all features are displayed
+  # login: true
+  # showInfo: true
+  # showSettings: true
+  # In combination with darkMode you can force specific theme
+  # showThemeSwitch: true
+  # showFooter: true
+  # showSearch: true
+  # showRaw: true
+  # showDownloadTarball: true
+  # showUplinks: true
+  #
+  # HTML tags injected before ends </head>
+  # metaScripts:
+  #   - '<script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>'
+  #   - '<script type="text/javascript" src="https://browser.sentry-cdn.com/5.15.5/bundle.min.js"></script>'
+  #   - '<meta name="robots" content="noindex">'
+  #
+  # HTML tags injected as first child in <body>
+  # scriptsBodyBefore:
+  #   - '<div id="myId">html before webpack scripts</div>'
+  #
+  # HTML tags injected as last child in </body>
+  # scriptsBodyAfter:
+  #   - '<script type="text/javascript" src="https://my.company.com/customJS.min.js"></script>'
+  #
+  # Public path for template manifest scripts (only manifest)
+  # publicPath: http://somedomain.org/
+
+# Settings for authentication plugin
+# https://verdaccio.org/docs/configuration#authentication
+auth:
+  htpasswd:
+    file: /verdaccio/storage/htpasswd
+    # Maximum amount of users allowed to register, defaults to "+inf".
+    # You can set this to -1 to disable registration.
+    max_users: 1
+
+# A list of other known repositories we can talk to
+# https://verdaccio.org/docs/configuration#uplinks
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+# Learn how to protect your packages
+# https://verdaccio.org/docs/protect-your-dependencies/
+# https://verdaccio.org/docs/configuration#packages
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish/unpublish packages
+    # (anyone can register by default, remember?)
+    publish: $authenticated
+    unpublish: $authenticated
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+# To improve your security configuration and avoid dependency confusion
+# consider removing the proxy property for private packages
+# https://verdaccio.org/docs/best#remove-proxy-to-increase-security-at-private-packages
+
+# https://verdaccio.org/docs/configuration#server
+# You can specify HTTP/1.1 server keep alive timeout in seconds for incoming connections.
+# A value of 0 makes the http server behave similarly to Node.js versions prior to 8.0.0, which did not have a keep-alive timeout.
+# WORKAROUND: Through given configuration you can workaround following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enough.
+server:
+  keepAliveTimeout: 60
+  # The pluginPrefix replaces the default plugins prefix which is `verdaccio`. Please don't include `-`. If `something` is provided
+  # the resolved package will be `something-xxxx`.
+  # pluginPrefix: something
+  # A regex for the password validation /.{3}$/ (3 characters min)
+  # An example to limit to 10 characters minimum
+  # passwordValidationRegex: /.{10}$/
+  # Allow `req.ip` to resolve properly when Verdaccio is behind a proxy or load-balancer
+  # https://expressjs.com/en/guide/behind-proxies.html
+  # trustProxy: '127.0.0.1'
+
+# https://verdaccio.org/docs/configuration#offline-publish
+# publish:
+#   allow_offline: false
+#   check_owners: false
+#   keep_readmes: 'latest' | 'tagged' | 'all'
+
+# Define public URL of registry in combination with VERDACCIO_PUBLIC_URL environment variable
+# https://verdaccio.org/docs/configuration#url-prefix
+# url_prefix: /verdaccio/
+#
+# Examples:
+# VERDACCIO_PUBLIC_URL='https://somedomain.org'
+# url_prefix: '/my_prefix'
+# // url -> https://somedomain.org/my_prefix/
+#
+# VERDACCIO_PUBLIC_URL='https://somedomain.org'
+# url_prefix: '/'
+# // url -> https://somedomain.org/
+#
+# VERDACCIO_PUBLIC_URL='https://somedomain.org/first_prefix'
+# url_prefix: '/second_prefix'
+# // url -> https://somedomain.org/second_prefix/
+
+# Security settings
+# https://verdaccio.org/docs/configuration#security
+# security:
+#   api:
+#     legacy: true
+#     jwt:
+#       sign:
+#         expiresIn: 29d
+#       verify:
+#         someProp: [value]
+#   web:
+#     sign:
+#       expiresIn: 1h # 1 hour by default
+#     verify:
+#       someProp: [value]
+
+# https://verdaccio.org/docs/configuration#user-rate-limit
+# userRateLimit:
+#   windowMs: 50000
+#   max: 1000
+
+# https://verdaccio.org/docs/configuration#max-body-size
+# max_body_size: 10mb
+
+# https://verdaccio.org/docs/configuration#listen-port
+# listen:
+#   - localhost:4873            # default value
+#   - http://localhost:4873     # same thing
+#   - 0.0.0.0:4873              # listen on all addresses (INADDR_ANY)
+#   - https://example.org:4873  # if you want to use https
+#   - "[::1]:4873"              # ipv6
+#   - unix:/tmp/verdaccio.sock  # unix socket
+
+# The HTTPS configuration is useful if you do not consider use a HTTP Proxy
+# https://verdaccio.org/docs/configuration#https
+# https:
+#   key: ./path/verdaccio-key.pem
+#   cert: ./path/verdaccio-cert.pem
+#   ca: ./path/verdaccio-csr.pem
+
+# https://verdaccio.org/docs/configuration#proxy
+# http_proxy: http://something.local/
+# https_proxy: https://something.local/
+# no_proxy: localhost,127.0.0.1,server.local
+
+# https://verdaccio.org/docs/configuration#notifications
+# notify:
+#   method: 'POST'
+#   headers: '[{ "Content-Type": "application/json" }]'
+#   endpoint: 'https://usagge.hipchat.com/v2/room/3729485/notification?auth_token=mySecretToken'
+#   content: '{"color":"green","message":"New package published: * {{ name }}*","notify":true,"message_format":"text"}'
+
+# Settings for middleware plugins
+# https://verdaccio.org/docs/plugins#middleware-configuration
+middlewares:
+  audit:
+    enabled: true
+    # timeout: 10000
+
+# Log settings
+# https://verdaccio.org/docs/logger
+# Redaction: https://getpino.io/#/docs/redaction
+# Synchronous logging: https://getpino.io/#/docs/asynchronous
+log:
+  type: stdout
+  format: pretty
+  level: http
+#  redact:
+#    paths: ['req.header.authorization','req.header.cookie','req.remoteAddress','req.remotePort','ip','remoteIP','user','msg']
+#    censor: '<redacted>'
+#  sync: true
+
+# Feature flags (experimental settings that can be changed or removed in the future)
+# https://verdaccio.org/docs/configuration#experiments
+# experiments:
+#  # Support for npm token command
+#  token: false
+#  # Enable tarball URL redirect for hosting tarball with a different server.
+#  # The tarball_url_redirect can be a template string
+#  tarball_url_redirect: 'https://mycdn.com/verdaccio/${packageName}/${filename}'
+#  # The tarball_url_redirect can be a function, takes packageName and filename and returns the url,
+#  # when working with a js configuration file
+#  tarball_url_redirect(packageName, filename) {
+#    const signedUrl = // generate a signed url
+#    return signedUrl;
+#  }
+# Renamed from "experiments" to "flags" in next major release
+# flags:
+#  changePassword: true
+#  searchRemote: true
+
+# Translate your registry, API and web UI
+# List of the available translations https://github.com/verdaccio/verdaccio/blob/master/packages/plugins/ui-theme/src/i18n/ABOUT_TRANSLATIONS.md
+i18n:
+    web: en-US
+"""

--- a/blueprints/verdaccio/verdaccio.svg
+++ b/blueprints/verdaccio/verdaccio.svg
@@ -1,0 +1,38 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="100" height="100" rx="37" fill="white"/>
+<g filter="url(#filter0_d_0_18)">
+<mask id="path-2-inside-1_0_18" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M69 46.6L53.8 77H45L21.4 29.8L36.6 29.8L49.4 55.4L53.8 46.6H69Z"/>
+</mask>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M69 46.6L53.8 77H45L21.4 29.8L36.6 29.8L49.4 55.4L53.8 46.6H69Z" fill="#005EB8"/>
+<path d="M69 46.6L71.1466 47.6733L72.8833 44.2H69V46.6ZM53.8 77V79.4H55.2833L55.9466 78.0733L53.8 77ZM45 77L42.8534 78.0733L43.5167 79.4H45V77ZM21.4 29.8V27.4H17.5167L19.2534 30.8733L21.4 29.8ZM36.6 29.8L38.7466 28.7267L38.0833 27.4H36.6V29.8ZM49.4 55.4L47.2534 56.4733L49.4 60.7666L51.5466 56.4733L49.4 55.4ZM53.8 46.6V44.2H52.3167L51.6534 45.5267L53.8 46.6ZM66.8534 45.5267L51.6534 75.9267L55.9466 78.0733L71.1466 47.6733L66.8534 45.5267ZM53.8 74.6H45V79.4H53.8V74.6ZM47.1466 75.9267L23.5466 28.7267L19.2534 30.8733L42.8534 78.0733L47.1466 75.9267ZM21.4 32.2L36.6 32.2V27.4L21.4 27.4V32.2ZM34.4534 30.8733L47.2534 56.4733L51.5466 54.3267L38.7466 28.7267L34.4534 30.8733ZM51.5466 56.4733L55.9466 47.6733L51.6534 45.5267L47.2534 54.3267L51.5466 56.4733ZM53.8 49H69V44.2H53.8V49Z" fill="#005EB8" mask="url(#path-2-inside-1_0_18)"/>
+</g>
+<g filter="url(#filter1_d_0_18)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M71.8 41H56.6L62.2 29.8L77.4 29.8L71.8 41V41Z" fill="#005EB8"/>
+<path d="M62.9416 31H75.4584L71.0584 39.8H58.5416L62.9416 31Z" stroke="#005EB8" stroke-width="2.4"/>
+</g>
+<path d="M55.6351 70.688L53.0607 75.8H45.7416L23.3416 31H35.8573L55.6351 70.688Z" fill="#FFD101" stroke="#FFD101" stroke-width="2.4"/>
+<path d="M58.6 31H73.821" stroke="#005EB8" stroke-width="2.4" stroke-linecap="square"/>
+<path d="M54.6 35H69.821" stroke="#005EB8" stroke-width="2.4" stroke-linecap="square"/>
+<path d="M50.6 39.8H65.821" stroke="#005EB8" stroke-width="2.4" stroke-linecap="square"/>
+<defs>
+<filter id="filter0_d_0_18" x="16.4" y="28.8" width="57.6" height="57.2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.0906646 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_0_18"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_0_18" result="shape"/>
+</filter>
+<filter id="filter1_d_0_18" x="51.6" y="28.8" width="30.8" height="21.2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.0906646 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_0_18"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_0_18" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/meta.json
+++ b/meta.json
@@ -5859,6 +5859,24 @@
     ]
   },
   {
+    "id": "strapi",
+    "name": "Strapi",
+    "version": "v5.33.0",
+    "description": "Open-source headless CMS to build powerful APIs with built-in content management.",
+    "logo": "strapi.svg",
+    "links": {
+      "github": "https://github.com/strapi/strapi",
+      "discord": "https://discord.com/invite/strapi",
+      "docs": "https://docs.strapi.io",
+      "website": "https://strapi.io"
+    },
+    "tags": [
+      "headless",
+      "cms",
+      "content-management"
+    ]
+  },
+  {
     "id": "streamflow",
     "name": "StreamFlow",
     "version": "2.1",
@@ -5875,24 +5893,6 @@
       "video",
       "live-streaming",
       "media"
-    ]
-  },
-  {
-    "id": "strapi",
-    "name": "Strapi",
-    "version": "v5.33.0",
-    "description": "Open-source headless CMS to build powerful APIs with built-in content management.",
-    "logo": "strapi.svg",
-    "links": {
-      "github": "https://github.com/strapi/strapi",
-      "discord": "https://discord.com/invite/strapi",
-      "docs": "https://docs.strapi.io",
-      "website": "https://strapi.io"
-    },
-    "tags": [
-      "headless",
-      "cms",
-      "content-management"
     ]
   },
   {
@@ -6349,6 +6349,23 @@
     },
     "tags": [
       "open-source"
+    ]
+  },
+  {
+    "id": "verdaccio",
+    "name": "Verdaccio",
+    "version": "6",
+    "description": "A lightweight Node.js private proxy registry",
+    "logo": "verdaccio.svg",
+    "links": {
+      "github": "https://github.com/verdaccio/verdaccio",
+      "website": "https://www.verdaccio.org/",
+      "docs": "https://www.verdaccio.org/docs/what-is-verdaccio"
+    },
+    "tags": [
+      "node.js",
+      "package-repository",
+      "npm"
     ]
   },
   {


### PR DESCRIPTION
## What is this PR about?

New PR of [Template Name]

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

Close automatically the related issues using the keywords: `closes #ISSUE_NUMBER`


## Screenshots or Videos
<img width="1039" height="763" alt="image" src="https://github.com/user-attachments/assets/d9b66f13-28fc-4b33-971e-0dcb8d9c3a01" />
<img width="1256" height="942" alt="image" src="https://github.com/user-attachments/assets/937a8e99-18c3-4503-be5e-701af1d5a39b" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Verdaccio (private Node.js package registry) blueprint to the Dokploy templates collection. The template includes a `docker-compose.yml`, a `template.toml` with a fully embedded Verdaccio config (via `[[config.mounts]]`), an SVG logo, and a `meta.json` entry. The overall approach and configuration are correct; however, the `docker-compose.yml` violates two mandatory project conventions defined in AGENTS.md:

1. **`ports` used instead of `expose`**: Dokploy handles all external routing; using `ports` directly exposes port `4873` on the host rather than routing through Dokploy's managed reverse proxy.
2. **Missing `restart` policy**: The service does not define `restart: unless-stopped` (or `restart: always`), meaning the container will not automatically recover from crashes or host reboots.

Both issues are explicitly prohibited/required by the project's Docker Compose conventions and must be fixed before this template can be safely deployed.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the docker-compose.yml violates two mandatory project conventions that will prevent safe deployment in Dokploy.
- The PR contains two verified violations of mandatory Docker Compose conventions defined in AGENTS.md. The use of `ports` instead of `expose` bypasses Dokploy's routing system and exposes the service directly on the host, while the missing `restart` policy means the service cannot recover automatically. Both must be fixed before deployment. The other files (meta.json, template.toml, and SVG) are correct.
- blueprints/verdaccio/docker-compose.yml requires fixing: replace `ports` with `expose` and add `restart: unless-stopped`

<sub>Last reviewed commit: fc72f73</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Rule from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->