### PR TITLE
fix(logto): fix postgres role error and update to current version

### DIFF
--- a/blueprints/logto/docker-compose.yml
+++ b/blueprints/logto/docker-compose.yml
@@ -1,14 +1,11 @@
 services:
   app:
+    image: ghcr.io/logto-io/logto:1.41.0
+    restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy
-    image: ghcr.io/logto-io/logto:1.27.0
     entrypoint: ["sh", "-c", "npm run cli db seed -- --swe && npm start"]
-    ports:
-      - 3001
-      - 3002
-
     environment:
       TRUST_PROXY_HEADER: 1
       DB_URL: postgres://logto:${LOGTO_POSTGRES_PASSWORD}@postgres:5432/logto
@@ -18,19 +15,18 @@ services:
       - logto-connectors:/etc/logto/packages/core/connectors
   postgres:
     image: postgres:17-alpine
-    user: postgres
-
+    restart: unless-stopped
     environment:
       POSTGRES_USER: logto
       POSTGRES_PASSWORD: ${LOGTO_POSTGRES_PASSWORD}
+      POSTGRES_DB: logto
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U logto -d logto"]
       interval: 10s
       timeout: 5s
       retries: 5
-
 
 volumes:
   logto-connectors:

--- a/blueprints/logto/meta.json
+++ b/blueprints/logto/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "logto",
   "name": "Logto",
-  "version": "1.27.0",
+  "version": "1.41.0",
   "description": "Logto is an open-source Identity and Access Management (IAM) platform designed to streamline Customer Identity and Access Management (CIAM) and Workforce Identity Management.",
   "logo": "logto.png",
   "links": {

--- a/blueprints/logto/template.toml
+++ b/blueprints/logto/template.toml
@@ -1,7 +1,7 @@
 [variables]
 main_domain = "${domain}"
 admin_domain = "${domain}"
-postgres_password = "${password}"
+postgres_password = "${password:32}"
 
 [config]
 mounts = []
@@ -17,6 +17,6 @@ port = 3_002
 host = "${admin_domain}"
 
 [config.env]
-LOGTO_ENDPOINT = "http://${admin_domain}"
+LOGTO_ENDPOINT = "http://${main_domain}"
 LOGTO_ADMIN_ENDPOINT = "http://${admin_domain}"
 LOGTO_POSTGRES_PASSWORD = "${postgres_password}"


### PR DESCRIPTION
## Problem

Issue #130 reports the Logto template logs `FATAL: role "postgres" does not exist` and ships an outdated version.

## Root cause

The upstream Logto compose uses `POSTGRES_USER: postgres`, so its bare `pg_isready` healthcheck works there. Our template overrides the user to `logto` but kept the bare healthcheck, so every probe (running as OS user `postgres` due to `user: postgres`) tried to connect as the non-existent `postgres` role, spamming the FATAL error on every healthcheck interval.

## Changes

- **Healthcheck**: `pg_isready -U logto -d logto` so it probes the actual role/database; also set `POSTGRES_DB: logto` explicitly. No more FATAL log spam.
- **Version**: `ghcr.io/logto-io/logto` 1.27.0 → **1.41.0** (current latest release), `meta.json` updated.
- **Endpoint fix**: `LOGTO_ENDPOINT` was pointing at the *admin* domain; it now points at the main domain (admin console stays on `ADMIN_ENDPOINT`).
- **Conventions**: generated password uses `${password:32}`, removed the `ports:` entries that published ephemeral host ports (Traefik routes over the docker network), removed `user: postgres`, added `restart: unless-stopped`.

## Verification (deployed on a Dokploy instance)

- Deploy finished `done` in ~120s, both containers running, postgres reports **healthy** (healthcheck passing with the `logto` role — the source of the FATAL spam is gone).
- Core endpoint (`app:3001`): `/` → HTTP 200/302 as expected, `/api/status` → **204** (Logto health OK).
- Admin console (`app:3002`): `/console` → **200**, redirects to `/console/welcome` (fresh-install onboarding), confirming `TRUST_PROXY_HEADER`/endpoint config works behind the proxy.
- `node build-scripts/generate-meta.js --check` → 476 templates validated.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)