### PR TITLE
feat: add Firefly III template

### DIFF
--- a/blueprints/firefly-iii/README.md
+++ b/blueprints/firefly-iii/README.md
@@ -1,0 +1,13 @@
+# Firefly III
+
+Firefly III is a self-hosted personal finance manager for budgets, accounts, transactions, categories, and reports.
+
+This Dokploy template includes:
+
+- Firefly III core web application
+- MariaDB database with generated credentials
+- Persistent upload and database volumes
+- Daily cron runner using Firefly III's static cron token
+- Dokploy domain routing on the application service
+
+After deployment, open the generated domain and complete the first-user setup flow.

--- a/blueprints/firefly-iii/docker-compose.yml
+++ b/blueprints/firefly-iii/docker-compose.yml
@@ -1,0 +1,65 @@
+version: "3.8"
+
+services:
+  firefly-iii:
+    image: fireflyiii/core:version-6.6.3
+    restart: unless-stopped
+    depends_on:
+      firefly-iii-db:
+        condition: service_healthy
+    environment:
+      APP_KEY: ${APP_KEY}
+      APP_URL: ${APP_URL}
+      TRUSTED_PROXIES: "**"
+      TZ: ${TZ}
+      SITE_OWNER: ${SITE_OWNER}
+      DEFAULT_LANGUAGE: ${DEFAULT_LANGUAGE}
+      DEFAULT_LOCALE: ${DEFAULT_LOCALE}
+      DB_CONNECTION: mysql
+      DB_HOST: firefly-iii-db
+      DB_PORT: 3306
+      DB_DATABASE: ${DB_DATABASE}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      STATIC_CRON_TOKEN: ${STATIC_CRON_TOKEN}
+    expose:
+      - "8080"
+    volumes:
+      - firefly-iii-upload:/var/www/html/storage/upload
+
+  firefly-iii-db:
+    image: mariadb:11.8
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${DB_DATABASE}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+    volumes:
+      - firefly-iii-db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  firefly-iii-cron:
+    image: alpine:3.22
+    restart: unless-stopped
+    depends_on:
+      - firefly-iii
+    environment:
+      TZ: ${TZ}
+      STATIC_CRON_TOKEN: ${STATIC_CRON_TOKEN}
+    command:
+      - sh
+      - -c
+      - |
+        apk add --no-cache tzdata wget && \
+        (ln -snf /usr/share/zoneinfo/$$TZ /etc/localtime || true) && \
+        echo "0 3 * * * wget -qO- http://firefly-iii:8080/api/v1/cron/$$STATIC_CRON_TOKEN; echo" | crontab - && \
+        crond -f -L /dev/stdout
+
+volumes:
+  firefly-iii-upload: {}
+  firefly-iii-db: {}

--- a/blueprints/firefly-iii/logo.svg
+++ b/blueprints/firefly-iii/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Firefly III">
+  <defs>
+    <linearGradient id="g" x1="20" y1="16" x2="108" y2="112" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ffcf4a"/>
+      <stop offset="0.55" stop-color="#ff7a1a"/>
+      <stop offset="1" stop-color="#7936d8"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="#171923"/>
+  <circle cx="64" cy="66" r="38" fill="url(#g)" opacity="0.2"/>
+  <path d="M64 23c8 15 20 27 34 35-14 8-26 20-34 35-8-15-20-27-34-35 14-8 26-20 34-35Z" fill="url(#g)"/>
+  <circle cx="64" cy="58" r="13" fill="#fff4c7"/>
+  <path d="M46 93h36c-3 9-9 14-18 14s-15-5-18-14Z" fill="#ffcf4a"/>
+</svg>

--- a/blueprints/firefly-iii/template.toml
+++ b/blueprints/firefly-iii/template.toml
@@ -1,0 +1,36 @@
+[variables]
+main_domain = "${domain}"
+app_key = "${base64:32}"
+db_name = "firefly"
+db_user = "firefly"
+db_password = "${password:32}"
+cron_token = "${hash:32}"
+site_owner = "${email}"
+timezone = "UTC"
+default_language = "en_US"
+default_locale = "equal"
+
+[config]
+env = [
+  "APP_KEY=base64:${app_key}",
+  "APP_URL=https://${main_domain}",
+  "TRUSTED_PROXIES=**",
+  "TZ=${timezone}",
+  "SITE_OWNER=${site_owner}",
+  "DEFAULT_LANGUAGE=${default_language}",
+  "DEFAULT_LOCALE=${default_locale}",
+  "DB_DATABASE=${db_name}",
+  "DB_USERNAME=${db_user}",
+  "DB_PASSWORD=${db_password}",
+  "STATIC_CRON_TOKEN=${cron_token}",
+  "MYSQL_DATABASE=${db_name}",
+  "MYSQL_USER=${db_user}",
+  "MYSQL_PASSWORD=${db_password}",
+  "MYSQL_RANDOM_ROOT_PASSWORD=yes"
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "firefly-iii"
+port = 8080
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -2329,6 +2329,23 @@
     ]
   },
   {
+    "id": "firefly-iii",
+    "name": "Firefly III",
+    "version": "6.6.3",
+    "description": "Firefly III is a self-hosted personal finance manager for tracking expenses, budgets, accounts, and financial reports.",
+    "logo": "logo.svg",
+    "links": {
+      "github": "https://github.com/firefly-iii/firefly-iii",
+      "website": "https://www.firefly-iii.org/",
+      "docs": "https://docs.firefly-iii.org/"
+    },
+    "tags": [
+      "finance",
+      "budgeting",
+      "self-hosted"
+    ]
+  },
+  {
     "id": "fivem",
     "name": "FiveM Server",
     "version": "latest",


### PR DESCRIPTION
## What is this PR about?

/claim #152
Closes #873.

Adds a Firefly III template for Dokploy using the official Firefly III Docker layout adapted for Dokploy's template rules.

This template includes:

- Firefly III core service pinned to `fireflyiii/core:version-6.6.3`
- MariaDB 11.8 database with generated credentials
- Persistent upload and database volumes
- Daily cron runner using `STATIC_CRON_TOKEN`
- Dokploy domain routing on the Firefly III app service
- Template metadata, README, and SVG logo

## Validation

- `node dedupe-and-sort-meta.js` passed
- `npm.cmd run validate-template -- --dir ../blueprints/firefly-iii` passed
- `npm.cmd run validate-docker-compose -- --file ../blueprints/firefly-iii/docker-compose.yml` passed
- `git diff --check` passed with only normal Windows CRLF warnings

Docker runtime validation was not possible in this environment because Docker is not installed here.