### PR TITLE
feat: add Rustrak template

### DIFF
--- a/blueprints/rustrak/docker-compose.yml
+++ b/blueprints/rustrak/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  rustrak:
+    image: abians7/rustrak-server:latest
+    restart: unless-stopped
+    volumes:
+      - rustrak-data:/data
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8080
+      - RUST_LOG=info
+      - SSL_PROXY=true
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
+      - CREATE_SUPERUSER=${CREATE_SUPERUSER}
+    ports:
+      - 8080
+
+  ui:
+    image: abians7/rustrak-ui:latest
+    restart: unless-stopped
+    depends_on:
+      - rustrak
+    environment:
+      - RUSTRAK_API_URL=${RUSTRAK_API_URL}
+    ports:
+      - 3000
+
+volumes:
+  rustrak-data:

--- a/blueprints/rustrak/docker-compose.yml
+++ b/blueprints/rustrak/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   rustrak:
-    image: abians7/rustrak-server:latest
+    image: abians7/rustrak-server:0.2.0
     restart: unless-stopped
     volumes:
       - rustrak-data:/data
@@ -13,17 +13,17 @@ services:
       - SSL_PROXY=true
       - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
       - CREATE_SUPERUSER=${CREATE_SUPERUSER}
-    ports:
+    expose:
       - 8080
 
   ui:
-    image: abians7/rustrak-ui:latest
+    image: abians7/rustrak-ui:0.1.5
     restart: unless-stopped
     depends_on:
       - rustrak
     environment:
       - RUSTRAK_API_URL=${RUSTRAK_API_URL}
-    ports:
+    expose:
       - 3000
 
 volumes:

--- a/blueprints/rustrak/rustrak.svg
+++ b/blueprints/rustrak/rustrak.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
+  <rect width="80" height="80" rx="16" fill="#C5F11E"/>
+  <path d="M24 32L36 44L24 56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M44 56H56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/blueprints/rustrak/template.toml
+++ b/blueprints/rustrak/template.toml
@@ -1,0 +1,23 @@
+[variables]
+ui_domain = "${domain}"
+api_domain = "${domain}"
+session_secret = "${hash:64}"
+admin_password = "${password:16}"
+
+[config]
+env = [
+  "RUSTRAK_API_URL=https://${api_domain}",
+  "SESSION_SECRET_KEY=${session_secret}",
+  "CREATE_SUPERUSER=admin@example.com:${admin_password}",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "ui"
+port = 3000
+host = "${ui_domain}"
+
+[[config.domains]]
+serviceName = "rustrak"
+port = 8080
+host = "${api_domain}"

--- a/meta.json
+++ b/meta.json
@@ -5572,7 +5572,7 @@
     "logo": "rustrak.svg",
     "links": {
       "github": "https://github.com/AbianS/rustrak",
-      "website": "https://github.com/AbianS/rustrak",
+      "website": "https://abians.github.io/rustrak/",
       "docs": "https://abians.github.io/rustrak/"
     },
     "tags": [

--- a/meta.json
+++ b/meta.json
@@ -165,7 +165,7 @@
     "id": "alist",
     "name": "AList",
     "version": "v3.55.0",
-    "description": "🗂️A file list/WebDAV program that supports multiple storages, powered by Gin and Solidjs.",
+    "description": "\ud83d\uddc2\ufe0fA file list/WebDAV program that supports multiple storages, powered by Gin and Solidjs.",
     "logo": "alist.svg",
     "links": {
       "github": "https://github.com/AlistGo/alist",
@@ -299,7 +299,7 @@
     "id": "anytype",
     "name": "Anytype",
     "version": "latest",
-    "description": "Anytype is a personal knowledge base—your digital brain—that lets you gather, connect and remix all kinds of information. Create pages, tasks, wikis, journals—even entire apps—and define your own data model while your data stays offline-first, private and encrypted across devices.\n\nAfter installation, you can view the Anytype client configuration by running `cat /data/client-config.yml` inside the service container.",
+    "description": "Anytype is a personal knowledge base\u2014your digital brain\u2014that lets you gather, connect and remix all kinds of information. Create pages, tasks, wikis, journals\u2014even entire apps\u2014and define your own data model while your data stays offline-first, private and encrypted across devices.\n\nAfter installation, you can view the Anytype client configuration by running `cat /data/client-config.yml` inside the service container.",
     "logo": "logo.png",
     "links": {
       "github": "https://github.com/grishy/any-sync-bundle",
@@ -511,7 +511,7 @@
     "id": "autobase",
     "name": "Autobase",
     "version": "2.5.2",
-    "description": "Autobase for PostgreSQL® is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
+    "description": "Autobase for PostgreSQL\u00ae is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
     "links": {
       "github": "https://github.com/vitabaks/autobase",
       "website": "https://autobase.tech/",
@@ -721,7 +721,7 @@
     "id": "blender",
     "name": "Blender",
     "version": "latest",
-    "description": "Blender is a free and open-source 3D creation suite. It supports the entire 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing and motion tracking, video editing and 2D animation pipeline.",
+    "description": "Blender is a free and open-source 3D creation suite. It supports the entire 3D pipeline\u2014modeling, rigging, animation, simulation, rendering, compositing and motion tracking, video editing and 2D animation pipeline.",
     "logo": "blender.svg",
     "links": {
       "github": "https://github.com/linuxserver/docker-blender",
@@ -3047,7 +3047,7 @@
     "id": "huly",
     "name": "Huly",
     "version": "0.6.377",
-    "description": "Huly — All-in-One Project Management Platform (alternative to Linear, Jira, Slack, Notion, Motion)",
+    "description": "Huly \u2014 All-in-One Project Management Platform (alternative to Linear, Jira, Slack, Notion, Motion)",
     "logo": "huly.svg",
     "links": {
       "github": "https://github.com/hcengineering/huly-selfhost",
@@ -3553,7 +3553,7 @@
     "id": "librechat",
     "name": "LibreChat",
     "version": "latest",
-    "description": "LibreChat is the ultimate open-source app for all your AI conversations, fully customizable and compatible with any AI provider (Openai, Ollama, Google etc.) — all in one sleek interface.",
+    "description": "LibreChat is the ultimate open-source app for all your AI conversations, fully customizable and compatible with any AI provider (Openai, Ollama, Google etc.) \u2014 all in one sleek interface.",
     "logo": "librechat.png",
     "links": {
       "github": "https://github.com/danny-avila/librechat",
@@ -4962,7 +4962,7 @@
     "id": "photoprism",
     "name": "Photoprism",
     "version": "latest",
-    "description": "PhotoPrism® is an AI-Powered Photos App for the Decentralized Web. It makes use of the latest technologies to tag and find pictures automatically without getting in your way.",
+    "description": "PhotoPrism\u00ae is an AI-Powered Photos App for the Decentralized Web. It makes use of the latest technologies to tag and find pictures automatically without getting in your way.",
     "logo": "photoprism.svg",
     "links": {
       "github": "https://github.com/photoprism/photoprism",
@@ -5573,7 +5573,7 @@
     "links": {
       "github": "https://github.com/AbianS/rustrak",
       "website": "https://github.com/AbianS/rustrak",
-      "docs": "https://github.com/AbianS/rustrak#readme"
+      "docs": "https://abians.github.io/rustrak/"
     },
     "tags": [
       "monitoring",
@@ -6010,7 +6010,7 @@
     "id": "surrealdb",
     "name": "SurrealDB",
     "version": "2.3.10",
-    "description": "SurrealDB is a native, open-source, multi-model database that lets you store and manage data across relational, document, graph, time-series, vector & search, and geospatial models—all in one place.",
+    "description": "SurrealDB is a native, open-source, multi-model database that lets you store and manage data across relational, document, graph, time-series, vector & search, and geospatial models\u2014all in one place.",
     "logo": "surrealdb.svg",
     "links": {
       "github": "https://github.com/surrealdb/surrealdb",
@@ -6282,7 +6282,7 @@
     "id": "typecho",
     "name": "Typecho",
     "version": "stable",
-    "description": "Typecho 是一个轻量级的开源博客程序，基于 PHP 开发，支持多种数据库，简洁而强大。",
+    "description": "Typecho \u662f\u4e00\u4e2a\u8f7b\u91cf\u7ea7\u7684\u5f00\u6e90\u535a\u5ba2\u7a0b\u5e8f\uff0c\u57fa\u4e8e PHP \u5f00\u53d1\uff0c\u652f\u6301\u591a\u79cd\u6570\u636e\u5e93\uff0c\u7b80\u6d01\u800c\u5f3a\u5927\u3002",
     "logo": "typecho.png",
     "links": {
       "github": "https://github.com/typecho/typecho",

--- a/meta.json
+++ b/meta.json
@@ -5565,6 +5565,23 @@
     ]
   },
   {
+    "id": "rustrak",
+    "name": "Rustrak",
+    "version": "latest",
+    "description": "Rustrak is an ultra-lightweight, self-hosted error tracking system compatible with Sentry SDKs, featuring a Rust backend and Next.js dashboard.",
+    "logo": "rustrak.svg",
+    "links": {
+      "github": "https://github.com/AbianS/rustrak",
+      "website": "https://github.com/AbianS/rustrak",
+      "docs": "https://github.com/AbianS/rustrak#readme"
+    },
+    "tags": [
+      "monitoring",
+      "error-tracking",
+      "sentry"
+    ]
+  },
+  {
     "id": "rutorrent",
     "name": "ruTorrent",
     "version": "latest",
@@ -5950,24 +5967,6 @@
       "video",
       "live-streaming",
       "media"
-    ]
-  },
-  {
-    "id": "strapi",
-    "name": "Strapi",
-    "version": "v5.33.0",
-    "description": "Open-source headless CMS to build powerful APIs with built-in content management.",
-    "logo": "strapi.svg",
-    "links": {
-      "github": "https://github.com/strapi/strapi",
-      "discord": "https://discord.com/invite/strapi",
-      "docs": "https://docs.strapi.io",
-      "website": "https://strapi.io"
-    },
-    "tags": [
-      "headless",
-      "cms",
-      "content-management"
     ]
   },
   {

--- a/meta.json
+++ b/meta.json
@@ -165,7 +165,7 @@
     "id": "alist",
     "name": "AList",
     "version": "v3.55.0",
-    "description": "\ud83d\uddc2\ufe0fA file list/WebDAV program that supports multiple storages, powered by Gin and Solidjs.",
+    "description": "🗂️A file list/WebDAV program that supports multiple storages, powered by Gin and Solidjs.",
     "logo": "alist.svg",
     "links": {
       "github": "https://github.com/AlistGo/alist",
@@ -299,7 +299,7 @@
     "id": "anytype",
     "name": "Anytype",
     "version": "latest",
-    "description": "Anytype is a personal knowledge base\u2014your digital brain\u2014that lets you gather, connect and remix all kinds of information. Create pages, tasks, wikis, journals\u2014even entire apps\u2014and define your own data model while your data stays offline-first, private and encrypted across devices.\n\nAfter installation, you can view the Anytype client configuration by running `cat /data/client-config.yml` inside the service container.",
+    "description": "Anytype is a personal knowledge base—your digital brain—that lets you gather, connect and remix all kinds of information. Create pages, tasks, wikis, journals—even entire apps—and define your own data model while your data stays offline-first, private and encrypted across devices.\n\nAfter installation, you can view the Anytype client configuration by running `cat /data/client-config.yml` inside the service container.",
     "logo": "logo.png",
     "links": {
       "github": "https://github.com/grishy/any-sync-bundle",
@@ -511,7 +511,7 @@
     "id": "autobase",
     "name": "Autobase",
     "version": "2.5.2",
-    "description": "Autobase for PostgreSQL\u00ae is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
+    "description": "Autobase for PostgreSQL® is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
     "links": {
       "github": "https://github.com/vitabaks/autobase",
       "website": "https://autobase.tech/",
@@ -721,7 +721,7 @@
     "id": "blender",
     "name": "Blender",
     "version": "latest",
-    "description": "Blender is a free and open-source 3D creation suite. It supports the entire 3D pipeline\u2014modeling, rigging, animation, simulation, rendering, compositing and motion tracking, video editing and 2D animation pipeline.",
+    "description": "Blender is a free and open-source 3D creation suite. It supports the entire 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing and motion tracking, video editing and 2D animation pipeline.",
     "logo": "blender.svg",
     "links": {
       "github": "https://github.com/linuxserver/docker-blender",
@@ -3047,7 +3047,7 @@
     "id": "huly",
     "name": "Huly",
     "version": "0.6.377",
-    "description": "Huly \u2014 All-in-One Project Management Platform (alternative to Linear, Jira, Slack, Notion, Motion)",
+    "description": "Huly — All-in-One Project Management Platform (alternative to Linear, Jira, Slack, Notion, Motion)",
     "logo": "huly.svg",
     "links": {
       "github": "https://github.com/hcengineering/huly-selfhost",
@@ -3553,7 +3553,7 @@
     "id": "librechat",
     "name": "LibreChat",
     "version": "latest",
-    "description": "LibreChat is the ultimate open-source app for all your AI conversations, fully customizable and compatible with any AI provider (Openai, Ollama, Google etc.) \u2014 all in one sleek interface.",
+    "description": "LibreChat is the ultimate open-source app for all your AI conversations, fully customizable and compatible with any AI provider (Openai, Ollama, Google etc.) — all in one sleek interface.",
     "logo": "librechat.png",
     "links": {
       "github": "https://github.com/danny-avila/librechat",
@@ -4962,7 +4962,7 @@
     "id": "photoprism",
     "name": "Photoprism",
     "version": "latest",
-    "description": "PhotoPrism\u00ae is an AI-Powered Photos App for the Decentralized Web. It makes use of the latest technologies to tag and find pictures automatically without getting in your way.",
+    "description": "PhotoPrism® is an AI-Powered Photos App for the Decentralized Web. It makes use of the latest technologies to tag and find pictures automatically without getting in your way.",
     "logo": "photoprism.svg",
     "links": {
       "github": "https://github.com/photoprism/photoprism",
@@ -5970,6 +5970,24 @@
     ]
   },
   {
+    "id": "strapi",
+    "name": "Strapi",
+    "version": "v5.33.0",
+    "description": "Open-source headless CMS to build powerful APIs with built-in content management.",
+    "logo": "strapi.svg",
+    "links": {
+      "github": "https://github.com/strapi/strapi",
+      "discord": "https://discord.com/invite/strapi",
+      "docs": "https://docs.strapi.io",
+      "website": "https://strapi.io"
+    },
+    "tags": [
+      "headless",
+      "cms",
+      "content-management"
+    ]
+  },
+  {
     "id": "supabase",
     "name": "SupaBase",
     "version": "1.25.04 / dokploy >= 0.22.5",
@@ -6010,7 +6028,7 @@
     "id": "surrealdb",
     "name": "SurrealDB",
     "version": "2.3.10",
-    "description": "SurrealDB is a native, open-source, multi-model database that lets you store and manage data across relational, document, graph, time-series, vector & search, and geospatial models\u2014all in one place.",
+    "description": "SurrealDB is a native, open-source, multi-model database that lets you store and manage data across relational, document, graph, time-series, vector & search, and geospatial models—all in one place.",
     "logo": "surrealdb.svg",
     "links": {
       "github": "https://github.com/surrealdb/surrealdb",
@@ -6282,7 +6300,7 @@
     "id": "typecho",
     "name": "Typecho",
     "version": "stable",
-    "description": "Typecho \u662f\u4e00\u4e2a\u8f7b\u91cf\u7ea7\u7684\u5f00\u6e90\u535a\u5ba2\u7a0b\u5e8f\uff0c\u57fa\u4e8e PHP \u5f00\u53d1\uff0c\u652f\u6301\u591a\u79cd\u6570\u636e\u5e93\uff0c\u7b80\u6d01\u800c\u5f3a\u5927\u3002",
+    "description": "Typecho 是一个轻量级的开源博客程序，基于 PHP 开发，支持多种数据库，简洁而强大。",
     "logo": "typecho.png",
     "links": {
       "github": "https://github.com/typecho/typecho",

--- a/meta.json
+++ b/meta.json
@@ -5567,7 +5567,7 @@
   {
     "id": "rustrak",
     "name": "Rustrak",
-    "version": "latest",
+    "version": "0.2.0",
     "description": "Rustrak is an ultra-lightweight, self-hosted error tracking system compatible with Sentry SDKs, featuring a Rust backend and Next.js dashboard.",
     "logo": "rustrak.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -5970,6 +5970,24 @@
     ]
   },
   {
+    "id": "strapi",
+    "name": "Strapi",
+    "version": "v5.33.0",
+    "description": "Open-source headless CMS to build powerful APIs with built-in content management.",
+    "logo": "strapi.svg",
+    "links": {
+      "github": "https://github.com/strapi/strapi",
+      "discord": "https://discord.com/invite/strapi",
+      "docs": "https://docs.strapi.io",
+      "website": "https://strapi.io"
+    },
+    "tags": [
+      "headless",
+      "cms",
+      "content-management"
+    ]
+  },
+  {
     "id": "supabase",
     "name": "SupaBase",
     "version": "1.25.04 / dokploy >= 0.22.5",

--- a/meta.json
+++ b/meta.json
@@ -5970,24 +5970,6 @@
     ]
   },
   {
-    "id": "strapi",
-    "name": "Strapi",
-    "version": "v5.33.0",
-    "description": "Open-source headless CMS to build powerful APIs with built-in content management.",
-    "logo": "strapi.svg",
-    "links": {
-      "github": "https://github.com/strapi/strapi",
-      "discord": "https://discord.com/invite/strapi",
-      "docs": "https://docs.strapi.io",
-      "website": "https://strapi.io"
-    },
-    "tags": [
-      "headless",
-      "cms",
-      "content-management"
-    ]
-  },
-  {
     "id": "supabase",
     "name": "SupaBase",
     "version": "1.25.04 / dokploy >= 0.22.5",


### PR DESCRIPTION
## Description

Adds a deployment template for **Rustrak**, an ultra-lightweight, self-hosted error tracking system compatible with Sentry SDKs.

- **Server**: Rust/Actix-web backend with **SQLite** (bundled, zero external DB dependency)
- **UI**: Next.js dashboard for browsing issues and events
- Docker images: `abians7/rustrak-server:latest` + `abians7/rustrak-ui:latest`

## Services

| Service | Image | Port |
|---------|-------|------|
| `rustrak` | `abians7/rustrak-server:latest` | 8080 |
| `ui` | `abians7/rustrak-ui:latest` | 3000 |

## What gets configured automatically

- Two domains: one for the UI (`ui`), one for the API (`rustrak`)
- A random 64-char session secret key (`SESSION_SECRET_KEY`)
- A bootstrap admin user with a random password via `CREATE_SUPERUSER`
- SQLite data persisted in a named volume (`rustrak-data:/data`)
- `SSL_PROXY=true` since Dokploy terminates SSL via its reverse proxy

## Files added

```
blueprints/rustrak/
├── docker-compose.yml
├── template.toml
└── rustrak.svg
```

## Testing notes

> ⚠️ I will test this using the auto-generated Cloudflare preview URL once CI builds it. Steps:
> 1. Find the Rustrak template in the preview
> 2. Copy the Base64 config
> 3. In Dokploy: Compose > Advanced > Import > Paste Base64 > Deploy
> 4. Verify both services start, UI loads, and login with the bootstrap credentials works

## Related

- GitHub repo: https://github.com/AbianS/rustrak
- Closes: N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Rustrak template (a self-hosted Sentry-compatible error tracking tool with a Rust backend and Next.js UI) to the Dokploy template library. The `template.toml` and SVG logo are well-formed and follow project conventions, but there are three issues that need to be addressed before merging:

- **`ports` instead of `expose` in `docker-compose.yml`**: Both the `rustrak` and `ui` services declare `ports` mappings, which is explicitly prohibited by the project guidelines. Dokploy manages all routing via its reverse proxy, so `expose` must be used instead.
- **Unpinned Docker image tags**: Both `abians7/rustrak-server:latest` and `abians7/rustrak-ui:latest` use `:latest`, violating the guideline to pin images to a specific version to prevent supply-chain attacks. The `version` field in `meta.json` should also reflect the pinned tag rather than `"latest"`.
- **Accidental deletion of the Strapi `meta.json` entry**: The existing Strapi template entry was removed from `meta.json` in this PR. The blueprint files still exist on disk but Strapi will be invisible to users until the entry is restored. This was likely an unintended side-effect of running `dedupe-and-sort-meta.js` or a manual merge conflict resolution.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — accidental deletion of the Strapi registry entry and `ports` convention violation must be fixed first.
- The accidental removal of the Strapi entry from `meta.json` is a regression that would break an existing, working template for all users. The `ports` directive is a clear guidelines violation that would cause incorrect networking behaviour in Dokploy deployments.
- `meta.json` (Strapi deletion) and `blueprints/rustrak/docker-compose.yml` (`ports` → `expose`, unpinned images).

<sub>Last reviewed commit: bc7879f</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->