### PR TITLE
[codex] fix: update firecrawl template for v2.8.0

### DIFF
--- a/blueprints/firecrawl/docker-compose.yml
+++ b/blueprints/firecrawl/docker-compose.yml
@@ -1,25 +1,39 @@
-name: firecrawl
- 
+version: "3.8"
+
 x-common-service: &common-service
-  image: ghcr.io/firecrawl/firecrawl:latest
+  build:
+    context: "https://github.com/firecrawl/firecrawl.git#v2.8.0:apps/api"
+  restart: unless-stopped
   ulimits:
     nofile:
       soft: 65535
       hard: 65535
   extra_hosts:
     - "host.docker.internal:host-gateway"
- 
+
 x-common-env: &common-env
   REDIS_URL: ${REDIS_URL:-redis://redis:6379}
   REDIS_RATE_LIMIT_URL: ${REDIS_RATE_LIMIT_URL:-redis://redis:6379}
   PLAYWRIGHT_MICROSERVICE_URL: ${PLAYWRIGHT_MICROSERVICE_URL:-http://playwright-service:3000/scrape}
-  NUQ_DATABASE_URL: ${NUQ_DATABASE_URL:-postgres://postgres:postgres@nuq-postgres:5432/postgres}
-  USE_DB_AUTHENTICATION: ${USE_DB_AUTHENTICATION:-}
+  POSTGRES_HOST: ${POSTGRES_HOST:-nuq-postgres}
+  POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+  POSTGRES_USER: ${POSTGRES_USER:-firecrawl}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-firecrawl}
+  POSTGRES_DB: ${POSTGRES_DB:-firecrawl}
+  NUQ_RABBITMQ_URL: ${NUQ_RABBITMQ_URL:-amqp://rabbitmq:5672}
+  USE_DB_AUTHENTICATION: ${USE_DB_AUTHENTICATION:-false}
+  NUM_WORKERS_PER_QUEUE: ${NUM_WORKERS_PER_QUEUE:-8}
+  CRAWL_CONCURRENT_REQUESTS: ${CRAWL_CONCURRENT_REQUESTS:-10}
+  MAX_CONCURRENT_JOBS: ${MAX_CONCURRENT_JOBS:-5}
+  BROWSER_POOL_SIZE: ${BROWSER_POOL_SIZE:-5}
   OPENAI_API_KEY: ${OPENAI_API_KEY:-}
   OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
+  OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
   MODEL_NAME: ${MODEL_NAME:-}
   MODEL_EMBEDDING_NAME: ${MODEL_EMBEDDING_NAME:-}
   OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+  AUTUMN_SECRET_KEY: ${AUTUMN_SECRET_KEY:-}
+  LLAMAPARSE_API_KEY: ${LLAMAPARSE_API_KEY:-}
   SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
   BULL_AUTH_KEY: ${BULL_AUTH_KEY:-}
   TEST_API_KEY: ${TEST_API_KEY:-}
@@ -29,39 +43,43 @@ x-common-env: &common-env
   SUPABASE_URL: ${SUPABASE_URL:-}
   SUPABASE_SERVICE_TOKEN: ${SUPABASE_SERVICE_TOKEN:-}
   SELF_HOSTED_WEBHOOK_URL: ${SELF_HOSTED_WEBHOOK_URL:-}
-  SERPER_API_KEY: ${SERPER_API_KEY:-}
-  SEARCHAPI_API_KEY: ${SEARCHAPI_API_KEY:-}
-  LOGGING_LEVEL: ${LOGGING_LEVEL:-INFO}
+  ALLOW_LOCAL_WEBHOOKS: ${ALLOW_LOCAL_WEBHOOKS:-}
+  LOGGING_LEVEL: ${LOGGING_LEVEL:-}
   PROXY_SERVER: ${PROXY_SERVER:-}
   PROXY_USERNAME: ${PROXY_USERNAME:-}
   PROXY_PASSWORD: ${PROXY_PASSWORD:-}
-  NO_PROXY: ${NO_PROXY:-localhost,127.0.0.1,redis,nuq-postgres,playwright-service,host.docker.internal}
   SEARXNG_ENDPOINT: ${SEARXNG_ENDPOINT:-}
   SEARXNG_ENGINES: ${SEARXNG_ENGINES:-}
   SEARXNG_CATEGORIES: ${SEARXNG_CATEGORIES:-}
- 
+  MAX_CPU: ${MAX_CPU:-0.8}
+  MAX_RAM: ${MAX_RAM:-0.8}
+
 services:
   playwright-service:
-    image: ghcr.io/firecrawl/playwright-service:latest
-    shm_size: "1g"
+    build:
+      context: "https://github.com/firecrawl/firecrawl.git#v2.8.0:apps/playwright-service-ts"
     restart: unless-stopped
+    shm_size: "1g"
     environment:
       PORT: 3000
       PROXY_SERVER: ${PROXY_SERVER:-}
       PROXY_USERNAME: ${PROXY_USERNAME:-}
       PROXY_PASSWORD: ${PROXY_PASSWORD:-}
+      ALLOW_LOCAL_WEBHOOKS: ${ALLOW_LOCAL_WEBHOOKS:-}
       BLOCK_MEDIA: ${BLOCK_MEDIA:-}
-      NO_PROXY: ${NO_PROXY:-localhost,127.0.0.1,redis,nuq-postgres,playwright-service,host.docker.internal}
- 
+      MAX_CONCURRENT_PAGES: ${CRAWL_CONCURRENT_REQUESTS:-10}
+    expose:
+      - "3000"
+
   api:
     <<: *common-service
-    restart: unless-stopped
-    ports:
+    expose:
       - "3002"
     environment:
       <<: *common-env
       HOST: "0.0.0.0"
       PORT: 3002
+      EXTRACT_WORKER_PORT: 3004
       WORKER_PORT: 3005
       ENV: local
     depends_on:
@@ -69,53 +87,40 @@ services:
         condition: service_started
       playwright-service:
         condition: service_started
+      rabbitmq:
+        condition: service_healthy
       nuq-postgres:
         condition: service_healthy
-    command: node --import ./dist/src/otel.js dist/src/index.js
- 
-  worker:
-    <<: *common-service
-    restart: unless-stopped
-    environment:
-      <<: *common-env
-      HOST: "0.0.0.0"
-      PORT: 3005
-      ENV: local
-    depends_on:
-      redis:
-        condition: service_started
-      nuq-postgres:
-        condition: service_healthy
-    command: node --import ./dist/src/otel.js dist/src/services/queue-worker.js
- 
-  extract-worker:
-    <<: *common-service
-    restart: unless-stopped
-    environment:
-      <<: *common-env
-      HOST: "0.0.0.0"
-      PORT: 3004
-      ENV: local
-    depends_on:
-      redis:
-        condition: service_started
-      nuq-postgres:
-        condition: service_healthy
-    command: node --import ./dist/src/otel.js dist/src/services/extract-worker.js
- 
+    command: node dist/src/harness.js --start-docker
+
   redis:
-    image: redis:alpine
-    command: redis-server --bind 0.0.0.0
- 
+    image: redis:7.4-alpine
+    restart: unless-stopped
+    command: redis-server --bind 0.0.0.0 --appendonly yes
+    volumes:
+      - redis_data:/data
+
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    restart: unless-stopped
+    command: rabbitmq-server
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
   nuq-postgres:
     build:
-      context: "https://github.com/firecrawl/firecrawl.git#main:apps/nuq-postgres"
-      dockerfile: Dockerfile
+      context: "https://github.com/firecrawl/firecrawl.git#v2.8.0:apps/nuq-postgres"
     restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-firecrawl}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-firecrawl}
+      POSTGRES_DB: ${POSTGRES_DB:-firecrawl}
     volumes:
       - nuq_pg_data:/var/lib/postgresql/data
     healthcheck:
@@ -124,6 +129,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
- 
+
 volumes:
   nuq_pg_data:
+  rabbitmq_data:
+  redis_data:

--- a/blueprints/firecrawl/template.toml
+++ b/blueprints/firecrawl/template.toml
@@ -1,7 +1,11 @@
 [variables]
 main_domain = "${domain}"
+postgres_user = "firecrawl"
+postgres_password = "${password:32}"
+postgres_db = "firecrawl"
 openai_api_key = "${OPENAI_API_KEY}"
 openai_base_url = "${OPENAI_BASE_URL}"
+openrouter_api_key = "${OPENROUTER_API_KEY}"
 ollama_base_url = "${OLLAMA_BASE_URL}"
 model_name = "${MODEL_NAME}"
 model_embedding_name = "${MODEL_EMBEDDING_NAME}"
@@ -20,6 +24,15 @@ llamaparse_api_key = "${LLAMAPARSE_API_KEY}"
 slack_webhook_url = "${SLACK_WEBHOOK_URL}"
 posthog_api_key = "${POSTHOG_API_KEY}"
 posthog_host = "${POSTHOG_HOST}"
+self_hosted_webhook_url = "${SELF_HOSTED_WEBHOOK_URL}"
+autumn_secret_key = "${AUTUMN_SECRET_KEY}"
+allow_local_webhooks = "${ALLOW_LOCAL_WEBHOOKS}"
+block_media = "${BLOCK_MEDIA}"
+num_workers_per_queue = "${NUM_WORKERS_PER_QUEUE}"
+crawl_concurrent_requests = "${CRAWL_CONCURRENT_REQUESTS}"
+max_concurrent_jobs = "${MAX_CONCURRENT_JOBS}"
+browser_pool_size = "${BROWSER_POOL_SIZE}"
+logging_level = "${LOGGING_LEVEL}"
 max_cpu = "${MAX_CPU}"
 max_ram = "${MAX_RAM}"
 
@@ -27,13 +40,20 @@ max_ram = "${MAX_RAM}"
 env = [
   "PORT=3002",
   "HOST=0.0.0.0",
+  "POSTGRES_HOST=nuq-postgres",
+  "POSTGRES_PORT=5432",
+  "POSTGRES_USER=${postgres_user}",
+  "POSTGRES_PASSWORD=${postgres_password}",
+  "POSTGRES_DB=${postgres_db}",
   "USE_DB_AUTHENTICATION=false",
   "BULL_AUTH_KEY=${bull_auth_key}",
   "PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/scrape",
   "REDIS_URL=redis://redis:6379",
   "REDIS_RATE_LIMIT_URL=redis://redis:6379",
+  "NUQ_RABBITMQ_URL=amqp://rabbitmq:5672",
   "OPENAI_API_KEY=${openai_api_key}",
   "OPENAI_BASE_URL=${openai_base_url}",
+  "OPENROUTER_API_KEY=${openrouter_api_key}",
   "OLLAMA_BASE_URL=${ollama_base_url}",
   "MODEL_NAME=${model_name}",
   "MODEL_EMBEDDING_NAME=${model_embedding_name}",
@@ -51,8 +71,17 @@ env = [
   "SLACK_WEBHOOK_URL=${slack_webhook_url}",
   "POSTHOG_API_KEY=${posthog_api_key}",
   "POSTHOG_HOST=${posthog_host}",
-  "MAX_CPU=0.8",
-  "MAX_RAM=0.8"
+  "SELF_HOSTED_WEBHOOK_URL=${self_hosted_webhook_url}",
+  "AUTUMN_SECRET_KEY=${autumn_secret_key}",
+  "ALLOW_LOCAL_WEBHOOKS=${allow_local_webhooks}",
+  "BLOCK_MEDIA=${block_media}",
+  "NUM_WORKERS_PER_QUEUE=${num_workers_per_queue}",
+  "CRAWL_CONCURRENT_REQUESTS=${crawl_concurrent_requests}",
+  "MAX_CONCURRENT_JOBS=${max_concurrent_jobs}",
+  "BROWSER_POOL_SIZE=${browser_pool_size}",
+  "LOGGING_LEVEL=${logging_level}",
+  "MAX_CPU=${max_cpu}",
+  "MAX_RAM=${max_ram}"
 ]
 mounts = []
 
@@ -61,5 +90,3 @@ serviceName = "api"
 port = 3002
 host = "${main_domain}"
 path = "/"
-
- 

--- a/meta.json
+++ b/meta.json
@@ -2312,8 +2312,8 @@
   {
     "id": "firecrawl",
     "name": "Firecrawl",
-    "version": "latest",
-    "description": "Firecrawl is an API service that takes a URL, crawls it, and converts it into clean markdown or structured data. It can crawl all accessible subpages and provide clean data for each.",
+    "version": "v2.8.0",
+    "description": "Firecrawl is a self-hosted crawling and scraping API that can turn web pages into clean markdown or structured data, crawl accessible subpages, and power extract workflows with optional AI providers.",
     "logo": "firecrawl.svg",
     "links": {
       "github": "https://github.com/firecrawl/firecrawl",
@@ -5950,24 +5950,6 @@
       "video",
       "live-streaming",
       "media"
-    ]
-  },
-  {
-    "id": "strapi",
-    "name": "Strapi",
-    "version": "v5.33.0",
-    "description": "Open-source headless CMS to build powerful APIs with built-in content management.",
-    "logo": "strapi.svg",
-    "links": {
-      "github": "https://github.com/strapi/strapi",
-      "discord": "https://discord.com/invite/strapi",
-      "docs": "https://docs.strapi.io",
-      "website": "https://strapi.io"
-    },
-    "tags": [
-      "headless",
-      "cms",
-      "content-management"
     ]
   },
   {


### PR DESCRIPTION
## Summary
- align the Firecrawl Dokploy template with the current upstream self-hosted architecture
- pin Firecrawl source builds to `v2.8.0` and switch startup to the upstream harness entrypoint
- update the template env model for PostgreSQL and RabbitMQ, and refresh the `meta.json` entry

## What changed
- replaced the stale split-process Firecrawl deployment with the current harness-driven `api` service
- added the missing `rabbitmq` dependency and kept `redis`, `playwright-service`, and `nuq-postgres`
- changed Firecrawl-owned services from `latest` images to remote source builds pinned to `v2.8.0`
- updated Dokploy template variables to use `POSTGRES_*`, `NUQ_RABBITMQ_URL`, and current optional Firecrawl envs
- pinned the Firecrawl metadata version to `v2.8.0`
- running the required meta processing also removed a pre-existing duplicate `strapi` entry from `meta.json`

## Root cause
The existing Firecrawl template still launched the old runtime layout using `node --import ./dist/src/otel.js ...`. Upstream Firecrawl now starts through `node dist/src/harness.js --start-docker` and expects RabbitMQ plus harness-managed workers, so the old Dokploy template crashed with `ERR_MODULE_NOT_FOUND` for `/app/dist/src/otel.js`.

## Impact
Dokploy users should get a Firecrawl deployment shape that matches current upstream self-hosting instead of the broken legacy image startup path. The template is also now version-pinned instead of following `latest`.

## Validation
- `node dedupe-and-sort-meta.js`
- `docker compose -f blueprints/firecrawl/docker-compose.yml config`
- `npm run validate-docker-compose -- --file ../blueprints/firecrawl/docker-compose.yml` (from `build-scripts/`)
- `npm run validate-template -- --dir ../blueprints/firecrawl` (from `build-scripts/`)
- `git diff --check`
