### PR TITLE
fix(affinepro): update to current AFFiNE images

### DIFF
--- a/blueprints/affinepro/docker-compose.yml
+++ b/blueprints/affinepro/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   affinepro:
-    image: ghcr.io/toeverything/affine-graphql:stable-780dd83
+    image: ghcr.io/toeverything/affine:stable
     restart: unless-stopped
     ports:
       - 3010
@@ -12,6 +12,7 @@ services:
       - REDIS_SERVER_HOST=redis
       - REDIS_SERVER_PASSWORD=${REDIS_PASSWORD}
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/affinepro
+      - AFFINE_INDEXER_ENABLED=false
       - AFFINE_SERVER_HOST=${DOMAIN}
       - MAILER_HOST=${MAILER_HOST}
       - MAILER_PORT=${MAILER_PORT}
@@ -19,16 +20,21 @@ services:
       - MAILER_PASSWORD=${MAILER_PASSWORD}
       - MAILER_SENDER=${MAILER_SENDER}
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migration:
+        condition: service_completed_successfully
 
   migration:
-    image: ghcr.io/toeverything/affine-graphql:stable-780dd83
-    command: node ./scripts/self-host-predeploy.js
+    image: ghcr.io/toeverything/affine:stable
+    command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
     environment:
       - REDIS_SERVER_HOST=redis
       - REDIS_SERVER_PASSWORD=${REDIS_PASSWORD}
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/affinepro
+      - AFFINE_INDEXER_ENABLED=false
       - AFFINE_SERVER_HOST=${DOMAIN}
       - MAILER_HOST=${MAILER_HOST}
       - MAILER_PORT=${MAILER_PORT}
@@ -39,17 +45,25 @@ services:
       - affine-storage:/root/.affine/storage
       - affine-config:/root/.affine/config
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   db:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg16
     restart: unless-stopped
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=affinepro
+      - POSTGRES_INITDB_ARGS=--data-checksums
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "affinepro"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
@@ -57,9 +71,14 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD}
     volumes:
       - redis-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a '${REDIS_PASSWORD}' ping | grep PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   affine-storage: {}
   affine-config: {}
   postgres-data: {}
-  redis-data: {} 
+  redis-data: {}

--- a/blueprints/affinepro/meta.json
+++ b/blueprints/affinepro/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "affinepro",
   "name": "Affine Pro",
-  "version": "stable-780dd83",
+  "version": "stable",
   "description": "Affine Pro is a modern, self-hosted platform designed for collaborative content creation and project management. It offers an intuitive interface, seamless real-time collaboration, and powerful tools for organizing tasks, notes, and ideas.",
   "logo": "logo.png",
   "links": {


### PR DESCRIPTION
## Problem

The template pinned `ghcr.io/toeverything/affine-graphql:stable-780dd83` — an ephemeral per-commit tag on the old image name. That tag has been removed from GHCR, so the template fails to pull and can no longer be deployed (issue #777).

## Changes

- Switch the app and migration services to `ghcr.io/toeverything/affine:stable`, the rolling stable tag used by the [official self-host compose](https://github.com/toeverything/AFFiNE/blob/canary/.docker/selfhost/compose.yml). This also prevents future rot when upstream garbage-collects per-commit tags.
- Move postgres to `pgvector/pgvector:pg16` and set `AFFINE_INDEXER_ENABLED=false`, matching current upstream self-host requirements.
- Add postgres/redis healthchecks and `depends_on` conditions so the `self-host-predeploy` migration job runs only after the database is ready, and the server starts only after migrations complete successfully.
- Update `meta.json` version to `stable`.

No changes needed in `template.toml` (same service name, port 3010, and env vars).

## Evidence (deploy-tested on a Dokploy instance)

- Deploy finished in ~113s; app responds `HTTP 200` with the AFFiNE UI on the generated domain.
- Container states after deploy: `affinepro` running, `migration` exited(0) (one-shot job), `db` running, `redis` running.
- Migration job logs: `Done 8 migrations` with all migrations checked, then clean shutdown (`Done in 10.64s`).

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)