### PR TITLE
fix(discourse): replace deprecated Bitnami images with official alternatives

### DIFF
--- a/blueprints/discourse/docker-compose.yml
+++ b/blueprints/discourse/docker-compose.yml
@@ -1,29 +1,24 @@
-version: '3.7'
-
 services:
   discourse-db:
-    image: docker.io/bitnami/postgresql:17
-
+    image: pgvector/pgvector:pg16
     volumes:
-      - discourse-postgresql-data:/bitnami/postgresql
+      - discourse-postgresql-data:/var/lib/postgresql/data
     environment:
-      POSTGRESQL_USERNAME: bn_discourse
-      POSTGRESQL_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRESQL_DATABASE: bitnami_discourse
+      POSTGRES_USER: discourse
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: discourse
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bn_discourse -d bitnami_discourse"]
+      test: ["CMD-SHELL", "pg_isready -U discourse -d discourse"]
       interval: 10s
       timeout: 5s
       retries: 5
     restart: unless-stopped
 
   discourse-redis:
-    image: docker.io/bitnami/redis:7.4
-
+    image: redis:7-alpine
     volumes:
-      - discourse-redis-data:/bitnami/redis
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      - discourse-redis-data:/data
+    command: redis-server --requirepass ${REDIS_PASSWORD}
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
@@ -32,59 +27,39 @@ services:
     restart: unless-stopped
 
   discourse-app:
-    image: docker.io/bitnamilegacy/discourse:3.5.0
-
+    image: discourse/discourse:2026.1.4
     volumes:
-      - discourse-data:/bitnami/discourse
+      - discourse-data:/shared
     depends_on:
       discourse-db:
         condition: service_healthy
       discourse-redis:
         condition: service_healthy
     environment:
-      DISCOURSE_HOST: ${DISCOURSE_HOST}
-      DISCOURSE_DATABASE_HOST: discourse-db
-      DISCOURSE_DATABASE_PORT_NUMBER: 5432
-      DISCOURSE_DATABASE_USER: bn_discourse
-      DISCOURSE_DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
-      DISCOURSE_DATABASE_NAME: bitnami_discourse
+      DISCOURSE_HOSTNAME: ${DISCOURSE_HOST}
+      DISCOURSE_DB_HOST: discourse-db
+      DISCOURSE_DB_PORT: 5432
+      DISCOURSE_DB_USERNAME: discourse
+      DISCOURSE_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      DISCOURSE_DB_NAME: discourse
       DISCOURSE_REDIS_HOST: discourse-redis
-      DISCOURSE_REDIS_PORT_NUMBER: 6379
+      DISCOURSE_REDIS_PORT: 6379
       DISCOURSE_REDIS_PASSWORD: ${REDIS_PASSWORD}
-      # Optional: Configure SMTP for email delivery
-      # DISCOURSE_SMTP_HOST: ${SMTP_HOST}
+      DISCOURSE_DEVELOPER_EMAILS: ${DISCOURSE_ADMIN_EMAIL}
+      UNICORN_BIND_ALL: "true"
+      # Required for email delivery - Discourse will not function correctly without SMTP
+      # DISCOURSE_SMTP_ADDRESS: ${SMTP_HOST}
       # DISCOURSE_SMTP_PORT: ${SMTP_PORT}
-      # DISCOURSE_SMTP_USER: ${SMTP_USER}
+      # DISCOURSE_SMTP_USER_NAME: ${SMTP_USER}
       # DISCOURSE_SMTP_PASSWORD: ${SMTP_PASSWORD}
-    restart: unless-stopped
-
-  discourse-sidekiq:
-    image: docker.io/bitnamilegacy/discourse:3.5.0
-
-    volumes:
-      - discourse-sidekiq-data:/bitnami/discourse
-    depends_on:
-      - discourse-app
-    command: /opt/bitnami/scripts/discourse-sidekiq/run.sh
-    environment:
-      DISCOURSE_HOST: ${DISCOURSE_HOST}
-      DISCOURSE_DATABASE_HOST: discourse-db
-      DISCOURSE_DATABASE_PORT_NUMBER: 5432
-      DISCOURSE_DATABASE_USER: bn_discourse
-      DISCOURSE_DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
-      DISCOURSE_DATABASE_NAME: bitnami_discourse
-      DISCOURSE_REDIS_HOST: discourse-redis
-      DISCOURSE_REDIS_PORT_NUMBER: 6379
-      DISCOURSE_REDIS_PASSWORD: ${REDIS_PASSWORD}
-      # Optional: Configure SMTP for email delivery
-      # DISCOURSE_SMTP_HOST: ${SMTP_HOST}
-      # DISCOURSE_SMTP_PORT: ${SMTP_PORT}
-      # DISCOURSE_SMTP_USER: ${SMTP_USER}
-      # DISCOURSE_SMTP_PASSWORD: ${SMTP_PASSWORD}
+      # DISCOURSE_SMTP_ENABLE_START_TLS: "true"
+      # DISCOURSE_NOTIFICATION_EMAIL: [email protected]
+      # DISCOURSE_DEVELOPER_EMAILS: [email protected]
+    ports:
+      - 3000
     restart: unless-stopped
 
 volumes:
   discourse-postgresql-data:
   discourse-redis-data:
   discourse-data:
-  discourse-sidekiq-data: 

--- a/blueprints/discourse/docker-compose.yml
+++ b/blueprints/discourse/docker-compose.yml
@@ -46,9 +46,6 @@ services:
       DISCOURSE_REDIS_PORT: 6379
       DISCOURSE_REDIS_PASSWORD: ${REDIS_PASSWORD}
       DISCOURSE_DEVELOPER_EMAILS: ${DISCOURSE_ADMIN_EMAIL}
-      UNICORN_BIND_ALL: "true"
-      # Required for production
-      # DISCOURSE_FORCE_HTTPS: "true"
       # Required for email delivery - Discourse will not function correctly without SMTP
       # DISCOURSE_SMTP_ADDRESS: ${SMTP_HOST}
       # DISCOURSE_SMTP_PORT: ${SMTP_PORT}
@@ -58,7 +55,7 @@ services:
       # DISCOURSE_NOTIFICATION_EMAIL: [email protected]
       # DISCOURSE_DEVELOPER_EMAILS: [email protected]
     ports:
-      - 3000
+      - 80
     restart: unless-stopped
 
 volumes:

--- a/blueprints/discourse/docker-compose.yml
+++ b/blueprints/discourse/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       DISCOURSE_REDIS_PASSWORD: ${REDIS_PASSWORD}
       DISCOURSE_DEVELOPER_EMAILS: ${DISCOURSE_ADMIN_EMAIL}
       UNICORN_BIND_ALL: "true"
+      # Required for production
+      # DISCOURSE_FORCE_HTTPS: "true"
       # Required for email delivery - Discourse will not function correctly without SMTP
       # DISCOURSE_SMTP_ADDRESS: ${SMTP_HOST}
       # DISCOURSE_SMTP_PORT: ${SMTP_PORT}

--- a/blueprints/discourse/template.toml
+++ b/blueprints/discourse/template.toml
@@ -1,11 +1,13 @@
 [variables]
 main_domain = "${domain}"
+admin_email = "${email}"
 postgres_password = "${password}"
 redis_password = "${password}"
 
 [config]
 env = [
   "DISCOURSE_HOST=${main_domain}",
+  "DISCOURSE_ADMIN_EMAIL=${admin_email}",
   "POSTGRES_PASSWORD=${postgres_password}",
   "REDIS_PASSWORD=${redis_password}",
 ]

--- a/blueprints/discourse/template.toml
+++ b/blueprints/discourse/template.toml
@@ -15,5 +15,5 @@ mounts = []
 
 [[config.domains]]
 serviceName = "discourse-app"
-port = 3_000
+port = 80
 host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -1785,7 +1785,7 @@
   {
     "id": "discourse",
     "name": "Discourse",
-    "version": "3.5.0",
+    "version": "2026.1.4",
     "description": "Discourse is a modern forum software for your community. Use it as a mailing list, discussion forum, or long-form chat room.",
     "logo": "discourse.svg",
     "links": {


### PR DESCRIPTION
## What is this PR about?

Fixes the Discourse template which was broken due to Bitnami discontinuing their legacy images (`bitnami/discourse`, `bitnami/postgresql`, `bitnami/redis`, `bitnamilegacy`).

**Changes:**
- Replaced `bitnamilegacy/discourse:3.5.0` with `discourse/discourse:2026.1.4` (official ESR image)
- Replaced `bitnami/postgresql:17` with `pgvector/pgvector:pg16` (required for Discourse's vector extension)
- Replaced `bitnami/redis:7.4` with `redis:7-alpine`
- Removed separate sidekiq container — the official image runs web + sidekiq internally via runit
- Updated all env var names from Bitnami-specific (`DISCOURSE_DATABASE_*`, `POSTGRESQL_*`) to standard ones (`DISCOURSE_DB_*`, `POSTGRES_*`)
- Added `UNICORN_BIND_ALL: "true"` to allow the proxy to reach the web process
- Added `DISCOURSE_DEVELOPER_EMAILS` variable to `template.toml` so admin email is set at deploy time
- Consolidated volumes from 4 down to 3

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)
Closed: #502 - Fix was replacing with BitnamiLegacy images which may soon be deprecated. Replacing with official images ensures that Bitnami does not have control to pull the plug suddenly again.

## Screenshots or Videos
<img width="1278" height="686" alt="Discourse Setup Wizard" src="https://github.com/user-attachments/assets/9eec0bae-7d81-4b0a-9720-526a088d88a1" />
<img width="2482" height="1386" alt="Disource App Logs" src="https://github.com/user-attachments/assets/ed56940a-0228-4536-8646-b52fa37bd714" />
<img width="2482" height="1386" alt="Discourse Redis Logs" src="https://github.com/user-attachments/assets/e631eb24-984a-416a-b6ae-65fe2ef06dd9" />
<img width="2482" height="1386" alt="Discourse DB Logs" src="https://github.com/user-attachments/assets/16f05ba4-631b-43ab-aafa-2912c00b56d5" />

~~Note: The "Tada" SVG is not showing due to it not being served on HTTPS/SSL. This is using **sslip** for testing. SMTP is partially required for Discourse otherwise manual admin account creation is required, and it disables a lot of features that require emails.~~ Refer to [this](https://github.com/Dokploy/templates/pull/910#issuecomment-4550408174)
