### PR TITLE
feat: add FileGator template

### DIFF
--- a/blueprints/filegator/docker-compose.yml
+++ b/blueprints/filegator/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  filegator:
+    image: filegator/filegator:latest
+    restart: unless-stopped
+    volumes:
+      - filegator_repository:/var/www/filegator/repository
+      - filegator_private:/var/www/filegator/private
+    ports:
+      - "8080"
+
+volumes:
+  filegator_repository:
+  filegator_private:

--- a/blueprints/filegator/docker-compose.yml
+++ b/blueprints/filegator/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   filegator:
-    image: filegator/filegator:latest
+    image: filegator/filegator:v7.14.3
     restart: unless-stopped
     volumes:
       - filegator_repository:/var/www/filegator/repository

--- a/blueprints/filegator/filegator.svg
+++ b/blueprints/filegator/filegator.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#101828"/>
+  <circle cx="64" cy="64" r="34" fill="#38bdf8" opacity="0.92"/>
+  <text x="64" y="74" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="#ffffff">F</text>
+</svg>

--- a/blueprints/filegator/template.toml
+++ b/blueprints/filegator/template.toml
@@ -1,0 +1,11 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+env = {}
+mounts = []
+
+[[config.domains]]
+serviceName = "filegator"
+port = 8080
+host = "${main_domain}"

--- a/meta.json
+++ b/meta.json
@@ -2295,7 +2295,7 @@
   {
     "id": "filegator",
     "name": "FileGator",
-    "version": "latest",
+    "version": "7.14.3",
     "description": "FileGator is a simple self-hosted web file manager with multi-user support.",
     "logo": "filegator.svg",
     "links": {

--- a/meta.json
+++ b/meta.json
@@ -2293,6 +2293,23 @@
     ]
   },
   {
+    "id": "filegator",
+    "name": "FileGator",
+    "version": "latest",
+    "description": "FileGator is a simple self-hosted web file manager with multi-user support.",
+    "logo": "filegator.svg",
+    "links": {
+      "github": "https://github.com/filegator/filegator",
+      "website": "https://filegator.io/",
+      "docs": "https://docs.filegator.io/"
+    },
+    "tags": [
+      "files",
+      "file-manager",
+      "self-hosted"
+    ]
+  },
+  {
     "id": "filestash",
     "name": "Filestash",
     "version": "latest",


### PR DESCRIPTION
/claim #152

## What is this PR about?

This PR adds a new FileGator Dokploy template. Adds a FileGator template with persistent repository/private storage and Dokploy domain routing on port 8080.

## Validation

- Ran `node dedupe-and-sort-meta.js`
- Ran `npm --prefix build-scripts run validate-template -- --dir ../blueprints/filegator`
- Ran `npm --prefix build-scripts run validate-docker-compose -- --file ../blueprints/filegator/docker-compose.yml`
- Ran `git diff --check`

Not run: full Docker runtime smoke test, because Docker is unavailable locally.

## Notes

I kept this as a focused single-template PR so it stays easy to review. Maintainer edits are enabled.