### PR TITLE
feat: add Jitsi Meet template

### DIFF
--- a/blueprints/jitsi/docker-compose.yml
+++ b/blueprints/jitsi/docker-compose.yml
@@ -1,0 +1,105 @@
+services:
+  web:
+    image: jitsi/web:${JITSI_IMAGE_VERSION:-unstable}
+    restart: unless-stopped
+    depends_on:
+      - prosody
+    volumes:
+      - jitsiWebConfig:/config
+      - jitsiWebTranscripts:/usr/share/jitsi-meet/transcripts
+    environment:
+      - PUBLIC_URL
+      - TZ
+      - XMPP_DOMAIN
+      - XMPP_AUTH_DOMAIN
+      - XMPP_BOSH_URL_BASE
+      - XMPP_MUC_DOMAIN
+      - XMPP_GUEST_DOMAIN
+      - XMPP_RECORDER_DOMAIN
+      - ENABLE_AUTH
+      - ENABLE_GUESTS
+      - ENABLE_LETSENCRYPT
+      - ENABLE_HTTP_REDIRECT
+      - ENABLE_XMPP_WEBSOCKET
+      - ENABLE_COLIBRI_WEBSOCKET
+      - DISABLE_HTTPS
+      - JICOFO_AUTH_USER
+      - JVB_AUTH_USER
+      - JICOFO_AUTH_PASSWORD
+      - JVB_AUTH_PASSWORD
+
+  prosody:
+    image: jitsi/prosody:${JITSI_IMAGE_VERSION:-unstable}
+    restart: unless-stopped
+    volumes:
+      - jitsiProsodyConfig:/config
+      - jitsiProsodyPlugins:/prosody-plugins-custom
+    environment:
+      - TZ
+      - XMPP_DOMAIN
+      - XMPP_AUTH_DOMAIN
+      - XMPP_MUC_DOMAIN
+      - XMPP_GUEST_DOMAIN
+      - XMPP_RECORDER_DOMAIN
+      - JICOFO_AUTH_USER
+      - JVB_AUTH_USER
+      - JICOFO_AUTH_PASSWORD
+      - JVB_AUTH_PASSWORD
+      - JICOFO_COMPONENT_SECRET
+      - JWT_APP_ID
+      - JWT_APP_SECRET
+      - ENABLE_AUTH
+      - ENABLE_GUESTS
+
+  jicofo:
+    image: jitsi/jicofo:${JITSI_IMAGE_VERSION:-unstable}
+    restart: unless-stopped
+    depends_on:
+      - prosody
+    volumes:
+      - jitsiJicofoConfig:/config
+    environment:
+      - TZ
+      - XMPP_DOMAIN
+      - XMPP_AUTH_DOMAIN
+      - XMPP_MUC_DOMAIN
+      - XMPP_INTERNAL_MUC_DOMAIN
+      - JICOFO_AUTH_USER
+      - JICOFO_AUTH_PASSWORD
+      - JICOFO_COMPONENT_SECRET
+      - JVB_BREWERY_MUC
+
+  jvb:
+    image: jitsi/jvb:${JITSI_IMAGE_VERSION:-unstable}
+    restart: unless-stopped
+    depends_on:
+      - prosody
+    ports:
+      - 10000
+    volumes:
+      - jitsiJvbConfig:/config
+    environment:
+      - TZ
+      - XMPP_AUTH_DOMAIN
+      - XMPP_INTERNAL_MUC_DOMAIN
+      - JVB_AUTH_USER
+      - JVB_AUTH_PASSWORD
+      - JVB_BREWERY_MUC
+      - JVB_PORT
+      - JVB_ADVERTISE_IPS
+      - PUBLIC_URL
+
+volumes:
+  jitsiWebConfig:
+    driver: local
+  jitsiWebTranscripts:
+    driver: local
+  jitsiProsodyConfig:
+    driver: local
+  jitsiProsodyPlugins:
+    driver: local
+  jitsiJicofoConfig:
+    driver: local
+  jitsiJvbConfig:
+    driver: local
+

--- a/blueprints/jitsi/jitsi.svg
+++ b/blueprints/jitsi/jitsi.svg
@@ -1,0 +1,1 @@
+﻿<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#1d74f5"/><circle cx="32" cy="32" r="20" fill="white"/><path d="M22 32h20M32 22v20" stroke="#1d74f5" stroke-width="6" stroke-linecap="round"/></svg>

--- a/blueprints/jitsi/template.toml
+++ b/blueprints/jitsi/template.toml
@@ -1,0 +1,43 @@
+[variables]
+main_domain = "${domain}"
+jitsi_image_version = "unstable"
+jicofo_auth_password = "${password:32}"
+jvb_auth_password = "${password:32}"
+jicofo_component_secret = "${password:32}"
+
+[config]
+mounts = []
+
+[[config.domains]]
+serviceName = "web"
+port = 8_000
+host = "${main_domain}"
+
+[config.env]
+PUBLIC_URL = "https://${main_domain}"
+TZ = "UTC"
+JITSI_IMAGE_VERSION = "${jitsi_image_version}"
+XMPP_DOMAIN = "meet.jitsi"
+XMPP_AUTH_DOMAIN = "auth.meet.jitsi"
+XMPP_BOSH_URL_BASE = "http://prosody:5280"
+XMPP_MUC_DOMAIN = "muc.meet.jitsi"
+XMPP_INTERNAL_MUC_DOMAIN = "internal-muc.meet.jitsi"
+XMPP_GUEST_DOMAIN = "guest.meet.jitsi"
+XMPP_RECORDER_DOMAIN = "recorder.meet.jitsi"
+ENABLE_AUTH = "0"
+ENABLE_GUESTS = "1"
+ENABLE_LETSENCRYPT = "0"
+ENABLE_HTTP_REDIRECT = "0"
+ENABLE_XMPP_WEBSOCKET = "1"
+ENABLE_COLIBRI_WEBSOCKET = "1"
+DISABLE_HTTPS = "1"
+JICOFO_AUTH_USER = "focus"
+JVB_AUTH_USER = "jvb"
+JICOFO_AUTH_PASSWORD = "${jicofo_auth_password}"
+JVB_AUTH_PASSWORD = "${jvb_auth_password}"
+JICOFO_COMPONENT_SECRET = "${jicofo_component_secret}"
+JVB_BREWERY_MUC = "jvbbrewery"
+JVB_PORT = "10000"
+JVB_ADVERTISE_IPS = ""
+JWT_APP_ID = ""
+JWT_APP_SECRET = ""


### PR DESCRIPTION
/claim #152
Closes #916

## Summary
- Add a Jitsi Meet template for self-hosted video meetings.
- Wire the Jitsi web, Prosody, Jicofo, and JVB services with Dokploy domain routing.
- Add generated auth/component secrets, persistent config/transcript volumes, metadata, and logo.

## Validation
- `node dedupe-and-sort-meta.js`
- `npm --prefix build-scripts run validate-template -- --dir ../blueprints/jitsi`
- `npm --prefix build-scripts run validate-docker-compose -- --file ../blueprints/jitsi/docker-compose.yml`
- `git diff --check`

## Notes
- Based on the official docker-jitsi-meet compose structure and Docker deployment guide.
- JVB exposes port `10000` using the template validator-compatible port format.
Not run: full Docker runtime smoke test, because Docker is unavailable locally.
