### PR TITLE
feat(directus): upgrade template to Directus 12.1.1

### DIFF
--- a/blueprints/directus/docker-compose.yml
+++ b/blueprints/directus/docker-compose.yml
@@ -1,15 +1,73 @@
 services:
+  directus:
+    image: directus/directus:12.1.1
+    ports:
+      - 8055
+    volumes:
+      - directus_uploads:/directus/uploads
+      - directus_extensions:/directus/extensions
+    depends_on:
+      database:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:8055/server/ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_interval: 5s
+      start_period: 30s
+    environment:
+      SECRET: ${DIRECTUS_SECRET}
+
+      DB_CLIENT: "pg"
+      DB_HOST: "database"
+      DB_PORT: "5432"
+      DB_DATABASE: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+
+      CACHE_ENABLED: "true"
+      CACHE_AUTO_PURGE: "true"
+      CACHE_STORE: "redis"
+      REDIS: "redis://cache:6379"
+
+      WEBSOCKETS_ENABLED: "true"
+      PUBLIC_URL: ${PUBLIC_URL}
+      LICENSE_KEY: ${LICENSE_KEY}
+
+      # After first successful login, remove ADMIN_EMAIL and ADMIN_PASSWORD below.
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+
+      STORAGE_LOCATIONS: "local"
+      STORAGE_LOCAL_DRIVER: "local"
+      STORAGE_LOCAL_ROOT: "/directus/uploads"
+
+      # S3-compatible storage — uncomment and set S3_* env vars in template.toml.
+      # STORAGE_LOCATIONS: "s3"
+      # STORAGE_S3_DRIVER: "s3"
+      # STORAGE_S3_KEY: ${S3_ACCESS_KEY}
+      # STORAGE_S3_SECRET: ${S3_SECRET_KEY}
+      # STORAGE_S3_BUCKET: ${S3_BUCKET}
+      # STORAGE_S3_REGION: ${S3_REGION}
+      # STORAGE_S3_ENDPOINT: ${S3_ENDPOINT}
+      # STORAGE_S3_ROOT: ${S3_ROOT}
+      # STORAGE_S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE}
+      # STORAGE_S3_ACL: "private"
+
   database:
     image: postgis/postgis:13-master
     volumes:
       - directus_database:/var/lib/postgresql/data
 
     environment:
-      POSTGRES_USER: "directus"
-      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
-      POSTGRES_DB: "directus"
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
     healthcheck:
-      test: ["CMD", "pg_isready", "--host=localhost", "--username=directus"]
+      test: ["CMD-SHELL", "pg_isready --host=localhost --username=$$POSTGRES_USER"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -26,38 +84,6 @@ services:
       start_interval: 5s
       start_period: 30s
 
-
-  directus:
-    image: directus/directus:11.12.0
-    ports:
-      - 8055
-    volumes:
-      - directus_uploads:/directus/uploads
-      - directus_extensions:/directus/extensions
-    depends_on:
-      database:
-        condition: service_healthy
-      cache:
-        condition: service_healthy
-    environment:
-      SECRET: ${DIRECTUS_SECRET}
-
-      DB_CLIENT: "pg"
-      DB_HOST: "database"
-      DB_PORT: "5432"
-      DB_DATABASE: "directus"
-      DB_USER: "directus"
-      DB_PASSWORD: ${DATABASE_PASSWORD}
-
-      CACHE_ENABLED: "true"
-      CACHE_AUTO_PURGE: "true"
-      CACHE_STORE: "redis"
-      REDIS: "redis://cache:6379"
-
-      # After first successful login, remove the admin email/password env. variables below
-      # as these will now be stored in the database.
-      ADMIN_EMAIL: "admin@example.com"
-      ADMIN_PASSWORD: "d1r3ctu5"
 volumes:
   directus_uploads:
   directus_extensions:

--- a/blueprints/directus/meta.json
+++ b/blueprints/directus/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "directus",
   "name": "Directus",
-  "version": "11.0.2",
+  "version": "12.1.1",
   "description": "Directus is an open source headless CMS that provides an API-first solution for building custom backends.",
   "logo": "directus.jpg",
   "links": {
     "github": "https://github.com/directus/directus",
     "website": "https://directus.io/",
-    "docs": "https://docs.directus.io/"
+    "docs": "https://directus.com/docs/"
   },
   "tags": [
     "cms"

--- a/blueprints/directus/template.toml
+++ b/blueprints/directus/template.toml
@@ -1,12 +1,24 @@
 [variables]
 main_domain = "${domain}"
+public_url = "https://${main_domain}"
 directus_secret = "${base64:64}"
-database_password = "${password}"
+db_password = "${password:32}"
+db_user = "directus"
+db_name = "directus"
+admin_email = "${email}"
+admin_password = "${password:24}"
+license_key = ""
 
 [config]
 env = [
-  "DATABASE_PASSWORD=${database_password}",
+  "PUBLIC_URL=${public_url}",
   "DIRECTUS_SECRET=${directus_secret}",
+  "DB_PASSWORD=${db_password}",
+  "DB_USER=${db_user}",
+  "DB_NAME=${db_name}",
+  "ADMIN_EMAIL=${admin_email}",
+  "ADMIN_PASSWORD=${admin_password}",
+  "LICENSE_KEY=${license_key}",
 ]
 mounts = []
 

--- a/blueprints/directus/template.toml
+++ b/blueprints/directus/template.toml
@@ -9,6 +9,15 @@ admin_email = "${email}"
 admin_password = "${password:24}"
 license_key = ""
 
+# Object storage (S3-compatible) — uncomment when switching from local to S3.
+# s3_access_key = ""
+# s3_secret_key = ""
+# s3_bucket = ""
+# s3_region = "us-east-1"
+# s3_endpoint = "https://s3.amazonaws.com"
+# s3_root = ""
+# s3_force_path_style = "false"
+
 [config]
 env = [
   "PUBLIC_URL=${public_url}",
@@ -19,6 +28,14 @@ env = [
   "ADMIN_EMAIL=${admin_email}",
   "ADMIN_PASSWORD=${admin_password}",
   "LICENSE_KEY=${license_key}",
+  # Uncomment when enabling S3 storage in docker-compose.yml:
+  # "S3_ACCESS_KEY=${s3_access_key}",
+  # "S3_SECRET_KEY=${s3_secret_key}",
+  # "S3_BUCKET=${s3_bucket}",
+  # "S3_REGION=${s3_region}",
+  # "S3_ENDPOINT=${s3_endpoint}",
+  # "S3_ROOT=${s3_root}",
+  # "S3_FORCE_PATH_STYLE=${s3_force_path_style}",
 ]
 mounts = []
 


### PR DESCRIPTION
## Summary

- Upgrade `directus/directus` image from `11.12.0` to `12.1.1`
- Add Directus service healthcheck using `127.0.0.1` (Directus binds IPv4 only; `localhost` resolves to `::1` and fails, which marks the container unhealthy and causes Traefik to skip routing)
- Add Directus 12 env vars: `PUBLIC_URL`, `WEBSOCKETS_ENABLED`, `LICENSE_KEY`
- Parameterize DB credentials (`DB_USER`, `DB_NAME`, `DB_PASSWORD`) and admin bootstrap credentials via `template.toml`
- Add local storage defaults with commented S3-compatible object storage block
- Update `meta.json` version and docs link

## Test plan

- [x] `node build-scripts/generate-meta.js --check` passes
- [ ] Import template Base64 from PR preview in Dokploy Compose → Advanced → Import
- [ ] Deploy and confirm container reaches `healthy` status
- [ ] Confirm HTTPS route works and Let's Encrypt cert is issued
- [ ] Log in with generated admin credentials