### PR TITLE
fix(cockpit): persist config and storage volumes per upstream docs

### DIFF
--- a/blueprints/cockpit/docker-compose.yml
+++ b/blueprints/cockpit/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       - COCKPIT_DATABASE_SERVER=mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongo:27017
       - COCKPIT_DATABASE_NAME=cockpit
     volumes:
-      - html:/var/www/html
-      - data:/var/www/html/storage/data
+      - config:/var/www/html/config
+      - storage:/var/www/html/storage
     depends_on:
       - mongo
 
@@ -25,6 +25,6 @@ services:
       - mongo-data:/data/db
 
 volumes:
-  html:
-  data:
+  config:
+  storage:
   mongo-data: 


### PR DESCRIPTION
## Problem

The Cockpit CMS template mounts the wrong paths:

```yaml
volumes:
  - html:/var/www/html
  - data:/var/www/html/storage/data
```

- `html:/var/www/html` mounts a named volume over the whole app directory, which freezes the application code at whatever the image contained on the very first deploy (image updates never take effect).
- `data:/var/www/html/storage/data` only persists the `storage/data` subfolder, so uploaded assets (`storage/uploads`) and the rest of `storage/` are lost when the container is recreated / the system is pruned.

## Fix

Mount exactly what the [official Cockpit persistent-storage docs](https://getcockpit.com/documentation/core/quickstart/installation#persistent-storage) recommend:

```yaml
volumes:
  - config:/var/www/html/config
  - storage:/var/www/html/storage
```

`storage/` holds user uploads, cache and data; `config/` holds configuration files. The MongoDB volume is unchanged.

## Evidence

Deployed the updated template on a Dokploy instance: deploy finished in 72s, all containers running, and the app responds with HTTP 200 (`<title>Cockpit</title>`) on its generated domain.

## Note for existing installs

This changes volume names/paths, so existing deployments of this template will start with fresh `config`/`storage` volumes. Users who already run the old template need to migrate their data from the old `html`/`data` volumes manually.

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)