### PR TITLE
Add Cut (self-hosted URL shortener)

### DIFF
--- a/blueprints/cut/cut.svg
+++ b/blueprints/cut/cut.svg
@@ -1,0 +1,10 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Cut logo">
+  <rect width="64" height="64" rx="16" fill="#059669"/>
+  <g transform="translate(14 14) scale(1.5)" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="6" cy="6" r="3"/>
+    <path d="M8.12 8.12 12 12"/>
+    <path d="M20 4 8.12 15.88"/>
+    <circle cx="6" cy="18" r="3"/>
+    <path d="M14.8 14.8 20 20"/>
+  </g>
+</svg>

--- a/blueprints/cut/docker-compose.yml
+++ b/blueprints/cut/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  cut:
+    image: ghcr.io/mendylanda/cut:latest
+    restart: unless-stopped
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      # Injected by Dokploy from template.toml (generated strong password).
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      # Bundled Redis below, private to the project network.
+      - REDIS_URL=redis://redis:6379
+    # Expose the container port only; Dokploy maps the domain to it.
+    ports:
+      - 3000
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    # appendonly = durable across restarts; noeviction because this is Cut's
+    # primary datastore, not a cache (don't drop links under memory pressure).
+    command: redis-server --appendonly yes --maxmemory-policy noeviction
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  redis-data:

--- a/blueprints/cut/template.toml
+++ b/blueprints/cut/template.toml
@@ -1,0 +1,14 @@
+[variables]
+main_domain = "${domain}"
+admin_password = "${password:24}"
+
+[config]
+env = [
+  "ADMIN_PASSWORD=${admin_password}",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "cut"
+port = 3000
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -1681,6 +1681,22 @@
     ]
   },
   {
+    "id": "cut",
+    "name": "Cut",
+    "version": "0.1.0",
+    "description": "A tiny, self-hosted URL shortener — short links that are entirely yours, with per-link passwords, expiries, and click limits.",
+    "logo": "cut.svg",
+    "links": {
+      "github": "https://github.com/MendyLanda/cut",
+      "website": "https://github.com/MendyLanda/cut",
+      "docs": "https://github.com/MendyLanda/cut#readme"
+    },
+    "tags": [
+      "url-shortener",
+      "links"
+    ]
+  },
+  {
     "id": "cyberchef",
     "name": "CyberChef",
     "version": "latest",


### PR DESCRIPTION
## What is this PR about?

New PR of **Cut** — a small self-hosted URL shortener (owner-only admin behind a single password, with per-link passwords, expiries, and click limits).

The template runs the published image `ghcr.io/mendylanda/cut` with a private Redis for storage. `template.toml` generates the domain and a strong `ADMIN_PASSWORD`, then maps the `cut` service to port 3000. Redis runs with `noeviction` since it holds the actual links rather than cache data, so it shouldn't drop keys when memory fills up. Cut reads the request host at runtime, so nothing else needs configuring.

Added `blueprints/cut/` (`docker-compose.yml`, `template.toml`, `cut.svg`) plus the `meta.json` entry, sorted with `node dedupe-and-sort-meta.js`. Compose follows the requirements: `ports: - 3000` (no host mapping), matching `cut` service name, no `container_name`, no custom network.

## Checklist

- [x] I have read the suggestions in the README.md file
- [ ] I have tested the template in my instance (see note below)
- [ ] I have added tests (n/a for a template)

Note on testing: I verified the stack directly with Docker Compose — the image builds, the container serves `/` and `/admin` (both 200), and a `/api/keepalive` write lands in Redis. I don't have a separate Dokploy instance on hand, so I'm relying on this PR's automatic preview deploy to exercise the template itself. Happy to import the preview Base64 and confirm end-to-end if you'd like.

## Issues related (if applicable)

None.

## Screenshots or Videos

The app running from the same two-container stack (app + `redis:7-alpine`); the Dokploy preview deploy will show it inside Dokploy.