### PR TITLE
feat(blueprint): add LibreDB Studio

### DIFF
--- a/blueprints/libredb-studio/docker-compose.yml
+++ b/blueprints/libredb-studio/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   libredb-studio:
-    image: ghcr.io/libredb/libredb-studio:v0.9.27
+    image: ghcr.io/libredb/libredb-studio:0.9.27
     restart: unless-stopped
     environment:
       - ADMIN_EMAIL=admin@libredb.org

--- a/blueprints/libredb-studio/docker-compose.yml
+++ b/blueprints/libredb-studio/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   libredb-studio:
-    image: ghcr.io/libredb/libredb-studio:v0.9.13
+    image: ghcr.io/libredb/libredb-studio:v0.9.27
     restart: unless-stopped
     environment:
       - ADMIN_EMAIL=admin@libredb.org

--- a/blueprints/libredb-studio/docker-compose.yml
+++ b/blueprints/libredb-studio/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+  libredb-studio:
+    image: ghcr.io/libredb/libredb-studio:v0.9.13
+    restart: unless-stopped
+    environment:
+      - ADMIN_EMAIL=admin@libredb.org
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - USER_EMAIL=user@libredb.org
+      - USER_PASSWORD=${USER_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
+      - STORAGE_PROVIDER=sqlite
+      - STORAGE_SQLITE_PATH=/app/data/libredb-storage.db
+    volumes:
+      - libredb-data:/app/data
+volumes:
+  libredb-data:

--- a/blueprints/libredb-studio/libredb-studio.svg
+++ b/blueprints/libredb-studio/libredb-studio.svg
@@ -1,0 +1,32 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="logo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4F46E5" />
+      <stop offset="100%" stop-color="#9333EA" />
+    </linearGradient>
+    <linearGradient id="code-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#10B981" />
+      <stop offset="100%" stop-color="#3B82F6" />
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="3" result="blur" />
+      <feComposite in="SourceGraphic" in2="blur" operator="over" />
+    </filter>
+  </defs>
+  
+  <!-- Background Shape -->
+  <path d="M100 20L169.282 60V140L100 180L30.718 140V60L100 20Z" fill="url(#logo-gradient)" fill-opacity="0.05" stroke="url(#logo-gradient)" stroke-width="1.5"/>
+  
+  <!-- Database Layers (De-emphasized) -->
+  <g opacity="0.3">
+    <rect x="70" y="80" width="60" height="10" rx="2" fill="url(#logo-gradient)" />
+    <rect x="70" y="95" width="60" height="10" rx="2" fill="url(#logo-gradient)" />
+    <rect x="70" y="110" width="60" height="10" rx="2" fill="url(#logo-gradient)" />
+  </g>
+  
+  <!-- Coding Brackets (Emphasized) -->
+  <g filter="url(#glow)">
+    <path d="M55 70L35 100L55 130" stroke="url(#code-gradient)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M145 70L165 100L145 130" stroke="url(#code-gradient)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+</svg>

--- a/blueprints/libredb-studio/template.toml
+++ b/blueprints/libredb-studio/template.toml
@@ -16,6 +16,3 @@ USER_PASSWORD = "${user_password}"
 
 [[config.env]]
 JWT_SECRET = "${jwt_secret}"
-
-[[config.mounts]]
-filePath = "/app/data"

--- a/blueprints/libredb-studio/template.toml
+++ b/blueprints/libredb-studio/template.toml
@@ -1,0 +1,21 @@
+[variables]
+admin_password = "${password:32}"
+user_password = "${password:32}"
+jwt_secret = "${password:64}"
+
+[config]
+[[config.domains]]
+serviceName = "libredb-studio"
+port = 3000
+
+[[config.env]]
+ADMIN_PASSWORD = "${admin_password}"
+
+[[config.env]]
+USER_PASSWORD = "${user_password}"
+
+[[config.env]]
+JWT_SECRET = "${jwt_secret}"
+
+[[config.mounts]]
+filePath = "/app/data"

--- a/meta.json
+++ b/meta.json
@@ -1,18 +1,5 @@
 [
   {
-    "id": "libredb-studio",
-    "name": "LibreDB Studio",
-    "version": "v0.9.13",
-    "description": "The modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
-    "logo": "libredb-studio.svg",
-    "links": {
-      "github": "https://github.com/libredb/libredb-studio",
-      "website": "https://libredb.org/",
-      "docs": "https://libredb.org/"
-    },
-    "tags": ["database", "sql"]
-  },
-  {
     "id": "ackee",
     "name": "Ackee",
     "version": "latest",
@@ -3619,6 +3606,19 @@
       "BYOK",
       "generative-ai"
     ]
+  },
+  {
+    "id": "libredb-studio",
+    "name": "LibreDB Studio",
+    "version": "v0.9.13",
+    "description": "The modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
+    "logo": "libredb-studio.svg",
+    "links": {
+      "github": "https://github.com/libredb/libredb-studio",
+      "website": "https://libredb.org/",
+      "docs": "https://libredb.org/"
+    },
+    "tags": ["database", "sql"]
   },
   {
     "id": "libredesk",

--- a/meta.json
+++ b/meta.json
@@ -3618,7 +3618,7 @@
       "website": "https://libredb.org/",
       "docs": "https://libredb.org/"
     },
-   "tags": [
+    "tags": [
       "database",
       "sql"
     ]

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "libredb-studio",
+    "name": "LibreDB Studio",
+    "version": "v0.9.13",
+    "description": "The modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
+    "logo": "libredb-studio.svg",
+    "links": {
+      "github": "https://github.com/libredb/libredb-studio",
+      "website": "https://libredb.org/",
+      "docs": "https://libredb.org/"
+    },
+    "tags": ["database", "sql"]
+  },
+  {
     "id": "ackee",
     "name": "Ackee",
     "version": "latest",

--- a/meta.json
+++ b/meta.json
@@ -3610,7 +3610,7 @@
   {
     "id": "libredb-studio",
     "name": "LibreDB Studio",
-    "version": "v0.9.13",
+    "version": "v0.9.27",
     "description": "The modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
     "logo": "libredb-studio.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -3610,7 +3610,7 @@
   {
     "id": "libredb-studio",
     "name": "LibreDB Studio",
-    "version": "v0.9.27",
+    "version": "0.9.27",
     "description": "The modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
     "logo": "libredb-studio.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -3618,7 +3618,10 @@
       "website": "https://libredb.org/",
       "docs": "https://libredb.org/"
     },
-    "tags": ["database", "sql"]
+   "tags": [
+      "database",
+      "sql"
+    ]
   },
   {
     "id": "libredesk",


### PR DESCRIPTION
## What is this PR about?

New PR of **LibreDB Studio** — an MIT-licensed, AI-powered open-source SQL IDE (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis).

Files added:
- `blueprints/libredb-studio/docker-compose.yml`
- `blueprints/libredb-studio/template.toml`
- `meta.json` entry

Details:
- Single container via `ghcr.io/libredb/libredb-studio:0.9.27`
- SQLite storage with a persistent mount at `/app/data`
- Admin/user passwords and JWT secret auto-generated via template variables
- Exposes port `3000` on the primary domain
- No `container_name`, no custom network (per contribution guidelines)

Links:
- GitHub: https://github.com/libredb/libredb-studio
- Website: https://libredb.org/

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

N/A

## Screenshots or Videos

See the project README for screenshots: https://github.com/libredb/libredb-studio