### PR TITLE
chore: normalize template tags to kebab-case

### DIFF
--- a/blueprints/answer/meta.json
+++ b/blueprints/answer/meta.json
@@ -10,7 +10,7 @@
     "docs": "https://answer.apache.org/docs"
   },
   "tags": [
-    "q&a",
+    "q-and-a",
     "self-hosted"
   ]
 }

--- a/blueprints/calibre/meta.json
+++ b/blueprints/calibre/meta.json
@@ -10,7 +10,7 @@
     "docs": "https://manual.calibre-ebook.com/"
   },
   "tags": [
-    "Documents",
-    "E-Commerce"
+    "documents",
+    "e-commerce"
   ]
 }

--- a/blueprints/carbone/meta.json
+++ b/blueprints/carbone/meta.json
@@ -10,9 +10,9 @@
     "docs": "https://carbone.io/documentation/design/overview/getting-started.html"
   },
   "tags": [
-    "Document Generation",
-    "Automation",
-    "Reporting",
-    "Productivity"
+    "document-generation",
+    "automation",
+    "reporting",
+    "productivity"
   ]
 }

--- a/blueprints/changedetection/meta.json
+++ b/blueprints/changedetection/meta.json
@@ -10,8 +10,8 @@
     "docs": "https://github.com/dgtlmoon/changedetection.io/wiki"
   },
   "tags": [
-    "Monitoring",
-    "Data",
-    "Notifications"
+    "monitoring",
+    "data",
+    "notifications"
   ]
 }

--- a/blueprints/chevereto/meta.json
+++ b/blueprints/chevereto/meta.json
@@ -10,10 +10,10 @@
     "docs": "https://v4-docs.chevereto.com/"
   },
   "tags": [
-    "Image Hosting",
-    "File Management",
-    "Open Source",
-    "Multi-User",
-    "Private Albums"
+    "image-hosting",
+    "file-management",
+    "open-source",
+    "multi-user",
+    "private-albums"
   ]
 }

--- a/blueprints/chibisafe/meta.json
+++ b/blueprints/chibisafe/meta.json
@@ -10,7 +10,7 @@
     "docs": "https://chibisafe.app/docs/intro"
   },
   "tags": [
-    "media system",
+    "media-system",
     "storage",
     "file-sharing"
   ]

--- a/blueprints/chiefonboarding/meta.json
+++ b/blueprints/chiefonboarding/meta.json
@@ -10,10 +10,10 @@
     "docs": "https://docs.chiefonboarding.com/"
   },
   "tags": [
-    "Employee Onboarding",
-    "HR Management",
-    "Task Tracking",
-    "Role-Based Access",
-    "Document Management"
+    "employee-onboarding",
+    "hr-management",
+    "task-tracking",
+    "role-based-access",
+    "document-management"
   ]
 }

--- a/blueprints/crawl4ai/meta.json
+++ b/blueprints/crawl4ai/meta.json
@@ -12,8 +12,8 @@
   "tags": [
     "crawler",
     "scraping",
-    "AI",
-    "LLM",
-    "API"
+    "ai",
+    "llm",
+    "api"
   ]
 }

--- a/blueprints/emby/meta.json
+++ b/blueprints/emby/meta.json
@@ -11,6 +11,6 @@
   },
   "tags": [
     "media",
-    "media system"
+    "media-system"
   ]
 }

--- a/blueprints/evershop/meta.json
+++ b/blueprints/evershop/meta.json
@@ -10,7 +10,7 @@
     "docs": "https://evershop.io/docs/development/getting-started/introduction"
   },
   "tags": [
-    "E-Commerce",
+    "e-commerce",
     "shopping"
   ]
 }

--- a/blueprints/flowise/meta.json
+++ b/blueprints/flowise/meta.json
@@ -10,8 +10,8 @@
     "docs": "https://docs.flowiseai.com/"
   },
   "tags": [
-    "AI",
-    "LLM",
+    "ai",
+    "llm",
     "workflow",
     "automation"
   ]

--- a/blueprints/go2rtc/meta.json
+++ b/blueprints/go2rtc/meta.json
@@ -13,6 +13,6 @@
     "streaming",
     "webrtc",
     "video",
-    "home assistant"
+    "home-assistant"
   ]
 }

--- a/blueprints/jellyfin/meta.json
+++ b/blueprints/jellyfin/meta.json
@@ -10,6 +10,6 @@
     "docs": "https://jellyfin.org/docs/"
   },
   "tags": [
-    "media system"
+    "media-system"
   ]
 }

--- a/blueprints/kaneo/meta.json
+++ b/blueprints/kaneo/meta.json
@@ -10,6 +10,6 @@
     "docs": "https://kaneo.app/docs/"
   },
   "tags": [
-    "Task Tracking"
+    "task-tracking"
   ]
 }

--- a/blueprints/librechat/meta.json
+++ b/blueprints/librechat/meta.json
@@ -2,7 +2,7 @@
   "id": "librechat",
   "name": "LibreChat",
   "version": "latest",
-  "description": "LibreChat is the ultimate open-source app for all your AI conversations, fully customizable and compatible with any AI provider (Openai, Ollama, Google etc.) â€” all in one sleek interface.",
+  "description": "LibreChat is the ultimate open-source app for all your AI conversations, fully customizable and compatible with any AI provider (Openai, Ollama, Google etc.) \u00e2\u20ac\u201d all in one sleek interface.",
   "logo": "librechat.png",
   "links": {
     "github": "https://github.com/danny-avila/librechat",
@@ -13,8 +13,8 @@
     "ai",
     "chatbot",
     "llm",
-    "MIT-license",
-    "BYOK",
+    "mit-license",
+    "byok",
     "generative-ai"
   ]
 }

--- a/blueprints/livekit/meta.json
+++ b/blueprints/livekit/meta.json
@@ -10,10 +10,10 @@
     "docs": "https://docs.livekit.io/"
   },
   "tags": [
-    "Video",
-    "Audio",
-    "Real-time",
-    "Streaming",
-    "Webrtc"
+    "video",
+    "audio",
+    "real-time",
+    "streaming",
+    "webrtc"
   ]
 }

--- a/blueprints/lobe-chat/meta.json
+++ b/blueprints/lobe-chat/meta.json
@@ -10,7 +10,7 @@
     "docs": "https://lobehub.com/docs/self-hosting/platform/docker-compose"
   },
   "tags": [
-    "IA",
+    "ia",
     "chat"
   ]
 }

--- a/blueprints/scrutiny/meta.json
+++ b/blueprints/scrutiny/meta.json
@@ -11,6 +11,6 @@
   },
   "tags": [
     "monitoring",
-    "NAS"
+    "nas"
   ]
 }

--- a/blueprints/verdaccio/meta.json
+++ b/blueprints/verdaccio/meta.json
@@ -10,7 +10,7 @@
     "docs": "https://www.verdaccio.org/docs/what-is-verdaccio"
   },
   "tags": [
-    "node.js",
+    "node-js",
     "package-repository",
     "npm"
   ]

--- a/blueprints/zipline/meta.json
+++ b/blueprints/zipline/meta.json
@@ -10,7 +10,7 @@
     "docs": "https://zipline.diced.sh/docs/"
   },
   "tags": [
-    "media system",
+    "media-system",
     "storage"
   ]
 }


### PR DESCRIPTION
## Summary

Normalize non-kebab-case tags across blueprint `meta.json` files for consistent template catalog filtering.

## Changes

- 20 templates updated (35 tag values normalized)
- Examples: `AI` → `ai`, `Document Generation` → `document-generation`, `home assistant` → `home-assistant`, `node.js` → `node-js`, `q&a` → `q-and-a`
- Duplicate tags removed when normalization collapsed variants (e.g. `E-Commerce` + existing `e-commerce`)

## Verification

- [x] `node build-scripts/generate-meta.js --check` — 476 templates validated
- [x] Zero non-kebab tags remaining across all `meta.json` files