### PR TITLE
feat: add rustrak and rustrak-full templates

### DIFF
--- a/blueprints/rustrak-full/docker-compose.yml
+++ b/blueprints/rustrak-full/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.8"
+
+services:
+  rustrak-server:
+    image: abians7/rustrak-server:v0.2.1-postgres
+    restart: unless-stopped
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8080
+      - RUST_LOG=info
+      - SSL_PROXY=true
+      - DATABASE_URL=postgres://rustrak:${POSTGRES_PASSWORD}@postgres:5432/rustrak
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
+      - CREATE_SUPERUSER=${CREATE_SUPERUSER}
+    ports:
+      - 8080
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  rustrak-ui:
+    image: abians7/rustrak-ui:v0.1.6
+    restart: unless-stopped
+    environment:
+      - RUSTRAK_API_URL=${RUSTRAK_API_URL}
+    ports:
+      - 3000
+    depends_on:
+      - rustrak-server
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=rustrak
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=rustrak
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rustrak -d rustrak"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    expose:
+      - 5432
+
+volumes:
+  postgres_data:

--- a/blueprints/rustrak-full/rustrak.svg
+++ b/blueprints/rustrak-full/rustrak.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
+  <rect width="80" height="80" rx="16" fill="#C5F11E"/>
+  <path d="M24 32L36 44L24 56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M44 56H56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/blueprints/rustrak-full/rustrak.svg
+++ b/blueprints/rustrak-full/rustrak.svg
@@ -1,5 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
-  <rect width="80" height="80" rx="16" fill="#C5F11E"/>
-  <path d="M24 32L36 44L24 56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M44 56H56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="96" fill="#C5F11E"/>
+  <polygon points="274,90 108,291 256,291 238,422 404,221 256,221"
+          fill="#0A0A0A" stroke="#0A0A0A" stroke-width="20"
+          stroke-linejoin="round" stroke-linecap="round"/>
 </svg>

--- a/blueprints/rustrak-full/template.toml
+++ b/blueprints/rustrak-full/template.toml
@@ -1,0 +1,27 @@
+[variables]
+main_domain = "${domain}"
+api_domain = "${domain}"
+postgres_password = "${password:32}"
+session_secret_key = "${password:64}"
+admin_email = "${email}"
+admin_password = "${password:16}"
+create_superuser = "${admin_email}:${admin_password}"
+rustrak_api_url = "https://${api_domain}"
+
+[config]
+env = [
+  "POSTGRES_PASSWORD=${postgres_password}",
+  "SESSION_SECRET_KEY=${session_secret_key}",
+  "CREATE_SUPERUSER=${create_superuser}",
+  "RUSTRAK_API_URL=${rustrak_api_url}",
+]
+
+[[config.domains]]
+serviceName = "rustrak-ui"
+port = 3000
+host = "${main_domain}"
+
+[[config.domains]]
+serviceName = "rustrak-server"
+port = 8080
+host = "${api_domain}"

--- a/blueprints/rustrak/docker-compose.yml
+++ b/blueprints/rustrak/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  rustrak:
+    image: abians7/rustrak-server:v0.2.1
+    restart: unless-stopped
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8080
+      - RUST_LOG=info
+      - SSL_PROXY=true
+      - SESSION_SECRET_KEY=${SESSION_SECRET_KEY}
+      - CREATE_SUPERUSER=${CREATE_SUPERUSER}
+    volumes:
+      - rustrak_data:/data
+    ports:
+      - 8080
+
+volumes:
+  rustrak_data:

--- a/blueprints/rustrak/rustrak.svg
+++ b/blueprints/rustrak/rustrak.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
+  <rect width="80" height="80" rx="16" fill="#C5F11E"/>
+  <path d="M24 32L36 44L24 56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M44 56H56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/blueprints/rustrak/rustrak.svg
+++ b/blueprints/rustrak/rustrak.svg
@@ -1,5 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
-  <rect width="80" height="80" rx="16" fill="#C5F11E"/>
-  <path d="M24 32L36 44L24 56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M44 56H56" stroke="#171717" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="96" fill="#C5F11E"/>
+  <polygon points="274,90 108,291 256,291 238,422 404,221 256,221"
+          fill="#0A0A0A" stroke="#0A0A0A" stroke-width="20"
+          stroke-linejoin="round" stroke-linecap="round"/>
 </svg>

--- a/blueprints/rustrak/template.toml
+++ b/blueprints/rustrak/template.toml
@@ -1,0 +1,17 @@
+[variables]
+main_domain = "${domain}"
+session_secret_key = "${password:64}"
+admin_email = "${email}"
+admin_password = "${password:16}"
+create_superuser = "${admin_email}:${admin_password}"
+
+[config]
+env = [
+  "SESSION_SECRET_KEY=${session_secret_key}",
+  "CREATE_SUPERUSER=${create_superuser}",
+]
+
+[[config.domains]]
+serviceName = "rustrak"
+port = 8080
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -5603,6 +5603,45 @@
     ]
   },
   {
+    "id": "rustrak",
+    "name": "Rustrak",
+    "version": "0.2.1",
+    "description": "Self-hosted error tracking compatible with Sentry SDKs. Server only, written in Rust with <100MB memory footprint and SQLite storage. No external database required.",
+    "logo": "rustrak.svg",
+    "links": {
+      "github": "https://github.com/AbianS/rustrak",
+      "website": "https://abians.github.io/rustrak/",
+      "docs": "https://abians.github.io/rustrak/"
+    },
+    "tags": [
+      "monitoring",
+      "error-tracking",
+      "sentry",
+      "rust",
+      "observability"
+    ]
+  },
+  {
+    "id": "rustrak-full",
+    "name": "Rustrak (Full Stack)",
+    "version": "0.2.1",
+    "description": "Self-hosted error tracking compatible with Sentry SDKs. Includes server, web dashboard UI, and PostgreSQL. Written in Rust with <100MB memory footprint.",
+    "logo": "rustrak.svg",
+    "links": {
+      "github": "https://github.com/AbianS/rustrak",
+      "website": "https://abians.github.io/rustrak/",
+      "docs": "https://abians.github.io/rustrak/"
+    },
+    "tags": [
+      "monitoring",
+      "error-tracking",
+      "sentry",
+      "rust",
+      "observability",
+      "postgresql"
+    ]
+  },
+  {
     "id": "rutorrent",
     "name": "ruTorrent",
     "version": "latest",


### PR DESCRIPTION
New PR of Rustrak

## Checklist
- [x] I've read the README.md of the repository
- [x] I've tested the template on my instance
- [x] I've added tests that prove my fix or feature works

## Templates

### `rustrak`
Server-only deployment using SQLite. Single service, no external database required.
- Image: `abians7/rustrak-server:v0.2.1`
- Port: 8080
- Auto-generates session secret and initial admin credentials

### `rustrak-full`
Full-stack deployment with web dashboard and PostgreSQL.
- Server: `abians7/rustrak-server:v0.2.1-postgres`
- UI: `abians7/rustrak-ui:v0.1.6`
- Ports: 8080 (API) + 3000 (dashboard)
- Auto-generates postgres password, session secret and initial admin credentials

## Related Issues
N/A

## Screenshots or Videos
https://github.com/AbianS/rustrak