### PR TITLE
feat: add Dockge template

### DIFF
--- a/blueprints/dockge/docker-compose.yml
+++ b/blueprints/dockge/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  dockge:
+    image: louislam/dockge:1
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - dockge_data:/app/data
+      - dockge_stacks:/opt/stacks
+    environment:
+      DOCKGE_STACKS_DIR: /opt/stacks
+    ports:
+      - "5001"
+
+volumes:
+  dockge_data:
+  dockge_stacks:

--- a/blueprints/dockge/dockge.svg
+++ b/blueprints/dockge/dockge.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#101828"/>
+  <circle cx="64" cy="64" r="34" fill="#38bdf8" opacity="0.92"/>
+  <text x="64" y="74" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="#ffffff">D</text>
+</svg>

--- a/blueprints/dockge/template.toml
+++ b/blueprints/dockge/template.toml
@@ -1,0 +1,11 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+env = {}
+mounts = []
+
+[[config.domains]]
+serviceName = "dockge"
+port = 5001
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -1800,6 +1800,23 @@
     ]
   },
   {
+    "id": "dockge",
+    "name": "Dockge",
+    "version": "1",
+    "description": "Dockge is a reactive, self-hosted Docker Compose stack manager from the creator of Uptime Kuma.",
+    "logo": "dockge.svg",
+    "links": {
+      "github": "https://github.com/louislam/dockge",
+      "website": "https://dockge.kuma.pet/",
+      "docs": "https://github.com/louislam/dockge"
+    },
+    "tags": [
+      "docker",
+      "compose",
+      "management"
+    ]
+  },
+  {
     "id": "docling-serve",
     "name": "Docling Serve",
     "version": "latest",


### PR DESCRIPTION
/claim #152

## What is this PR about?

This PR adds a new Dockge Dokploy template. Adds a Dockge template for managing Docker Compose stacks with persistent Dockge data and stacks storage, routed through Dokploy on port 5001.

## Validation

- Ran `node dedupe-and-sort-meta.js`
- Ran `npm --prefix build-scripts run validate-template -- --dir ../blueprints/dockge`
- Ran `npm --prefix build-scripts run validate-docker-compose -- --file ../blueprints/dockge/docker-compose.yml`
- Ran `git diff --check`

Not run: full Docker runtime smoke test, because Docker is unavailable locally.

## Notes

I kept this as a focused single-template PR so it stays easy to review. Maintainer edits are enabled.