### PR TITLE
feat: add SFTPGo template

### DIFF
--- a/blueprints/sftpgo/docker-compose.yml
+++ b/blueprints/sftpgo/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - sftpgo_home:/var/lib/sftpgo
     ports:
       - "8080"
-      - "2022:2022"
+      - "2022"
 
 volumes:
   sftpgo_data:

--- a/blueprints/sftpgo/docker-compose.yml
+++ b/blueprints/sftpgo/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  sftpgo:
+    image: drakkan/sftpgo:latest
+    restart: unless-stopped
+    volumes:
+      - sftpgo_data:/srv/sftpgo
+      - sftpgo_home:/var/lib/sftpgo
+    ports:
+      - "8080"
+      - "2022:2022"
+
+volumes:
+  sftpgo_data:
+  sftpgo_home:

--- a/blueprints/sftpgo/docker-compose.yml
+++ b/blueprints/sftpgo/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sftpgo:
-    image: drakkan/sftpgo:latest
+    image: drakkan/sftpgo:v2.7.3
     restart: unless-stopped
     volumes:
       - sftpgo_data:/srv/sftpgo

--- a/blueprints/sftpgo/sftpgo.svg
+++ b/blueprints/sftpgo/sftpgo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#101828"/>
+  <circle cx="64" cy="64" r="34" fill="#38bdf8" opacity="0.92"/>
+  <text x="64" y="74" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="#ffffff">S</text>
+</svg>

--- a/blueprints/sftpgo/template.toml
+++ b/blueprints/sftpgo/template.toml
@@ -1,0 +1,11 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+env = {}
+mounts = []
+
+[[config.domains]]
+serviceName = "sftpgo"
+port = 8080
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -5744,7 +5744,7 @@
   {
     "id": "sftpgo",
     "name": "SFTPGo",
-    "version": "latest",
+    "version": "2.7.3",
     "description": "SFTPGo is a full-featured and highly configurable SFTP, HTTP/S, FTP/S, and WebDAV server.",
     "logo": "sftpgo.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -5742,6 +5742,23 @@
     ]
   },
   {
+    "id": "sftpgo",
+    "name": "SFTPGo",
+    "version": "latest",
+    "description": "SFTPGo is a full-featured and highly configurable SFTP, HTTP/S, FTP/S, and WebDAV server.",
+    "logo": "sftpgo.svg",
+    "links": {
+      "github": "https://github.com/drakkan/sftpgo",
+      "website": "https://sftpgo.com/",
+      "docs": "https://docs.sftpgo.com/"
+    },
+    "tags": [
+      "sftp",
+      "files",
+      "webdav"
+    ]
+  },
+  {
     "id": "shlink",
     "name": "Shlink",
     "version": "stable",


### PR DESCRIPTION
/claim #152

## What is this PR about?

This PR adds a new SFTPGo Dokploy template. Adds an SFTPGo template with persistent data/home volumes, web admin routing on port 8080, and Dokploy-compatible port syntax for the SFTP service.

## Validation

- Ran `node dedupe-and-sort-meta.js`
- Ran `npm --prefix build-scripts run validate-template -- --dir ../blueprints/sftpgo`
- Ran `npm --prefix build-scripts run validate-docker-compose -- --file ../blueprints/sftpgo/docker-compose.yml`
- Ran `git diff --check`

Not run: full Docker runtime smoke test, because Docker is unavailable locally.

## Notes

I kept this as a focused single-template PR so it stays easy to review. Maintainer edits are enabled.