### PR TITLE
feat: add Rallly template

### DIFF
--- a/blueprints/rallly/docker-compose.yml
+++ b/blueprints/rallly/docker-compose.yml
@@ -1,0 +1,66 @@
+version: "3.8"
+
+services:
+  rallly:
+    image: lukevella/rallly:4.11.1
+    restart: unless-stopped
+    depends_on:
+      - db
+      - minio
+      - minio-init
+    environment:
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL}
+      DATABASE_URL: ${DATABASE_URL}
+      SECRET_PASSWORD: ${SECRET_PASSWORD}
+      SUPPORT_EMAIL: ${SUPPORT_EMAIL}
+      NOREPLY_EMAIL: ${NOREPLY_EMAIL}
+      SMTP_HOST: ${SMTP_HOST}
+      SMTP_PORT: ${SMTP_PORT}
+      SMTP_USER: ${SMTP_USER}
+      SMTP_PWD: ${SMTP_PWD}
+      SMTP_SECURE: ${SMTP_SECURE}
+      S3_ENDPOINT: ${S3_ENDPOINT}
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME}
+      S3_REGION: ${S3_REGION}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
+      INITIAL_ADMIN_EMAIL: ${INITIAL_ADMIN_EMAIL}
+
+  db:
+    image: postgres:14-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: rallly
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - rallly-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d rallly"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY_ID}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY}
+    volumes:
+      - rallly-minio:/data
+
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    restart: "no"
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 ${S3_ACCESS_KEY_ID} ${S3_SECRET_ACCESS_KEY}; do sleep 2; done;
+      mc mb --ignore-existing local/rallly;
+      "
+
+volumes:
+  rallly-db:
+  rallly-minio:

--- a/blueprints/rallly/rallly.svg
+++ b/blueprints/rallly/rallly.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title">
+  <title>Rallly</title>
+  <rect width="256" height="256" rx="56" fill="#111827"/>
+  <circle cx="84" cy="98" r="28" fill="#f97316"/>
+  <circle cx="140" cy="98" r="28" fill="#22c55e"/>
+  <circle cx="112" cy="150" r="28" fill="#38bdf8"/>
+  <path d="M80 194h96" stroke="#ffffff" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/blueprints/rallly/template.toml
+++ b/blueprints/rallly/template.toml
@@ -1,0 +1,40 @@
+[variables]
+main_domain = "${domain}"
+support_email = "${email}"
+noreply_email = "${email}"
+initial_admin_email = "${email}"
+postgres_password = "${password:32}"
+secret_password = "${password:32}"
+s3_access_key_id = "rallly"
+s3_secret_access_key = "${password:32}"
+smtp_host = "smtp.example.com"
+smtp_port = "587"
+smtp_user = "change-me"
+smtp_password = "${password:32}"
+smtp_secure = "false"
+
+[config]
+env = [
+  "NEXT_PUBLIC_BASE_URL=https://${main_domain}",
+  "DATABASE_URL=postgres://postgres:${postgres_password}@db:5432/rallly",
+  "SECRET_PASSWORD=${secret_password}",
+  "SUPPORT_EMAIL=${support_email}",
+  "NOREPLY_EMAIL=${noreply_email}",
+  "SMTP_HOST=${smtp_host}",
+  "SMTP_PORT=${smtp_port}",
+  "SMTP_USER=${smtp_user}",
+  "SMTP_PWD=${smtp_password}",
+  "SMTP_SECURE=${smtp_secure}",
+  "S3_ENDPOINT=http://minio:9000",
+  "S3_BUCKET_NAME=rallly",
+  "S3_REGION=us-east-1",
+  "S3_ACCESS_KEY_ID=${s3_access_key_id}",
+  "S3_SECRET_ACCESS_KEY=${s3_secret_access_key}",
+  "INITIAL_ADMIN_EMAIL=${initial_admin_email}",
+  "POSTGRES_PASSWORD=${postgres_password}",
+]
+
+[[config.domains]]
+serviceName = "rallly"
+port = 3000
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -5448,6 +5448,23 @@
     ]
   },
   {
+    "id": "rallly",
+    "name": "Rallly",
+    "version": "4.11.1",
+    "description": "Rallly is an open-source scheduling and collaboration tool for organizing events and meetings.",
+    "logo": "rallly.svg",
+    "links": {
+      "website": "https://rallly.co/",
+      "docs": "https://support.rallly.co/self-hosting/introduction",
+      "github": "https://github.com/lukevella/rallly"
+    },
+    "tags": [
+      "scheduling",
+      "polls",
+      "collaboration"
+    ]
+  },
+  {
     "id": "reactive-resume",
     "name": "Reactive Resume",
     "version": "latest",


### PR DESCRIPTION
## What is this PR about?

Adds a Rallly template for Dokploy using the current self-hosted Rallly image and a Dokploy-friendly service layout.

This template includes:
- Rallly web app pinned to `lukevella/rallly:4.11.1`
- PostgreSQL database with persistent storage
- S3-compatible MinIO storage with a bucket initialization helper
- generated secrets for database, session secret, and object storage
- explicit SMTP variables because Rallly self-hosting requires transactional email for production use
- Dokploy domain routing directly to the Rallly service on port 3000

## Why this shape

The official Rallly self-hosted stack includes Traefik and host port bindings. For Dokploy, this PR intentionally removes the bundled proxy/host-port layer and lets Dokploy own routing through the template domain configuration.

/claim #152
Closes #121

## Validation

- `node dedupe-and-sort-meta.js`
- `npm run validate-template -- --dir ../blueprints/rallly`
- `npm run validate-docker-compose -- --file ../blueprints/rallly/docker-compose.yml`
- `git diff --check`

## Screenshots or Videos

Not applicable for this template-only change.
