### PR TITLE
fix(homarr): use named volume for /appdata and 64-char hex encryption key

### DIFF
--- a/blueprints/homarr/docker-compose.yml
+++ b/blueprints/homarr/docker-compose.yml
@@ -4,8 +4,11 @@ services:
     restart: unless-stopped
     volumes:
       # - /var/run/docker.sock:/var/run/docker.sock # Optional, only if you want docker integration
-      - ../homarr/appdata:/appdata
+      - homarr_appdata:/appdata
     environment:
       - SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY}
     ports:
       - 7575
+
+volumes:
+  homarr_appdata:

--- a/blueprints/homarr/template.toml
+++ b/blueprints/homarr/template.toml
@@ -1,6 +1,6 @@
 [variables]
 main_domain = "${domain}"
-secret_key = "${password:64}"
+secret_key = "${hash:64}"
 
 [config]
 env = ["SECRET_ENCRYPTION_KEY=${secret_key}"]


### PR DESCRIPTION
## Problem

As reported in #738, the Homarr template mounts its data with a relative bind mount:

```yaml
volumes:
  - ../homarr/appdata:/appdata
```

Bind mounts like this can't be backed up with Dokploy volume backups and depend on the compose file location on disk.

Additionally, `SECRET_ENCRYPTION_KEY` was generated with `${password:64}`. Homarr requires a **64-character hex string** (equivalent to `openssl rand -hex 32`, see the [official install docs](https://homarr.dev/docs/getting-started/installation/docker)), but Dokploy's `password` helper emits lowercase alphanumeric characters including `g-z`, which are not valid hex.

## Fix

- Use a named volume, as suggested in the issue: `homarr_appdata:/appdata` (declared in a top-level `volumes:` section).
- Generate `SECRET_ENCRYPTION_KEY` with `${hash:64}`, which produces exactly 64 hex characters (`randomBytes().toString("hex")`).

## Evidence

Deployed the updated template on a Dokploy instance: deploy finished in 21s, container running, HTTP 200 on the generated domain, and the generated `SECRET_ENCRYPTION_KEY` verified as a valid 64-character hex string.

## Note for existing installs

Existing deployments of this template keep their data in the old bind-mount directory (`../homarr/appdata` inside the compose folder). After updating, they will start with a fresh named volume and need to copy their old `appdata` contents into it manually.

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)