### PR TITLE
feat: add Open Source POS template

### DIFF
--- a/blueprints/opensourcepos/docker-compose.yml
+++ b/blueprints/opensourcepos/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+
+services:
+  mysql:
+    image: mariadb:10.5
+    restart: unless-stopped
+    volumes:
+      - opensourceposMysqlData:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+
+  opensourcepos:
+    image: jekkos/opensourcepos:master
+    restart: unless-stopped
+    depends_on:
+      - mysql
+    volumes:
+      - opensourceposUploads:/app/public/uploads
+      - opensourceposLogs:/app/writable/logs
+    environment:
+      CI_ENVIRONMENT: production
+      ALLOWED_HOSTNAMES: ${ALLOWED_HOSTNAMES}
+      FORCE_HTTPS: ${FORCE_HTTPS}
+      PHP_TIMEZONE: ${PHP_TIMEZONE}
+      MYSQL_USERNAME: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DB_NAME: ${MYSQL_DATABASE}
+      MYSQL_HOST_NAME: mysql
+
+volumes:
+  opensourceposMysqlData:
+  opensourceposUploads:
+  opensourceposLogs:

--- a/blueprints/opensourcepos/opensourcepos.svg
+++ b/blueprints/opensourcepos/opensourcepos.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Open Source POS</title>
+  <desc id="desc">Open Source Point of Sale template logo</desc>
+  <rect width="256" height="256" rx="48" fill="#1d4ed8"/>
+  <path d="M58 78c0-12 10-22 22-22h96c12 0 22 10 22 22v72c0 12-10 22-22 22H80c-12 0-22-10-22-22V78z" fill="#eff6ff"/>
+  <path d="M82 88h92v24H82z" fill="#1d4ed8"/>
+  <circle cx="92" cy="140" r="9" fill="#1d4ed8"/>
+  <circle cx="128" cy="140" r="9" fill="#1d4ed8"/>
+  <circle cx="164" cy="140" r="9" fill="#1d4ed8"/>
+  <path d="M74 188h108c7 0 12 5 12 12v8H62v-8c0-7 5-12 12-12z" fill="#dbeafe"/>
+</svg>

--- a/blueprints/opensourcepos/template.toml
+++ b/blueprints/opensourcepos/template.toml
@@ -1,0 +1,19 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+env = [
+  "ALLOWED_HOSTNAMES=${main_domain}",
+  "FORCE_HTTPS=true",
+  "PHP_TIMEZONE=UTC",
+  "MYSQL_ROOT_PASSWORD=${password:32}",
+  "MYSQL_DATABASE=ospos",
+  "MYSQL_USER=ospos",
+  "MYSQL_PASSWORD=${password:32}",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "opensourcepos"
+port = 80
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -4762,6 +4762,24 @@
     ]
   },
   {
+    "id": "opensourcepos",
+    "name": "Open Source POS",
+    "version": "master",
+    "description": "Open Source Point of Sale is a PHP and MySQL-based web point-of-sale system for inventory, customers, sales, receipts, and reporting.",
+    "logo": "opensourcepos.svg",
+    "links": {
+      "github": "https://github.com/opensourcepos/opensourcepos",
+      "website": "https://opensourcepos.org/",
+      "docs": "https://github.com/opensourcepos/opensourcepos/blob/master/INSTALL.md"
+    },
+    "tags": [
+      "pos",
+      "retail",
+      "inventory",
+      "self-hosted"
+    ]
+  },
+  {
     "id": "openspeedtest",
     "name": "OpenSpeedTest",
     "version": "latest",


### PR DESCRIPTION
## Summary
/claim #152

Closes #860.

Adds an Open Source POS template adapted from the official Docker compose setup.

The template includes:

- Open Source POS app service
- MariaDB service
- generated database credentials instead of sample defaults
- persistent uploads, logs, and database volumes
- Dokploy domain routing on port 80
- `ALLOWED_HOSTNAMES` wired from the Dokploy domain, matching the app's production host-header security requirement
- `FORCE_HTTPS=true` for proxy/TLS-offload deployments behind Dokploy

## Validation
- `node dedupe-and-sort-meta.js`
- `npm.cmd run validate-template -- --dir ../blueprints/opensourcepos`
- `npm.cmd run validate-docker-compose -- --file ../blueprints/opensourcepos/docker-compose.yml`
- `git diff --check` passed with only normal CRLF line-ending warnings

Not run: full Docker runtime smoke test, because Docker is unavailable locally.