### PR TITLE
feat: add PrivateBin template

### DIFF
--- a/blueprints/privatebin/docker-compose.yml
+++ b/blueprints/privatebin/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   privatebin:
-    image: privatebin/nginx-fpm-alpine:latest
+    image: privatebin/nginx-fpm-alpine:2.0.4
     restart: unless-stopped
     volumes:
       - privatebin_data:/srv/data

--- a/blueprints/privatebin/docker-compose.yml
+++ b/blueprints/privatebin/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  privatebin:
+    image: privatebin/nginx-fpm-alpine:latest
+    restart: unless-stopped
+    volumes:
+      - privatebin_data:/srv/data
+    ports:
+      - "8080"
+
+volumes:
+  privatebin_data:

--- a/blueprints/privatebin/privatebin.svg
+++ b/blueprints/privatebin/privatebin.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#101828"/>
+  <circle cx="64" cy="64" r="34" fill="#38bdf8" opacity="0.92"/>
+  <text x="64" y="74" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="#ffffff">P</text>
+</svg>

--- a/blueprints/privatebin/template.toml
+++ b/blueprints/privatebin/template.toml
@@ -1,0 +1,11 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+env = {}
+mounts = []
+
+[[config.domains]]
+serviceName = "privatebin"
+port = 8080
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -5293,7 +5293,7 @@
   {
     "id": "privatebin",
     "name": "PrivateBin",
-    "version": "latest",
+    "version": "2.0.4",
     "description": "PrivateBin is a minimalist, open-source online pastebin where the server has zero knowledge of pasted data.",
     "logo": "privatebin.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -5291,6 +5291,23 @@
     "dokploy_version": "<0.22.5"
   },
   {
+    "id": "privatebin",
+    "name": "PrivateBin",
+    "version": "latest",
+    "description": "PrivateBin is a minimalist, open-source online pastebin where the server has zero knowledge of pasted data.",
+    "logo": "privatebin.svg",
+    "links": {
+      "github": "https://github.com/PrivateBin/PrivateBin",
+      "website": "https://privatebin.info/",
+      "docs": "https://github.com/PrivateBin/docker-nginx-fpm-alpine"
+    },
+    "tags": [
+      "pastebin",
+      "privacy",
+      "self-hosted"
+    ]
+  },
+  {
     "id": "prometheus",
     "name": "Prometheus",
     "version": "latest",


### PR DESCRIPTION
/claim #152

## What is this PR about?

This PR adds a new PrivateBin Dokploy template. Adds a PrivateBin one-click template using the nginx-fpm Alpine image, persistent paste data storage, and Dokploy domain routing on port 8080.

## Validation

- Ran `node dedupe-and-sort-meta.js`
- Ran `npm --prefix build-scripts run validate-template -- --dir ../blueprints/privatebin`
- Ran `npm --prefix build-scripts run validate-docker-compose -- --file ../blueprints/privatebin/docker-compose.yml`
- Ran `git diff --check`

Not run: full Docker runtime smoke test, because Docker is unavailable locally.

## Notes

I kept this as a focused single-template PR so it stays easy to review. Maintainer edits are enabled.