### PR TITLE
fix: respect stopped Immich deployments

### DIFF
--- a/blueprints/immich/docker-compose.yml
+++ b/blueprints/immich/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       REDIS_DBINDEX: ${REDIS_DBINDEX}
       # Server Configuration
       TZ: ${TZ}
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:2283/server-info/ping"]
       interval: 30s
@@ -44,7 +44,7 @@ services:
       REDIS_HOSTNAME: ${REDIS_HOSTNAME}
       REDIS_PORT: ${REDIS_PORT}
       REDIS_DBINDEX: ${REDIS_DBINDEX}
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3003/ping"]
       interval: 30s
@@ -61,7 +61,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    restart: always
+    restart: unless-stopped
 
   immich-database:
     image: tensorchord/pgvecto-rs:pg14-v0.3.0
@@ -94,10 +94,10 @@ services:
         '-c',
         'wal_compression=on',
       ]
-    restart: always
+    restart: unless-stopped
 
 volumes:
   immich-model-cache:
   immich-postgres:
   immich-library:
-  immich-redis-data: 
+  immich-redis-data:


### PR DESCRIPTION
## Summary
Closes #792.

Changes the Immich template services from `restart: always` to `restart: unless-stopped`.

This keeps normal container recovery behavior, but respects a Dokploy/user stop action across host reboots. It should prevent Immich containers from coming back up after the app was stopped and autodeploy was disabled.

## Validation
- `npm.cmd run validate-template -- --dir ../blueprints/immich`
- `npm.cmd run validate-docker-compose -- --file ../blueprints/immich/docker-compose.yml`
- `git diff --check`