### PR TITLE
fix(vaultwarden): update outdated image version

### DIFF
--- a/blueprints/vaultwarden/docker-compose.yml
+++ b/blueprints/vaultwarden/docker-compose.yml
@@ -1,7 +1,7 @@
 # the webserver can take a while to start up, so don't be alarmed if it takes a few minutes to get a response
 services:
   vaultwarden:
-    image: vaultwarden/server:1.34.3
+    image: vaultwarden/server:1.36.0
     restart: always
     environment:
       DOMAIN: ${DOMAIN}

--- a/meta.json
+++ b/meta.json
@@ -6470,7 +6470,7 @@
   {
     "id": "vaultwarden",
     "name": "Vaultwarden",
-    "version": "1.34.3",
+    "version": "1.36.0",
     "description": "Unofficial Bitwarden compatible server written in Rust, formerly known as bitwarden_rs",
     "logo": "vaultwarden.svg",
     "links": {


### PR DESCRIPTION
## What is this PR about?

Update the Vaultwarden template from `vaultwarden/server:1.34.3` to `vaultwarden/server:1.36.0`.

The current template uses an outdated Vaultwarden version. During testing, deployments using `1.34.3` experienced issues with recent Bitwarden clients, including the browser extension and Android application. After upgrading to `1.36.0` and redeploying the template, authentication and synchronization worked correctly.

## Checklist

Before submitting this PR, please make sure that:

* [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
* [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
* [ ] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

N/A

## Screenshots or Videos

### Successful Deployment

<img width="1920" height="949" alt="dokploy2" src="https://github.com/user-attachments/assets/421c52f5-4c57-4481-852b-44ae04a9f3b9" />

<img width="1914" height="949" alt="dokploy1" src="https://github.com/user-attachments/assets/2439b524-502a-4ed6-a2d8-fb1695694bed" />

### Testing Performed

* Successfully deployed the updated template in Dokploy
* Verified web access through the configured domain
* Verified authentication using the Bitwarden browser extension
* Verified authentication using the Bitwarden Android application
* Verified vault synchronization between clients

### Changes

* Updated Vaultwarden image version from `1.34.3` to `1.36.0`
* Updated template metadata version accordingly