### PR TITLE
feat: add OpenSourcePOS template

### DIFF
--- a/blueprints/opensourcepos/docker-compose.yml
+++ b/blueprints/opensourcepos/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.8"
+
+services:
+  opensourcepos:
+    image: jekkos/opensourcepos:master
+    restart: unless-stopped
+    depends_on:
+      opensourcepos-db:
+        condition: service_healthy
+    expose:
+      - "80"
+    environment:
+      CI_ENVIRONMENT: production
+      ALLOWED_HOSTNAMES: ${ALLOWED_HOSTNAMES}
+      FORCE_HTTPS: ${FORCE_HTTPS}
+      PHP_TIMEZONE: ${PHP_TIMEZONE}
+      MYSQL_USERNAME: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DB_NAME: ${MYSQL_DATABASE}
+      MYSQL_HOST_NAME: opensourcepos-db
+    volumes:
+      - opensourcepos-uploads:/app/public/uploads
+      - opensourcepos-logs:/app/writable/logs
+
+  opensourcepos-db:
+    image: mariadb:10.11
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    volumes:
+      - opensourcepos-db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  opensourcepos-db:
+  opensourcepos-uploads:
+  opensourcepos-logs:

--- a/blueprints/opensourcepos/opensourcepos.svg
+++ b/blueprints/opensourcepos/opensourcepos.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="OpenSourcePOS">
+  <rect width="128" height="128" rx="24" fill="#177245"/>
+  <path fill="#fff" d="M30 34h68l-6 44H40L30 34Z"/>
+  <path fill="#d8f3dc" d="M42 45h44l-3 22H45l-3-22Z"/>
+  <path fill="#fff" d="M42 83h44a10 10 0 0 1 10 10v3H32v-3a10 10 0 0 1 10-10Z"/>
+  <path fill="#177245" d="M50 51h28v8H50zM49 88h30v5H49z"/>
+  <circle cx="48" cy="75" r="4" fill="#177245"/>
+  <circle cx="80" cy="75" r="4" fill="#177245"/>
+</svg>

--- a/blueprints/opensourcepos/template.toml
+++ b/blueprints/opensourcepos/template.toml
@@ -1,0 +1,51 @@
+[variables]
+main_domain = "${domain}"
+mysql_root_password = "${password:32}"
+mysql_password = "${password:32}"
+php_timezone = "UTC"
+force_https = "false"
+allowed_hostnames = "${main_domain}"
+
+[[config.domains]]
+serviceName = "opensourcepos"
+port = 80
+host = "${main_domain}"
+path = "/"
+
+[[config.mounts]]
+filePath = "README.md"
+content = """# OpenSourcePOS
+
+This template deploys Open Source Point of Sale with MariaDB using the upstream Docker image and persistent storage for uploads, logs, and database data.
+
+## Access
+
+- URL: `http://${main_domain}`
+- Default application user: `admin`
+- Default application password: `pointofsale`
+
+Change the default application password immediately after the first login.
+
+## Hostnames and HTTPS
+
+OpenSourcePOS validates incoming host headers in production. The `allowed_hostnames` variable defaults to `${main_domain}` and can be set to a comma-separated list such as `pos.example.com,www.pos.example.com`.
+
+The template defaults `force_https` to `false` because Dokploy terminates TLS outside the container. Set it to `true` only when your deployment always reaches OpenSourcePOS through HTTPS and the reverse proxy sends the expected headers.
+
+## Storage
+
+The template creates persistent volumes for:
+
+- MariaDB data
+- uploaded files
+- application logs
+"""
+
+[config.env]
+MYSQL_ROOT_PASSWORD = "${mysql_root_password}"
+MYSQL_DATABASE = "ospos"
+MYSQL_USER = "admin"
+MYSQL_PASSWORD = "${mysql_password}"
+PHP_TIMEZONE = "${php_timezone}"
+FORCE_HTTPS = "${force_https}"
+ALLOWED_HOSTNAMES = "${allowed_hostnames}"

--- a/meta.json
+++ b/meta.json
@@ -4762,6 +4762,25 @@
     ]
   },
   {
+    "id": "opensourcepos",
+    "name": "OpenSourcePOS",
+    "version": "master",
+    "description": "OpenSourcePOS is a web-based point of sale system for managing sales, inventory, customers, and reports.",
+    "logo": "opensourcepos.svg",
+    "links": {
+      "github": "https://github.com/opensourcepos/opensourcepos",
+      "website": "https://opensourcepos.org/",
+      "docs": "https://github.com/opensourcepos/opensourcepos/blob/master/README.md"
+    },
+    "tags": [
+      "pos",
+      "retail",
+      "inventory",
+      "sales",
+      "business"
+    ]
+  },
+  {
     "id": "openspeedtest",
     "name": "OpenSpeedTest",
     "version": "latest",


### PR DESCRIPTION
## Summary
- add an OpenSourcePOS template backed by the upstream `jekkos/opensourcepos:master` Docker image
- configure Dokploy domain routing, MariaDB persistence, generated database credentials, upload/log volumes, and allowed hostnames
- add README mount, SVG logo, and metadata entry

/claim #152
Closes #860

## Validation
- node dedupe-and-sort-meta.js
- node --import ./build-scripts/node_modules/tsx/dist/loader.mjs build-scripts/validate-template.ts --dir blueprints/opensourcepos
- node --import ./build-scripts/node_modules/tsx/dist/loader.mjs build-scripts/validate-docker-compose.ts --file blueprints/opensourcepos/docker-compose.yml
- MYSQL_ROOT_PASSWORD=root-password MYSQL_DATABASE=ospos MYSQL_USER=admin MYSQL_PASSWORD=app-password PHP_TIMEZONE=UTC FORCE_HTTPS=false ALLOWED_HOSTNAMES=pos.example.com docker compose -f blueprints/opensourcepos/docker-compose.yml config
- git diff --check
- Docker Hub API confirmed `jekkos/opensourcepos:master` is available for amd64 and arm64

Note: upstream docker-compose.yml currently uses `jekkos/opensourcepos:master`; the latest GitHub release tag exists, but the matching Docker tag is amd64-only, so this template follows upstream while preserving Apple Silicon/server ARM compatibility.