### PR TITLE
feat: add Joplin Server template

### DIFF
--- a/blueprints/joplin-server/docker-compose.yml
+++ b/blueprints/joplin-server/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - joplin_db_data:/var/lib/postgresql/data
 
   joplin-server:
-    image: joplin/server:latest
+    image: joplin/server:3.7.1
     restart: unless-stopped
     depends_on:
       - joplin-db

--- a/blueprints/joplin-server/docker-compose.yml
+++ b/blueprints/joplin-server/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  joplin-db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_DB: ${POSTGRES_DATABASE}
+    volumes:
+      - joplin_db_data:/var/lib/postgresql/data
+
+  joplin-server:
+    image: joplin/server:latest
+    restart: unless-stopped
+    depends_on:
+      - joplin-db
+    environment:
+      APP_BASE_URL: ${APP_BASE_URL}
+      APP_PORT: ${APP_PORT}
+      DB_CLIENT: pg
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DATABASE: ${POSTGRES_DATABASE}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PORT: 5432
+      POSTGRES_HOST: joplin-db
+    ports:
+      - "22300"
+
+volumes:
+  joplin_db_data:

--- a/blueprints/joplin-server/joplin-server.svg
+++ b/blueprints/joplin-server/joplin-server.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#101828"/>
+  <circle cx="64" cy="64" r="34" fill="#38bdf8" opacity="0.92"/>
+  <text x="64" y="74" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="#ffffff">J</text>
+</svg>

--- a/blueprints/joplin-server/template.toml
+++ b/blueprints/joplin-server/template.toml
@@ -1,0 +1,18 @@
+[variables]
+main_domain = "${domain}"
+postgres_password = "${password:32}"
+
+[config]
+mounts = []
+
+[[config.domains]]
+serviceName = "joplin-server"
+port = 22300
+host = "${main_domain}"
+
+[config.env]
+APP_BASE_URL = "https://${main_domain}"
+APP_PORT = "22300"
+POSTGRES_PASSWORD = "${postgres_password}"
+POSTGRES_USER = "joplin"
+POSTGRES_DATABASE = "joplin"

--- a/blueprints/joplin-server/template.toml
+++ b/blueprints/joplin-server/template.toml
@@ -11,7 +11,7 @@ port = 22300
 host = "${main_domain}"
 
 [config.env]
-APP_BASE_URL = "https://${main_domain}"
+APP_BASE_URL = "http://${main_domain}"
 APP_PORT = "22300"
 POSTGRES_PASSWORD = "${postgres_password}"
 POSTGRES_USER = "joplin"

--- a/meta.json
+++ b/meta.json
@@ -3350,7 +3350,7 @@
   {
     "id": "joplin-server",
     "name": "Joplin Server",
-    "version": "latest",
+    "version": "3.7.1",
     "description": "Joplin Server is the self-hosted sync backend for Joplin notes, notebooks, and attachments.",
     "logo": "joplin-server.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -3348,6 +3348,23 @@
     ]
   },
   {
+    "id": "joplin-server",
+    "name": "Joplin Server",
+    "version": "latest",
+    "description": "Joplin Server is the self-hosted sync backend for Joplin notes, notebooks, and attachments.",
+    "logo": "joplin-server.svg",
+    "links": {
+      "github": "https://github.com/laurent22/joplin",
+      "website": "https://joplinapp.org/",
+      "docs": "https://github.com/laurent22/joplin/tree/dev/packages/server"
+    },
+    "tags": [
+      "notes",
+      "sync",
+      "productivity"
+    ]
+  },
+  {
     "id": "kaneo",
     "name": "Kaneo",
     "version": "latest",


### PR DESCRIPTION
/claim #152

## What is this PR about?

This PR adds a new Joplin Server Dokploy template. Adds a Joplin Server template with PostgreSQL, generated database password, APP_BASE_URL wired to the Dokploy domain, and routing on port 22300.

## Validation

- Ran `node dedupe-and-sort-meta.js`
- Ran `npm --prefix build-scripts run validate-template -- --dir ../blueprints/joplin-server`
- Ran `npm --prefix build-scripts run validate-docker-compose -- --file ../blueprints/joplin-server/docker-compose.yml`
- Ran `git diff --check`

Not run: full Docker runtime smoke test, because Docker is unavailable locally.

## Notes

I kept this as a focused single-template PR so it stays easy to review. Maintainer edits are enabled.