### PR TITLE
feat: add Paperclip template

### DIFF
--- a/blueprints/paperclip/README.md
+++ b/blueprints/paperclip/README.md
@@ -1,0 +1,15 @@
+# Paperclip
+
+Paperclip is an open-source control plane for managing teams of AI agents, goals, budgets, tickets, and recurring work.
+
+This Dokploy template includes:
+
+- Paperclip web/API service using the official GHCR image
+- PostgreSQL 17 database with health check
+- Generated `BETTER_AUTH_SECRET`
+- Generated database password
+- Persistent `/paperclip` storage for instance data
+- Public URL configured from the Dokploy domain
+- Dokploy domain routing to Paperclip on port 3100
+
+After deployment, check the Paperclip container logs for first-run setup or invite information.

--- a/blueprints/paperclip/docker-compose.yml
+++ b/blueprints/paperclip/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: paperclip
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: paperclip
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U paperclip -d paperclip"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  paperclip:
+    image: ghcr.io/paperclipai/paperclip:latest
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      HOST: 0.0.0.0
+      PORT: "3100"
+      SERVE_UI: "true"
+      DATABASE_URL: ${DATABASE_URL}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
+      PAPERCLIP_HOME: /paperclip
+      PAPERCLIP_INSTANCE_ID: default
+      PAPERCLIP_CONFIG: /paperclip/instances/default/config.json
+      PAPERCLIP_DEPLOYMENT_MODE: ${PAPERCLIP_DEPLOYMENT_MODE}
+      PAPERCLIP_DEPLOYMENT_EXPOSURE: ${PAPERCLIP_DEPLOYMENT_EXPOSURE}
+      PAPERCLIP_PUBLIC_URL: ${PAPERCLIP_PUBLIC_URL}
+    expose:
+      - "3100"
+    volumes:
+      - paperclip-data:/paperclip
+
+volumes:
+  postgres-data: {}
+  paperclip-data: {}

--- a/blueprints/paperclip/logo.svg
+++ b/blueprints/paperclip/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Paperclip logo">
+  <rect width="128" height="128" rx="28" fill="#111827"/>
+  <path d="M43 70.5 76.5 37c10.4-10.4 27.3-3 27.3 11.8 0 4.4-1.8 8.7-4.9 11.8L58.4 101.1c-13 13-34.2 3.8-34.2-14.6 0-5.5 2.2-10.7 6.1-14.6l43.9-43.9" fill="none" stroke="#f8fafc" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M46.6 78.8 83.3 42.1c4.8-4.8 12.9-1.4 12.9 5.4 0 2-.8 4-2.2 5.4L55.2 91.7c-6.3 6.3-17.2 1.9-17.2-7 0-2.6 1-5.1 2.9-7l36.4-36.4" fill="none" stroke="#38bdf8" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/blueprints/paperclip/template.toml
+++ b/blueprints/paperclip/template.toml
@@ -1,0 +1,20 @@
+[variables]
+main_domain = "${domain}"
+postgres_password = "${password:32}"
+better_auth_secret = "${password:64}"
+
+[config]
+env = [
+  "POSTGRES_PASSWORD=${postgres_password}",
+  "DATABASE_URL=postgres://paperclip:${postgres_password}@postgres:5432/paperclip",
+  "BETTER_AUTH_SECRET=${better_auth_secret}",
+  "PAPERCLIP_DEPLOYMENT_MODE=authenticated",
+  "PAPERCLIP_DEPLOYMENT_EXPOSURE=private",
+  "PAPERCLIP_PUBLIC_URL=https://${main_domain}"
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "paperclip"
+port = 3100
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -165,7 +165,7 @@
     "id": "alist",
     "name": "AList",
     "version": "v3.55.0",
-    "description": "🗂️A file list/WebDAV program that supports multiple storages, powered by Gin and Solidjs.",
+    "description": "ðŸ—‚ï¸A file list/WebDAV program that supports multiple storages, powered by Gin and Solidjs.",
     "logo": "alist.svg",
     "links": {
       "github": "https://github.com/AlistGo/alist",
@@ -299,7 +299,7 @@
     "id": "anytype",
     "name": "Anytype",
     "version": "latest",
-    "description": "Anytype is a personal knowledge base—your digital brain—that lets you gather, connect and remix all kinds of information. Create pages, tasks, wikis, journals—even entire apps—and define your own data model while your data stays offline-first, private and encrypted across devices.\n\nAfter installation, you can view the Anytype client configuration by running `cat /data/client-config.yml` inside the service container.",
+    "description": "Anytype is a personal knowledge baseâ€”your digital brainâ€”that lets you gather, connect and remix all kinds of information. Create pages, tasks, wikis, journalsâ€”even entire appsâ€”and define your own data model while your data stays offline-first, private and encrypted across devices.\n\nAfter installation, you can view the Anytype client configuration by running `cat /data/client-config.yml` inside the service container.",
     "logo": "logo.png",
     "links": {
       "github": "https://github.com/grishy/any-sync-bundle",
@@ -511,7 +511,7 @@
     "id": "autobase",
     "name": "Autobase",
     "version": "2.5.2",
-    "description": "Autobase for PostgreSQL® is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
+    "description": "Autobase for PostgreSQLÂ® is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
     "links": {
       "github": "https://github.com/vitabaks/autobase",
       "website": "https://autobase.tech/",
@@ -721,7 +721,7 @@
     "id": "blender",
     "name": "Blender",
     "version": "latest",
-    "description": "Blender is a free and open-source 3D creation suite. It supports the entire 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing and motion tracking, video editing and 2D animation pipeline.",
+    "description": "Blender is a free and open-source 3D creation suite. It supports the entire 3D pipelineâ€”modeling, rigging, animation, simulation, rendering, compositing and motion tracking, video editing and 2D animation pipeline.",
     "logo": "blender.svg",
     "links": {
       "github": "https://github.com/linuxserver/docker-blender",
@@ -3085,7 +3085,7 @@
     "id": "huly",
     "name": "Huly",
     "version": "0.6.377",
-    "description": "Huly — All-in-One Project Management Platform (alternative to Linear, Jira, Slack, Notion, Motion)",
+    "description": "Huly â€” All-in-One Project Management Platform (alternative to Linear, Jira, Slack, Notion, Motion)",
     "logo": "huly.svg",
     "links": {
       "github": "https://github.com/hcengineering/huly-selfhost",
@@ -3591,7 +3591,7 @@
     "id": "librechat",
     "name": "LibreChat",
     "version": "latest",
-    "description": "LibreChat is the ultimate open-source app for all your AI conversations, fully customizable and compatible with any AI provider (Openai, Ollama, Google etc.) — all in one sleek interface.",
+    "description": "LibreChat is the ultimate open-source app for all your AI conversations, fully customizable and compatible with any AI provider (Openai, Ollama, Google etc.) â€” all in one sleek interface.",
     "logo": "librechat.png",
     "links": {
       "github": "https://github.com/danny-avila/librechat",
@@ -4853,6 +4853,24 @@
     ]
   },
   {
+    "id": "paperclip",
+    "name": "Paperclip",
+    "version": "latest",
+    "description": "Paperclip is an open-source control plane for managing teams of AI agents, goals, budgets, tickets, and recurring work.",
+    "logo": "logo.svg",
+    "links": {
+      "github": "https://github.com/paperclipai/paperclip",
+      "website": "https://paperclip.ing/",
+      "docs": "https://docs.paperclip.ing/"
+    },
+    "tags": [
+      "ai",
+      "agents",
+      "automation",
+      "self-hosted"
+    ]
+  },
+  {
     "id": "parseable",
     "name": "Parseable",
     "version": "v1.6.5",
@@ -5000,7 +5018,7 @@
     "id": "photoprism",
     "name": "Photoprism",
     "version": "latest",
-    "description": "PhotoPrism® is an AI-Powered Photos App for the Decentralized Web. It makes use of the latest technologies to tag and find pictures automatically without getting in your way.",
+    "description": "PhotoPrismÂ® is an AI-Powered Photos App for the Decentralized Web. It makes use of the latest technologies to tag and find pictures automatically without getting in your way.",
     "logo": "photoprism.svg",
     "links": {
       "github": "https://github.com/photoprism/photoprism",
@@ -6031,7 +6049,7 @@
     "id": "surrealdb",
     "name": "SurrealDB",
     "version": "2.3.10",
-    "description": "SurrealDB is a native, open-source, multi-model database that lets you store and manage data across relational, document, graph, time-series, vector & search, and geospatial models—all in one place.",
+    "description": "SurrealDB is a native, open-source, multi-model database that lets you store and manage data across relational, document, graph, time-series, vector & search, and geospatial modelsâ€”all in one place.",
     "logo": "surrealdb.svg",
     "links": {
       "github": "https://github.com/surrealdb/surrealdb",
@@ -6303,7 +6321,7 @@
     "id": "typecho",
     "name": "Typecho",
     "version": "stable",
-    "description": "Typecho 是一个轻量级的开源博客程序，基于 PHP 开发，支持多种数据库，简洁而强大。",
+    "description": "Typecho æ˜¯ä¸€ä¸ªè½»é‡çº§çš„å¼€æºåšå®¢ç¨‹åºï¼ŒåŸºäºŽ PHP å¼€å‘ï¼Œæ”¯æŒå¤šç§æ•°æ®åº“ï¼Œç®€æ´è€Œå¼ºå¤§ã€‚",
     "logo": "typecho.png",
     "links": {
       "github": "https://github.com/typecho/typecho",


### PR DESCRIPTION
/claim #152

Closes #813

## Summary
- add a Paperclip Dokploy template using the current `paperclipai/paperclip` project
- include Paperclip service, PostgreSQL 17, generated database password, generated `BETTER_AUTH_SECRET`, persistent `/paperclip` storage, and Dokploy domain routing on port 3100
- document first-run setup notes and source links

## Validation
- `node dedupe-and-sort-meta.js`
- `npm.cmd run validate-template -- --dir ../blueprints/paperclip`
- `npm.cmd run validate-docker-compose -- --file ../blueprints/paperclip/docker-compose.yml`
- `git diff --check`
- checked Paperclip files for bidi/control Unicode characters

Docker runtime validation was not run because Docker is not installed in this environment.
