### PR TITLE
fix(kener): define REDIS_URL and drop unused databases

### DIFF
--- a/blueprints/kener/docker-compose.yml
+++ b/blueprints/kener/docker-compose.yml
@@ -1,39 +1,35 @@
-version: "3.8"
-
 services:
   kener:
     image: rajnandan1/kener:latest
     environment:
       - TZ=${TZ}
       - KENER_SECRET_KEY=${KENER_SECRET_KEY} # 🔐 API key / secret
+      - ORIGIN=${ORIGIN}
+      - REDIS_URL=${REDIS_URL}
       - DATABASE_URL=${DATABASE_URL}
       - KENER_BASE_PATH=${KENER_BASE_PATH}
-      - ORIGIN=${ORIGIN}
       - RESEND_API_KEY=${RESEND_API_KEY} # 🔐 API key
       - RESEND_SENDER_EMAIL=${RESEND_SENDER_EMAIL}
     ports:
       - 3000
     volumes:
       - kener_db:/app/database
-      - ../files/uploads:/app/uploads
+    depends_on:
+      redis:
+        condition: service_healthy
     restart: unless-stopped
 
-  postgres:
-    image: postgres:alpine
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD} # 🔐 DB password
-      - POSTGRES_DB=${POSTGRES_DB}
-    restart: unless-stopped
-
-  mysql:
-    image: mariadb:11
-    environment:
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD} # 🔐 DB password
-      - MYSQL_DATABASE=${MYSQL_DATABASE}
-      - MYSQL_RANDOM_ROOT_PASSWORD=true
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - kener_redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
 volumes:
   kener_db: {}
+  kener_redis: {}

--- a/blueprints/kener/template.toml
+++ b/blueprints/kener/template.toml
@@ -1,8 +1,6 @@
 [variables]
 main_domain = "${domain}"
 KENER_SECRET_KEY = "${password:64}"
-POSTGRES_PASSWORD = "${password:32}"
-MYSQL_PASSWORD = "${password:32}"
 
 [config]
 [[config.domains]]
@@ -13,25 +11,9 @@ host = "${main_domain}"
 [config.env]
 TZ = "Etc/UTC"
 KENER_SECRET_KEY = "${KENER_SECRET_KEY}" # 🔐 API key / secret
+ORIGIN = "https://${main_domain}"
+REDIS_URL = "redis://redis:6379"
 DATABASE_URL = "sqlite://./database/kener.sqlite.db"
 KENER_BASE_PATH = ""
-ORIGIN = "http://localhost:3000"
 RESEND_API_KEY = ""
 RESEND_SENDER_EMAIL = "Accounts <accounts@resend.dev>"
-POSTGRES_USER = "user"
-POSTGRES_DB = "kener_db"
-MYSQL_USER = "user"
-MYSQL_DATABASE = "kener_db"
-MYSQL_RANDOM_ROOT_PASSWORD = "true"
-MYSQL_PASSWORD = "${MYSQL_PASSWORD}" # 🔐 DB password
-POSTGRES_PASSWORD = "${POSTGRES_PASSWORD}" # 🔐 DB password
-
-[[config.mounts]]
-type = "volume"
-source = "kener_db"
-target = "/app/database"
-
-[[config.mounts]]
-type = "bind"
-source = "../files/uploads"
-target = "/app/uploads"


### PR DESCRIPTION
## What was broken

- **#976** — Kener v4 requires Redis for its BullMQ queues, caching and scheduler. The template did not provide one, so the container configured SQLite, ran migrations/seed, printed `Kener is running on port 3000!` and then immediately crashed with `Error: REDIS_URL is not defined in environment variables`.
- **#282** — The template deployed both a `postgres` and a `mariadb` service while `DATABASE_URL` pointed at SQLite, so neither database was ever used (pure bloat, plus two unused generated passwords).

## Fix

Aligned the template with the upstream `docker-compose.yml` from [rajnandan1/kener](https://github.com/rajnandan1/kener):

- Added a `redis:7-alpine` service with a healthcheck and a persistent `kener_redis` volume; set `REDIS_URL=redis://redis:6379` and made `kener` depend on redis being healthy.
- Removed the unused `postgres` and `mysql` services and all their env vars/passwords. SQLite (the upstream default) stays, persisted in the `kener_db` volume.
- Set `ORIGIN` to `https://${main_domain}` instead of `http://localhost:3000` so CSRF protection works behind the generated domain.
- Dropped the stale `/app/uploads` bind mount (kener v4 only persists `/app/database`) and the obsolete compose `version` key.

## Deploy test evidence

Deployed on a Dokploy instance from this branch:

- Deploy completed in 82s; both containers (`kener`, `redis`) running and stable after 30s (no restart loop).
- App log: migrations and seed completed, schedulers started (`ADDING NEW SCHEDULER: kener/earth`, maintenance + daily cleanup schedulers), banner `Kener version 4.1.2 is running!` — no `REDIS_URL` error.
- Generated domain returns HTTP 200 with title `Home - Kener.ing`.
- `node build-scripts/generate-meta.js --check` passes (476 templates validated).

Closes #976
Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)