### PR TITLE
feat(nextcloud-aio): add nextcloud_cron service

### DIFF
--- a/blueprints/nextcloud-aio/docker-compose.yml
+++ b/blueprints/nextcloud-aio/docker-compose.yml
@@ -14,6 +14,21 @@ services:
       - nextcloud_db
       - nextcloud_redis
 
+  nextcloud_cron:
+    image: nextcloud:stable
+    restart: always
+    volumes:
+      - nextcloud_data:/var/www/html
+    environment:
+      - MYSQL_HOST=nextcloud_db
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+    entrypoint: /cron.sh
+    depends_on:
+      - nextcloud_db
+      - nextcloud_redis
+
   nextcloud_db:
     image: mariadb:10.11
     restart: always


### PR DESCRIPTION
Adds a dedicated `nextcloud_cron` service to the blueprint. This ensures background tasks run reliably every 5 minutes, resolving the "Ajax/webcron mode detected" warning and ensuring feeds/notifications stay up to date.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a dedicated `nextcloud_cron` service to the `nextcloud-aio` blueprint, resolving the "Ajax/webcron mode detected" warning by running Nextcloud's background jobs via the official `/cron.sh` entrypoint on a 5-minute interval. The implementation correctly shares the `nextcloud_data` volume and MySQL credentials with the main service.

- The new `nextcloud_cron` service uses the same `nextcloud:stable` image and shares the `nextcloud_data` volume, which is the standard pattern for cron in the official Nextcloud Docker documentation.
- The service correctly uses `entrypoint: /cron.sh`, which is included in the official Nextcloud image and handles the scheduling loop internally.
- Minor: the cron service does not declare a `depends_on` for the main `nextcloud` service, meaning it can start concurrently during first-run initialization; adding this dependency would improve startup ordering.

<h3>Confidence Score: 4/5</h3>

This PR is safe to merge; the change is a well-known pattern for Nextcloud cron and introduces no breaking changes.

The implementation follows the standard Nextcloud Docker cron pattern (shared volume + /cron.sh entrypoint). The only concern is the absence of depends_on: nextcloud, which is a soft startup-ordering issue rather than a correctness bug — cron.sh retries every 5 minutes, so transient failures during first-run init self-resolve.

No files require special attention beyond the single depends_on suggestion in blueprints/nextcloud-aio/docker-compose.yml.

<sub>Reviews (1): Last reviewed commit: ["feat(nextcloud-aio): add nextcloud\_cron ..."](https://github.com/dokploy/templates/commit/26f52d26657d6237aa5244bdfed5436254c9ae46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27159390)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->