### PR TITLE
fix: revert Discourse, PostgreSQL and Redis to Bitnami legacy images

### DIFF
--- a/blueprints/discourse/docker-compose.yml
+++ b/blueprints/discourse/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   discourse-db:
-    image: docker.io/bitnami/postgresql:17
+    image: docker.io/bitnamilegacy/postgresql:17
 
     volumes:
       - discourse-postgresql-data:/bitnami/postgresql
@@ -18,7 +18,7 @@ services:
     restart: unless-stopped
 
   discourse-redis:
-    image: docker.io/bitnami/redis:7.4
+    image: docker.io/bitnamilegacy/redis:7.4
 
     volumes:
       - discourse-redis-data:/bitnami/redis


### PR DESCRIPTION
Bitnami deprecated their previous free Docker images after moving them behind a paid tier. Fortunately, they continue to maintain `bitnami` legacy images which are functionally identical to the previous versions.

This PR reverts the **Discourse**, **PostgreSQL**, and **Redis** Docker images back to the pre-deprecation (legacy) versions to restore compatibility and avoid the paid tier.

## What is this PR about?
New PR for Dokploy Templates — Bitnami legacy image fix.

## Checklist
Before submitting this PR, please make sure that:
- [x] I have read the suggestions in the README.md file [General requirements when creating a template](https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template)
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)
Closed #502

## Screenshots or Videos
Not Applicable