### PR TITLE
fix: meta.json of Poke blueprint

### DIFF
--- a/blueprints/poke/meta.json
+++ b/blueprints/poke/meta.json
@@ -5,9 +5,9 @@
   "description": "Poke is an open-source, self-hosted alternative to YouTube. A privacy-focused video platform that allows you to watch and share videos without tracking.",
   "logo": "image.png",
   "links": {
-    "github": "https://codeberg.org/ashley/poke",
+    "github": "https://codeberg.org/ashleyirispuppy/poke",
     "website": "https://poketube.fun/",
-    "docs": "https://codeberg.org/ashley/poke"
+    "docs": "https://codeberg.org/ashleyirispuppy/poke"
   },
   "tags": [
     "video",


### PR DESCRIPTION
The current github/docs links for "Poke" blueprint was broken

before:
https://codeberg.org/ashley/poke

after:
https://codeberg.org/ashleyirispuppy/poke