### PR TITLE
fix(billmora): add shared volumes for plugins and themes across containers

### DIFF
--- a/blueprints/billmora/docker-compose.yml
+++ b/blueprints/billmora/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       - AUTORUN_LARAVEL_STORAGE_LINK=true
     volumes:
       - billmora-storage:/var/www/html/storage
+      - billmora-plugins:/var/www/html/plugin
+      - billmora-themes-resources:/var/www/html/resources/themes
+      - billmora-themes-public:/var/www/html/public/themes
     depends_on:
       billmora-db:
         condition: service_healthy
@@ -58,6 +61,9 @@ services:
       - AUTORUN_ENABLED=false
     volumes:
       - billmora-storage:/var/www/html/storage
+      - billmora-plugins:/var/www/html/plugin
+      - billmora-themes-resources:/var/www/html/resources/themes
+      - billmora-themes-public:/var/www/html/public/themes
     depends_on:
       billmora-db:
         condition: service_healthy
@@ -88,6 +94,9 @@ services:
       - AUTORUN_ENABLED=false
     volumes:
       - billmora-storage:/var/www/html/storage
+      - billmora-plugins:/var/www/html/plugin
+      - billmora-themes-resources:/var/www/html/resources/themes
+      - billmora-themes-public:/var/www/html/public/themes
     depends_on:
       billmora-db:
         condition: service_healthy
@@ -126,5 +135,8 @@ services:
 
 volumes:
   billmora-storage:
+  billmora-plugins:
+  billmora-themes-resources:
+  billmora-themes-public:
   billmora-db-data:
   billmora-redis-data:


### PR DESCRIPTION
## What is this PR about?
This PR updates the Billmora template to mount shared named volumes for `plugins `and `themes`. This is required to synchronize dynamically installed user assets across the isolated app, worker, and scheduler containers.

New PR of Billmora

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

Close automatically the related issues using the keywords: `closes #ISSUE_NUMBER`


## Screenshots or Videos
