### PR TITLE
fix: Imgproxy container exposure

### DIFF
--- a/blueprints/imgproxy/docker-compose.yml
+++ b/blueprints/imgproxy/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   imgproxy:
     image: darthsim/imgproxy:v3.30.1
     restart: unless-stopped
+    expose:
+      - 8080
     environment:
       IMGPROXY_KEY: ${IMGPROXY_KEY}
       IMGPROXY_SALT: ${IMGPROXY_SALT}


### PR DESCRIPTION
## What is this PR about?

@Siumauricio On fresh dokploy installation imgproxy container exposure was needed. Unfortunately, my previous implementation doesn't work as expected without direct expose in docker-compose.yml.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes container-to-container communication for the `imgproxy` blueprint by adding an explicit `expose: - 8080` directive to the `imgproxy` service in `docker-compose.yml`. On fresh Dokploy installations, the platform relies on the `expose` declaration to wire up internal service routing, so without it nginx could not reach imgproxy on port 8080.

- The change is minimal and correct — it mirrors the existing `expose: - 80` pattern already present on the `nginx` service.
- Port `8080` is imgproxy's default listen port and is already referenced in the nginx `proxy_pass http://imgproxy:8080` directive, so this is a consistent fix.
- Uses `expose` (not `ports`), which is the required convention for this repository per the Docker Compose guidelines.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it makes a single, minimal, and correct change that aligns with both Docker Compose conventions and the repository's own guidelines.
- The change adds a single `expose: - 8080` directive that is already the established pattern for this repository (nginx already has `expose: - 80`), targets the correct default imgproxy port, does not introduce `ports` or any other prohibited directive, and directly resolves the reported deployment issue on fresh Dokploy installations.
- No files require special attention.

<sub>Last reviewed commit: 8d7fb61</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->