### PR TITLE
fix: broken links in some blueprints

### DIFF
--- a/blueprints/adventurelog/meta.json
+++ b/blueprints/adventurelog/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/seanmorley15/adventurelog",
     "website": "https://adventurelog.app/",
-    "docs": "https://adventurelog.app/docs/"
+    "docs": "https://adventurelog.app/docs/intro/adventurelog_overview.html"
   },
   "tags": [
     "activity",

--- a/blueprints/affinepro/meta.json
+++ b/blueprints/affinepro/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/toeverything/Affine",
     "website": "https://affine.pro/",
-    "docs": "https://affine.pro/docs"
+    "docs": "https://docs.affine.pro/"
   },
   "tags": [
     "collaboration",

--- a/blueprints/anythingllm/meta.json
+++ b/blueprints/anythingllm/meta.json
@@ -6,8 +6,8 @@
   "logo": "logo.png",
   "links": {
     "github": "https://github.com/Mintplex-Labs/anything-llm",
-    "website": "https://useanything.com",
-    "docs": "https://github.com/Mintplex-Labs/anything-llm/tree/master/docs"
+    "website": "https://anythingllm.com/",
+    "docs": "https://docs.anythingllm.com/"
   },
   "tags": [
     "ai",

--- a/blueprints/babybuddy/meta.json
+++ b/blueprints/babybuddy/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/babybuddy/babybuddy",
     "website": "https://babybuddy.app",
-    "docs": "https://docs.babybuddy.app"
+    "docs": "https://docs.baby-buddy.net/"
   },
   "tags": [
     "parenting",

--- a/blueprints/bazarr/meta.json
+++ b/blueprints/bazarr/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/morpheus65535/bazarr",
     "website": "https://www.bazarr.media/",
-    "docs": "https://www.bazarr.media/docs"
+    "docs": "https://wiki.bazarr.media/"
   },
   "tags": [
     "subtitles",

--- a/blueprints/bentopdf/meta.json
+++ b/blueprints/bentopdf/meta.json
@@ -5,9 +5,9 @@
   "description": "BentoPDF is a lightweight PDF conversion microservice that exposes a simple HTTP API for generating PDFs.",
   "logo": "image.png",
   "links": {
-    "github": "https://github.com/bentopdf/bentopdf",
+    "github": "https://github.com/alam00000/bentopdf/",
     "website": "https://bentopdf.com/",
-    "docs": "https://github.com/bentopdf/bentopdf#readme"
+    "docs": "https://www.bentopdf.com/docs/"
   },
   "tags": [
     "pdf",

--- a/blueprints/checkmate/meta.json
+++ b/blueprints/checkmate/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/bluewave-labs/checkmate",
     "website": "https://checkmate.so/",
-    "docs": "https://docs.checkmate.so"
+    "docs": "https://checkmate.so/docs"
   },
   "tags": [
     "self-hosted",

--- a/blueprints/documenso/meta.json
+++ b/blueprints/documenso/meta.json
@@ -6,7 +6,7 @@
   "links": {
     "github": "https://github.com/documenso/documenso",
     "website": "https://documenso.com/",
-    "docs": "https://documenso.com/docs"
+    "docs": "https://docs.documenso.com/"
   },
   "logo": "documenso.png",
   "tags": [

--- a/blueprints/maybe/meta.json
+++ b/blueprints/maybe/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/maybe-finance/maybe",
     "website": "https://maybe.finance/",
-    "docs": "https://docs.maybe.finance/"
+    "docs": "https://github.com/maybe-finance/maybe/blob/main/docs/hosting/docker.md"
   },
   "tags": [
     "finance",

--- a/blueprints/mumble/meta.json
+++ b/blueprints/mumble/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/mumble-voip/mumble",
     "website": "https://www.mumble.info/",
-    "docs": "https://wiki.mumble.info/"
+    "docs": "https://www.mumble.info/documentation/"
   },
   "tags": [
     "voice-chat",

--- a/blueprints/paymenter/meta.json
+++ b/blueprints/paymenter/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/Paymenter/Paymenter",
     "website": "https://paymenter.org/",
-    "docs": "https://paymenter.org/docs/"
+    "docs": "https://paymenter.org/docs/getting-started/introduction"
   },
   "tags": [
     "billing",

--- a/blueprints/rustrak/meta.json
+++ b/blueprints/rustrak/meta.json
@@ -6,8 +6,8 @@
   "logo": "rustrak.svg",
   "links": {
     "github": "https://github.com/AbianS/rustrak",
-    "website": "https://abians.github.io/rustrak/",
-    "docs": "https://abians.github.io/rustrak/"
+    "website": "https://rustrak.github.io/rustrak/",
+    "docs": "https://rustrak.github.io/rustrak/getting-started/overview"
   },
   "tags": [
     "monitoring",


### PR DESCRIPTION
I ran the check-links script from https://github.com/Dokploy/templates/pull/983 and slowly worked on fixing some of them. I couldn't do the whole thing today all at once so I'll maybe fix them one chunk at a time.

It takes a bit of searching sometimes to find the correct links. And some of them I couldn't even find the correct links (for example AgentDVR became closed-source and the only github repo is a fork that I'm not even sure if it's reliable enough to use it as the github link)