### PR TITLE
feat: add Jellyseerr template

### DIFF
--- a/blueprints/jellyseerr/docker-compose.yml
+++ b/blueprints/jellyseerr/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   jellyseerr:
-    image: fallenbagel/jellyseerr:latest
+    image: fallenbagel/jellyseerr:2.7.3
     restart: unless-stopped
     volumes:
       - jellyseerr_config:/app/config

--- a/blueprints/jellyseerr/docker-compose.yml
+++ b/blueprints/jellyseerr/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  jellyseerr:
+    image: fallenbagel/jellyseerr:latest
+    restart: unless-stopped
+    volumes:
+      - jellyseerr_config:/app/config
+    environment:
+      LOG_LEVEL: info
+    ports:
+      - "5055"
+
+volumes:
+  jellyseerr_config:

--- a/blueprints/jellyseerr/jellyseerr.svg
+++ b/blueprints/jellyseerr/jellyseerr.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#101828"/>
+  <circle cx="64" cy="64" r="34" fill="#38bdf8" opacity="0.92"/>
+  <text x="64" y="74" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="#ffffff">J</text>
+</svg>

--- a/blueprints/jellyseerr/template.toml
+++ b/blueprints/jellyseerr/template.toml
@@ -1,0 +1,11 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+env = {}
+mounts = []
+
+[[config.domains]]
+serviceName = "jellyseerr"
+port = 5055
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -3331,7 +3331,7 @@
   {
     "id": "jellyseerr",
     "name": "Jellyseerr",
-    "version": "latest",
+    "version": "2.7.3",
     "description": "Jellyseerr is a media request and discovery manager for Jellyfin, Plex, and Emby users.",
     "logo": "jellyseerr.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -3329,6 +3329,23 @@
     ]
   },
   {
+    "id": "jellyseerr",
+    "name": "Jellyseerr",
+    "version": "latest",
+    "description": "Jellyseerr is a media request and discovery manager for Jellyfin, Plex, and Emby users.",
+    "logo": "jellyseerr.svg",
+    "links": {
+      "github": "https://github.com/Fallenbagel/jellyseerr",
+      "website": "https://docs.jellyseerr.dev/",
+      "docs": "https://docs.jellyseerr.dev/"
+    },
+    "tags": [
+      "media",
+      "requests",
+      "jellyfin"
+    ]
+  },
+  {
     "id": "jenkins",
     "name": "jenkins",
     "version": "latest",


### PR DESCRIPTION
/claim #152

## What is this PR about?

This PR adds a new Jellyseerr Dokploy template. Adds a Jellyseerr template with persistent config storage and Dokploy domain routing on port 5055.

## Validation

- Ran `node dedupe-and-sort-meta.js`
- Ran `npm --prefix build-scripts run validate-template -- --dir ../blueprints/jellyseerr`
- Ran `npm --prefix build-scripts run validate-docker-compose -- --file ../blueprints/jellyseerr/docker-compose.yml`
- Ran `git diff --check`

Not run: full Docker runtime smoke test, because Docker is unavailable locally.

## Notes

I kept this as a focused single-template PR so it stays easy to review. Maintainer edits are enabled.