### PR TITLE
docs: fix remaining README references to the removed root meta.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the official repository for the Dokploy Open Source Templates.
 1. Fork the repository
 2. Create a new branch
 3. Add the template to the `blueprints` folder (`docker-compose.yml`, `template.toml`)
-4. Add the template metadata (name, description, version, logo, links, tags) to the `meta.json` file
+4. Add the template metadata (name, description, version, logo, links, tags) in a `meta.json` file inside your template folder (`blueprints/<id>/meta.json`) — do NOT create or edit a root-level `meta.json`, it is generated at build time
 5. Add the logo to the template folder
 6. Commit and push your changes
 7. Create a pull request (PR)
@@ -62,7 +62,7 @@ host = "${main_domain}"
 
 [[config.mounts]]
 ```
-4. Add meta information to the `meta.json` file in the root folder
+4. Add the meta information in `blueprints/<id>/meta.json` (a single JSON object; the root `meta.json` is generated automatically at build time)
 
 ```json
 {


### PR DESCRIPTION
Follow-up to #978 — two spots in the README (the quick "How to add a new template" list and the step-by-step section) still told contributors to add their metadata to the root `meta.json`, which no longer exists. Both now point to `blueprints/<id>/meta.json` and note that the root file is generated at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)