### PR TITLE
fix: keep Valkey internal

### DIFF
--- a/blueprints/valkey/docker-compose.yml
+++ b/blueprints/valkey/docker-compose.yml
@@ -4,8 +4,6 @@ services:
   valkey:
     image: valkey/valkey:8.1.4
     restart: unless-stopped
-    ports:
-      - 6379
     volumes:
       - ../files/valkey.conf:/etc/valkey/valkey.conf
       - valkey-data:/data


### PR DESCRIPTION
## Summary
Closes #684.

Removes the bare `ports:` mapping from the Valkey template so Dokploy does not publish Valkey externally on a random host port.

Valkey still listens on port 6379 inside the compose network, but it is no longer exposed to the host. That matches the expected isolated deployment behavior for an internal database/cache service.

## Validation
- `npm.cmd run validate-template -- --dir ../blueprints/valkey`
- `npm.cmd run validate-docker-compose -- --file ../blueprints/valkey/docker-compose.yml`
- `git diff --check`

The template validator warns that Valkey has no configured domains, which is expected for this non-web service.