### PR TITLE
Update Langflow docker-compose.yml

### DIFF
--- a/blueprints/langflow/docker-compose.yml
+++ b/blueprints/langflow/docker-compose.yml
@@ -1,31 +1,44 @@
-version: "3.8"
-
 services:
   langflow:
-    image: langflowai/langflow:v1.1.1
+    image: langflowai/langflow:latest
+    user: root
+    restart: always
+    pull_policy: always
     ports:
       - 7860
     depends_on:
       - postgres-langflow
     environment:
       - LANGFLOW_DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres-langflow:5432/langflow
-      # This variable defines where the logs, file storage, monitor data and secret keys are stored.
+      - LANGFLOW_CONFIG_DIR=/app/config
+      - LANGFLOW_SUPERUSER=email@domain.com
+      - LANGFLOW_SUPERUSER_PASSWORD=changepassword
+      - LANGFLOW_SECRET_KEY=PP_G4Gwm1lOkyG8r8N0LrdlpWXZ7Tyq5CVyfBquuj6g=
+      - DO_NOT_TRACK=True
+      - LANGFLOW_AUTO_SAVING=True
+      - LANGFLOW_AUTO_LOGIN=False
+      - LANGFLOW_NEW_USER_IS_ACTIVE=False
+      - LANGFLOW_ENABLE_SUPERUSER_CLI=False
     volumes:
-      - langflow-data:/app/langflow
-
-
+      - app-data:/app/langflow
+      - app-config:/app/config
+  
   postgres-langflow:
     image: postgres:16
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d langflow"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
     environment:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: langflow
-    ports:
-      - 5432
     volumes:
-      - langflow-postgres:/var/lib/postgresql/data
-
+      - postgres-data:/var/lib/postgresql/data
 
 volumes:
-  langflow-postgres:
-  langflow-data:
+  postgres-data:
+  app-data:
+  app-config:


### PR DESCRIPTION
## What is this PR about?

New PR of langflow

## Checklist

Before submitting this PR, please make sure that:

- [ yes] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [ yes] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ yes] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

Close automatically the related issues using the keywords: `closes #ISSUE_NUMBER`


## Screenshots or Videos

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Langflow blueprint's `docker-compose.yml` with several improvements — adding healthchecks for Postgres, better environment variable configuration, and cleaner volume naming — but introduces a number of violations of the repository's AGENTS.md conventions that must be fixed before merging.

Key issues found:

- **P0 – Hardcoded secret key**: `LANGFLOW_SECRET_KEY` is set to a static value committed in a public repo. Every deployment shares the same cryptographic secret; it must be replaced with the `${base64:32}` Dokploy helper.
- **P1 – Hardcoded superuser password**: `LANGFLOW_SUPERUSER_PASSWORD` uses a plain-text default that will be used as-is unless users manually intervene. Should use the `${password:16}` helper via the template variable system.
- **P1 – Missing `version: "3.8"`**: AGENTS.md mandates this declaration; it was removed entirely.
- **P1 – `ports` instead of `expose`**: AGENTS.md explicitly forbids `ports` in compose files; `expose` must be used instead.
- **P1 – Unpinned `latest` image**: Pinning to a specific version is required to ensure reproducible and supply-chain-safe deployments.
- **P2 – `pull_policy: always`**: Combined with `latest`, this causes silent uncontrolled upgrades on every container restart.

<h3>Confidence Score: 1/5</h3>

Not safe to merge — contains a publicly exposed cryptographic secret and multiple AGENTS.md convention violations.

The hardcoded LANGFLOW_SECRET_KEY committed to a public repository is a P0 security issue that alone blocks merging. On top of that, there are four P1 violations of mandatory AGENTS.md conventions (missing version, ports vs expose, unpinned image, hardcoded password). All of these need to be resolved before the template is suitable for public use.

blueprints/langflow/docker-compose.yml requires significant rework; blueprints/langflow/template.toml also needs updating to expose the new credentials as auto-generated variables.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| blueprints/langflow/docker-compose.yml | Updated Langflow compose with healthchecks and richer env config, but introduces a publicly committed secret key, hardcoded credentials, removed mandatory version declaration, uses `ports` instead of `expose`, and pins to the `latest` tag — all violating AGENTS.md conventions. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Update docker-compose.yml"](https://github.com/dokploy/templates/commit/bf8c13b23a5fd2a9ef66c2827643c70a1a99bf00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26425858)</sub>

> Greptile also left **6 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->