### PR TITLE
Add Marketing Dashboard template

### DIFF
--- a/blueprints/marketing-dashboard/docker-compose.yml
+++ b/blueprints/marketing-dashboard/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  marketing-dashboard:
+    image: ghcr.io/abel-yelin/marketing-dashboard:latest
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      DIRECT_URL: ${DIRECT_URL}
+      MARKETING_APP_URL: ${MARKETING_APP_URL}
+      MARKETING_COLLECTOR_UPSTREAM_URL: ${MARKETING_COLLECTOR_UPSTREAM_URL}
+      MARKETING_SESSION_TIMEOUT_MINUTES: ${MARKETING_SESSION_TIMEOUT_MINUTES}
+      MARKETING_PROXY_TIMEOUT_MS: ${MARKETING_PROXY_TIMEOUT_MS}
+      MARKETING_INGEST_MAX_BODY_BYTES: ${MARKETING_INGEST_MAX_BODY_BYTES}
+      MARKETING_INGEST_IP_RATE_LIMIT: ${MARKETING_INGEST_IP_RATE_LIMIT}
+      MARKETING_INGEST_CLIENT_RATE_LIMIT: ${MARKETING_INGEST_CLIENT_RATE_LIMIT}
+      MARKETING_INGEST_RATE_LIMIT_WINDOW_MS: ${MARKETING_INGEST_RATE_LIMIT_WINDOW_MS}
+      MARKETING_ENABLE_PILOT_API: ${MARKETING_ENABLE_PILOT_API}
+      MARKETING_DASHBOARD_ADMIN_USER: ${MARKETING_DASHBOARD_ADMIN_USER}
+      MARKETING_DASHBOARD_ADMIN_PASSWORD: ${MARKETING_DASHBOARD_ADMIN_PASSWORD}
+    ports:
+      - 3000
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3000/api/health > /dev/null || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - marketing-dashboard-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  marketing-dashboard-postgres:

--- a/blueprints/marketing-dashboard/logo.svg
+++ b/blueprints/marketing-dashboard/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Marketing Dashboard">
+  <rect width="128" height="128" rx="24" fill="#111827"/>
+  <path d="M28 86h72" stroke="#f8fafc" stroke-width="8" stroke-linecap="round"/>
+  <path d="M36 76V54" stroke="#22c55e" stroke-width="10" stroke-linecap="round"/>
+  <path d="M58 76V34" stroke="#38bdf8" stroke-width="10" stroke-linecap="round"/>
+  <path d="M80 76V46" stroke="#f59e0b" stroke-width="10" stroke-linecap="round"/>
+  <path d="M34 39l20-10 24 9 18-16" fill="none" stroke="#f8fafc" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/blueprints/marketing-dashboard/template.toml
+++ b/blueprints/marketing-dashboard/template.toml
@@ -1,0 +1,30 @@
+[variables]
+main_domain = "${domain}"
+postgres_password = "${password:32}"
+admin_password = "${password:32}"
+
+[config]
+mounts = []
+
+[[config.domains]]
+serviceName = "marketing-dashboard"
+port = 3000
+host = "${main_domain}"
+
+[config.env]
+POSTGRES_DB = "marketing_dashboard"
+POSTGRES_USER = "marketing_dashboard"
+POSTGRES_PASSWORD = "${postgres_password}"
+DATABASE_URL = "postgresql://marketing_dashboard:${postgres_password}@postgres:5432/marketing_dashboard?schema=public"
+DIRECT_URL = "postgresql://marketing_dashboard:${postgres_password}@postgres:5432/marketing_dashboard?schema=public"
+MARKETING_APP_URL = "https://${main_domain}"
+MARKETING_COLLECTOR_UPSTREAM_URL = "https://${main_domain}/api/ingest/browser"
+MARKETING_SESSION_TIMEOUT_MINUTES = "30"
+MARKETING_PROXY_TIMEOUT_MS = "4000"
+MARKETING_INGEST_MAX_BODY_BYTES = "65536"
+MARKETING_INGEST_IP_RATE_LIMIT = "300"
+MARKETING_INGEST_CLIENT_RATE_LIMIT = "1200"
+MARKETING_INGEST_RATE_LIMIT_WINDOW_MS = "60000"
+MARKETING_ENABLE_PILOT_API = "false"
+MARKETING_DASHBOARD_ADMIN_USER = "admin"
+MARKETING_DASHBOARD_ADMIN_PASSWORD = "${admin_password}"

--- a/meta.json
+++ b/meta.json
@@ -3864,6 +3864,25 @@
     ]
   },
   {
+    "id": "marketing-dashboard",
+    "name": "Marketing Dashboard",
+    "version": "latest",
+    "description": "Self-hosted marketing operations dashboard for product-led growth, checkout analytics, paid media, SEO signals, and Stripe readiness.",
+    "logo": "logo.svg",
+    "links": {
+      "github": "https://github.com/abel-yelin/marketing-dashboard",
+      "website": "https://github.com/abel-yelin/marketing-dashboard",
+      "docs": "https://github.com/abel-yelin/marketing-dashboard/blob/main/docs/production-deployment.md"
+    },
+    "tags": [
+      "analytics",
+      "marketing",
+      "self-hosted",
+      "postgresql",
+      "nextjs"
+    ]
+  },
+  {
     "id": "mattermost",
     "name": "Mattermost",
     "version": "10.6.1",


### PR DESCRIPTION
Adds a self-hosted Marketing Dashboard template with PostgreSQL, generated secrets, a GHCR image, health checks, and Dokploy domain configuration.

Local validation completed:
- validate-docker-compose.ts passed
- validate-template.ts passed
- process-meta.js passed with no diff
