### PR TITLE
feat: add ArchiveBox template

### DIFF
--- a/blueprints/archivebox/archivebox.svg
+++ b/blueprints/archivebox/archivebox.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#101828"/>
+  <circle cx="64" cy="64" r="34" fill="#38bdf8" opacity="0.92"/>
+  <text x="64" y="74" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="#ffffff">A</text>
+</svg>

--- a/blueprints/archivebox/docker-compose.yml
+++ b/blueprints/archivebox/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  archivebox:
+    image: archivebox/archivebox:latest
+    restart: unless-stopped
+    command: server --quick-init 0.0.0.0:8000
+    environment:
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS}
+      PUBLIC_INDEX: ${PUBLIC_INDEX}
+      PUBLIC_SNAPSHOTS: ${PUBLIC_SNAPSHOTS}
+    volumes:
+      - archivebox_data:/data
+    ports:
+      - "8000"
+
+volumes:
+  archivebox_data:

--- a/blueprints/archivebox/template.toml
+++ b/blueprints/archivebox/template.toml
@@ -1,0 +1,15 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+mounts = []
+
+[[config.domains]]
+serviceName = "archivebox"
+port = 8000
+host = "${main_domain}"
+
+[config.env]
+ALLOWED_HOSTS = "*"
+PUBLIC_INDEX = "True"
+PUBLIC_SNAPSHOTS = "True"

--- a/meta.json
+++ b/meta.json
@@ -415,6 +415,23 @@
     ]
   },
   {
+    "id": "archivebox",
+    "name": "ArchiveBox",
+    "version": "latest",
+    "description": "ArchiveBox is a self-hosted internet archiving solution for saving websites, media, and documents.",
+    "logo": "archivebox.svg",
+    "links": {
+      "github": "https://github.com/ArchiveBox/ArchiveBox",
+      "website": "https://archivebox.io/",
+      "docs": "https://docs.archivebox.io/"
+    },
+    "tags": [
+      "archive",
+      "bookmarks",
+      "web"
+    ]
+  },
+  {
     "id": "argilla",
     "name": "Argilla",
     "version": "latest",


### PR DESCRIPTION
/claim #152

## What is this PR about?

This PR adds a new ArchiveBox Dokploy template. Adds an ArchiveBox template with quick-init server startup, persistent archive data, and Dokploy domain routing on port 8000.

## Validation

- Ran `node dedupe-and-sort-meta.js`
- Ran `npm --prefix build-scripts run validate-template -- --dir ../blueprints/archivebox`
- Ran `npm --prefix build-scripts run validate-docker-compose -- --file ../blueprints/archivebox/docker-compose.yml`
- Ran `git diff --check`

Not run: full Docker runtime smoke test, because Docker is unavailable locally.

## Notes

I kept this as a focused single-template PR so it stays easy to review. Maintainer edits are enabled.