### PR TITLE
feat: add Seq template

### DIFF
--- a/blueprints/seq/docker-compose.yml
+++ b/blueprints/seq/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  seq:
+    image: datalust/seq:latest
+    restart: unless-stopped
+    environment:
+      ACCEPT_EULA: "Y"
+      SEQ_API_CANONICALURI: https://${SEQ_HOST}
+      SEQ_FIRSTRUN_ADMINPASSWORD: ${SEQ_ADMIN_PASSWORD}
+    volumes:
+      - seq-data:/data
+
+volumes:
+  seq-data:

--- a/blueprints/seq/seq.svg
+++ b/blueprints/seq/seq.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Seq">
+  <rect width="512" height="512" rx="96" fill="#f37021"/>
+  <circle cx="256" cy="256" r="162" fill="#ffffff" opacity="0.18"/>
+  <path fill="#ffffff" d="M145 334h226v42H145zm0-99h165v42H145zm0-99h226v42H145z"/>
+</svg>

--- a/blueprints/seq/template.toml
+++ b/blueprints/seq/template.toml
@@ -1,0 +1,15 @@
+[variables]
+main_domain = "${domain}"
+admin_password = "${password:32}"
+
+[config]
+env = [
+  "SEQ_HOST=${main_domain}",
+  "SEQ_ADMIN_PASSWORD=${admin_password}",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "seq"
+port = 80
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -5742,7 +5742,7 @@
     ]
   },
   {
-        "id": "seq",
+    "id": "seq",
     "name": "Seq",
     "version": "latest",
     "description": "Seq is a self-hosted search and analysis server for structured application logs and traces.",
@@ -5759,7 +5759,7 @@
     ]
   },
   {
-"id": "shlink",
+    "id": "shlink",
     "name": "Shlink",
     "version": "stable",
     "description": "URL shortener that can be used to serve shortened URLs under your own domain.",

--- a/meta.json
+++ b/meta.json
@@ -5742,7 +5742,24 @@
     ]
   },
   {
-    "id": "shlink",
+        "id": "seq",
+    "name": "Seq",
+    "version": "latest",
+    "description": "Seq is a self-hosted search and analysis server for structured application logs and traces.",
+    "logo": "seq.svg",
+    "links": {
+      "github": "https://github.com/datalust/seq-tickets",
+      "website": "https://datalust.co/seq",
+      "docs": "https://docs.datalust.co/"
+    },
+    "tags": [
+      "logs",
+      "monitoring",
+      "observability"
+    ]
+  },
+  {
+"id": "shlink",
     "name": "Shlink",
     "version": "stable",
     "description": "URL shortener that can be used to serve shortened URLs under your own domain.",


### PR DESCRIPTION
## What this does

Adds a Dokploy template for Seq, the self-hosted structured log and trace search server from Datalust.

Closes #815.

## What's included

- `blueprints/seq/docker-compose.yml` using the official `datalust/seq:latest` image
- persistent `seq-data` volume mounted at `/data`
- required `ACCEPT_EULA=Y`
- first-run admin password generated through Dokploy template variables
- canonical URL configured from the generated Dokploy domain
- `blueprints/seq/template.toml` mapping the web UI/API to port `80`
- `blueprints/seq/seq.svg` local SVG logo
- `meta.json` entry with observability/logging tags

## Verification

- `node dedupe-and-sort-meta.js`
- `npm run validate-template -- --dir ../blueprints/seq` from `build-scripts/`
- `npm run validate-docker-compose -- --file ../blueprints/seq/docker-compose.yml` from `build-scripts/`
- `node build-scripts/process-meta.js`
- `git diff --check HEAD`

## Notes

Seq's official Docker documentation states that `/data` stores configuration and log data, port `80` serves UI/API traffic, and `ACCEPT_EULA=Y` is required. The template sets a generated first-run admin password instead of deploying without authentication.