### PR TITLE
fix(cloudflared): opt-out of isolated deployment

### DIFF
--- a/blueprints/cloudflared/template.toml
+++ b/blueprints/cloudflared/template.toml
@@ -1,6 +1,7 @@
 variables = {}
 
 [config]
+isolated = false
 domains = []
 mounts = []
 


### PR DESCRIPTION
## Summary

- Adds `isolated = false` to the cloudflared template config
- Cloudflared requires `network_mode: host` which is mutually exclusive with Docker networks
- Without this, Dokploy injects networks into the compose causing: `service cloudflared declares mutually exclusive network_mode and networks`

Requires Dokploy/dokploy#4366