### PR TITLE
feat: add Velix API one-click template

### DIFF
--- a/blueprints/velix-api/docker-compose.yml
+++ b/blueprints/velix-api/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+services:
+  velix-api:
+    image: ghcr.io/paulolinder/velix-api:0.1.0
+    restart: always
+    environment:
+      - DATABASE_URL=postgres://postgres:${DB_PASSWORD}@postgres:5432/velix?sslmode=disable
+      - REDIS_URL=redis://redis:6379
+      - JWT_SECRET=${JWT_SECRET}
+      - HTTP_PORT=8080
+      - APP_ENV=production
+      - LOG_LEVEL=info
+      - MEDIA_STORAGE_PATH=/data/media
+      - ENGINE_STORE_PATH=/data/instances
+      - ENGINE_AUTO_RECONNECT=true
+      - ENGINE_MAX_INSTANCES=200
+      - REGISTRATION_ENABLED=false
+    volumes:
+      - velix-data:/data
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:16-alpine
+    restart: always
+    environment:
+      - POSTGRES_DB=velix
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    volumes:
+      - redis-data:/data
+
+volumes:
+  velix-data:
+  postgres-data:
+  redis-data:

--- a/blueprints/velix-api/template.toml
+++ b/blueprints/velix-api/template.toml
@@ -1,0 +1,16 @@
+[variables]
+main_domain = "${domain}"
+DB_PASSWORD = "${password:32}"
+JWT_SECRET = "${password:64}"
+
+[config]
+env = [
+  "DB_PASSWORD=${DB_PASSWORD}",
+  "JWT_SECRET=${JWT_SECRET}",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "velix-api"
+port = 8_080
+host = "${main_domain}"

--- a/blueprints/velix-api/template.toml
+++ b/blueprints/velix-api/template.toml
@@ -12,5 +12,5 @@ mounts = []
 
 [[config.domains]]
 serviceName = "velix-api"
-port = 8_080
+port = 8080
 host = "${main_domain}"

--- a/blueprints/velix-api/velix-api.svg
+++ b/blueprints/velix-api/velix-api.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="128" y2="128" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#15803d"/>
+    </linearGradient>
+    <linearGradient id="bubble" x1="20" y1="20" x2="108" y2="108" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0.08)"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#bg)"/>
+  <path d="M30 36 C30 28, 36 22, 44 22 L84 22 C92 22, 98 28, 98 36 L98 72 C98 80, 92 86, 84 86 L52 86 L38 98 L38 86 L44 86 C36 86, 30 80, 30 72 Z" fill="url(#bubble)"/>
+  <path d="M42 38 L58 82 C59 84.5, 61 86, 64 86 C67 86, 69 84.5, 70 82 L86 38" stroke="white" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M56 92 L62 98 L76 84" stroke="rgba(255,255,255,0.6)" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/meta.json
+++ b/meta.json
@@ -6463,6 +6463,24 @@
     ]
   },
   {
+    "id": "velix-api",
+    "name": "Velix API",
+    "version": "0.1.0",
+    "description": "Self-hosted WhatsApp API with multi-instance support, webhooks, n8n node, and Chatwoot integration.",
+    "logo": "velix-api.svg",
+    "links": {
+      "github": "https://github.com/paulolinder/velix-api",
+      "website": "https://velix.dev"
+    },
+    "tags": [
+      "whatsapp",
+      "api",
+      "messaging",
+      "chatbot",
+      "automation"
+    ]
+  },
+  {
     "id": "verdaccio",
     "name": "Verdaccio",
     "version": "6",


### PR DESCRIPTION
## Summary

Added Velix API as a new one-click blueprint. Velix is a self-hosted WhatsApp API built in Go with multi-instance support, webhooks, n8n node, and Chatwoot integration.

**Services included:**
- velix-api (Go, port 8080)
- PostgreSQL 16
- Redis 7

**Security:** Registration is disabled by default (`REGISTRATION_ENABLED=false`).

**Docker image:** `ghcr.io/paulolinder/velix-api:0.1.0`

## Preview

Admin panel accessible at the configured domain on port 8080 for QR code pairing and WhatsApp instance management.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Velix API — a self-hosted WhatsApp API — as a new one-click blueprint with a Go service, PostgreSQL 16, and Redis 7. The template follows all Dokploy conventions correctly: version 3.8, no `ports`/`container_name`/`networks`, `restart: always`, named volumes, and secrets properly randomized via template helpers. The only minor issue is `port = 8_080` in `template.toml` using TOML's underscore integer literal instead of the standard `8080` used by all other templates in this repository.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all conventions are followed and the single finding is a non-blocking style suggestion.

All changed files conform to AGENTS.md requirements: correct compose version, no forbidden fields, pinned image versions, secrets randomized, meta.json fields complete and version-matched. The only finding is a P2 style issue (underscore integer notation in template.toml) that doesn't affect runtime behavior given TOML 1.0 compliance.

blueprints/velix-api/template.toml — minor port notation style issue on line 14.

<sub>Reviews (1): Last reviewed commit: ["feat: add Velix API one-click template"](https://github.com/dokploy/templates/commit/5976110f05dff8605a1d5d60e902f3b5c38a6f12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28587964)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->