### PR TITLE
feat: Update Glitchtip to version 6.1.0

### DIFF
--- a/blueprints/glitchtip/docker-compose.yml
+++ b/blueprints/glitchtip/docker-compose.yml
@@ -1,54 +1,51 @@
+version: "3.8"
+
 x-environment: &default-environment
   DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
+  VALKEY_URL: redis://valkey:6379
   SECRET_KEY: ${SECRET_KEY}
   PORT: ${GLITCHTIP_PORT}
   EMAIL_URL: consolemail://
-  GLITCHTIP_DOMAIN: http://${GLITCHTIP_HOST}
-  DEFAULT_FROM_EMAIL: email@glitchtip.com
-  CELERY_WORKER_AUTOSCALE: "1,3"
-  CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
+  GLITCHTIP_DOMAIN: ${GLITCHTIP_DOMAIN}
+  DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL}
 
 x-depends_on: &default-depends_on
   - postgres
-  - redis
+  - valkey
 
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
     restart: unless-stopped
     volumes:
-      - pg-data:/var/lib/postgresql/data
-
-  redis:
-    image: redis
+      - pg-data:/var/lib/postgresql
+  valkey:
+    image: valkey/valkey:9
     restart: unless-stopped
-
   web:
-    image: glitchtip/glitchtip:v4.0
+    image: glitchtip/glitchtip:6.1.0
     depends_on: *default-depends_on
-    ports:
+    expose:
       - ${GLITCHTIP_PORT}
     environment: *default-environment
     restart: unless-stopped
     volumes:
       - uploads:/code/uploads
   worker:
-    image: glitchtip/glitchtip:v4.0
-    command: ./bin/run-celery-with-beat.sh
+    image: glitchtip/glitchtip:6.1.0
+    command: ./bin/run-worker.sh
     depends_on: *default-depends_on
     environment: *default-environment
     restart: unless-stopped
     volumes:
       - uploads:/code/uploads
-
   migrate:
-    image: glitchtip/glitchtip:v4.0
+    image: glitchtip/glitchtip:6.1.0
     depends_on: *default-depends_on
-    command: "./manage.py migrate"
+    command: ./bin/run-migrate.sh
     environment: *default-environment
-
 
 volumes:
   pg-data:

--- a/blueprints/glitchtip/docker-compose.yml
+++ b/blueprints/glitchtip/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: "trust"
     restart: unless-stopped
     volumes:
-      - pg-data:/var/lib/postgresql
+      - pg-data:/var/lib/postgresql/data
   valkey:
     image: valkey/valkey:9
     restart: unless-stopped

--- a/blueprints/glitchtip/template.toml
+++ b/blueprints/glitchtip/template.toml
@@ -4,7 +4,8 @@ secret_key = "${base64:32}"
 
 [config]
 env = [
-  "GLITCHTIP_HOST=${main_domain}",
+  "DEFAULT_FROM_EMAIL=${email}",
+  "GLITCHTIP_DOMAIN=https://${main_domain}",
   "GLITCHTIP_PORT=8000",
   "SECRET_KEY=${secret_key}",
 ]
@@ -12,5 +13,5 @@ mounts = []
 
 [[config.domains]]
 serviceName = "web"
-port = 8_000
+port = 8000
 host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -2763,7 +2763,7 @@
   {
     "id": "glitchtip",
     "name": "Glitchtip",
-    "version": "v4.0",
+    "version": "v6.1.0",
     "description": "Glitchtip is simple, open source error tracking",
     "logo": "glitchtip.png",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -2763,7 +2763,7 @@
   {
     "id": "glitchtip",
     "name": "Glitchtip",
-    "version": "v6.1.0",
+    "version": "6.1.0",
     "description": "Glitchtip is simple, open source error tracking",
     "logo": "glitchtip.png",
     "links": {


### PR DESCRIPTION
## What is this PR about?

Update Glitchtip to version 6.1.0

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

## Screenshots or Videos
<img width="1512" height="982" alt="glitchtip1" src="https://github.com/user-attachments/assets/b7a0c8da-6c87-4c8b-8f2b-98a859fc6642" />
<img width="1512" height="982" alt="glitchtip2" src="https://github.com/user-attachments/assets/127917d4-b32d-408d-b83f-0faf3c7a02f4" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Glitchtip template from v4.0 to 6.1.0, replacing Redis with Valkey, upgrading PostgreSQL from 16 to 18, switching from `ports` to `expose` (correct per conventions), and updating worker/migrate startup commands to match the new release's script layout.

**Key changes:**
- `glitchtip/glitchtip:v4.0` → `glitchtip/glitchtip:6.1.0` across all three services
- `redis` replaced with `valkey/valkey:9`; `VALKEY_URL` env var added
- `GLITCHTIP_DOMAIN` now properly constructed with `https://` prefix and configurable `DEFAULT_FROM_EMAIL` via `${email}` helper
- Worker command updated to `./bin/run-worker.sh`; migrate command updated to `./bin/run-migrate.sh`
- `version: "3.8"` correctly added to the compose file
- `ports` correctly replaced with `expose`

**Issues found:**
- The PostgreSQL volume mount was changed from `pg-data:/var/lib/postgresql/data` to `pg-data:/var/lib/postgresql`. While this works for fresh deployments, it would cause any existing deployment being upgraded to lose access to its data, since PostgreSQL's `PGDATA` still resolves to `/var/lib/postgresql/data` (a subdirectory of the new mount) rather than the root of the previously populated volume.
- `meta.json` lists the version as `v6.1.0` while the Docker image tag is `6.1.0` — these should match exactly per the project's AGENTS.md guide.

<h3>Confidence Score: 3/5</h3>

- Safe for new deployments, but the postgres volume path change is a data-loss risk for users upgrading from the previous template version.
- The overall update is well-structured and the v6.1.0 changes (Valkey, new script paths, https domain, expose vs ports) are all correct. However, the postgres volume mount path regression (`/var/lib/postgresql` vs `/var/lib/postgresql/data`) could silently wipe existing data for upgrading users, which is a meaningful reliability concern. The meta.json version prefix inconsistency is minor but straightforward to fix.
- blueprints/glitchtip/docker-compose.yml — specifically the postgres volume mount path on line 23.

<sub>Reviews (1): Last reviewed commit: ["feat(glitchtip): update to version 6.1.0"](https://github.com/dokploy/templates/commit/079be40968cf969ea2e3216ba758aa7cd4c32e2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26092159)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->