### PR TITLE
fix: remove duplicate search

### DIFF
--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/app/src/components/TemplateGrid.tsx
+++ b/app/src/components/TemplateGrid.tsx
@@ -42,10 +42,9 @@ const TemplateGrid: React.FC<TemplateGridProps> = ({ view }) => {
     filteredTemplates,
     setFilteredTemplates,
   } = useStore();
+  const searchQuery = useStore((state) => state.searchQuery);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const searchQuery = useStore((state) => state.searchQuery);
-  const selectedTags = useStore((state) => state.selectedTags);
   const { addSelectedTag } = useStore();
 
   const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(
@@ -104,25 +103,6 @@ const TemplateGrid: React.FC<TemplateGridProps> = ({ view }) => {
     setTemplateFiles(null); // Reset previous files
     fetchTemplateFiles(template.id);
   };
-
-  useEffect(() => {
-    const filtered = templates.filter((template) => {
-      // Filter by search query
-      const matchesSearch = template.name
-        .toLowerCase()
-        .includes(searchQuery.toLowerCase());
-
-      // Filter by selected tags
-      const matchesTags =
-        selectedTags.length === 0 ||
-        selectedTags.every((tag) => template.tags.includes(tag));
-
-      return matchesSearch && matchesTags;
-    });
-
-    setTemplatesCount(filtered.length);
-    setFilteredTemplates(filtered);
-  }, [searchQuery, selectedTags]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## What is this PR about?

There was an issue in the search functionality where it kept showing strapi cards even though the search has nothing to do with strapi..

There was a duplicate search functionality in an useEffect that caused the issue. I noticed the issue couldn't be replicated in local development but removing that useEffect didn't break anything.

## Screenshots or Videos

<img width="1904" height="908" alt="image" src="https://github.com/user-attachments/assets/669610c8-0089-445e-b673-ed89f1a06937" />

Note: the `pnpm-workspace.yaml` was added automatically when using pnpm v11