### PR TITLE
fix(zitadel): wire EXTERNALDOMAIN to the generated domain

### DIFF
--- a/blueprints/zitadel/docker-compose.yml
+++ b/blueprints/zitadel/docker-compose.yml
@@ -1,9 +1,7 @@
-version: '3.8'
-
 services:
   zitadel:
     restart: 'always'
-    image: 'ghcr.io/zitadel/zitadel:latest'
+    image: 'ghcr.io/zitadel/zitadel:v4.16.0'
     command: 'start-from-init --masterkey "${ZITADEL_MASTERKEY}" --tlsMode disabled'
     environment:
       # Database Configuration
@@ -17,15 +15,15 @@ services:
       ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD: "${POSTGRES_PASSWORD}"
       ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE: disable
 
-      # External Configuration for HTTP only - TLS mode disabled
-      ZITADEL_EXTERNALSECURE: false
-      ZITADEL_EXTERNALPORT: 8080
-      ZITADEL_EXTERNALDOMAIN: "${EXTERNAL_DOMAIN}"
+      # External access configuration. These MUST match the domain configured
+      # in the Domains tab and the scheme/port it is served on, otherwise
+      # Zitadel answers {"code":5,"message":"Not Found"}.
+      # HTTP  -> ZITADEL_EXTERNALPORT=80,  ZITADEL_EXTERNALSECURE=false
+      # HTTPS -> ZITADEL_EXTERNALPORT=443, ZITADEL_EXTERNALSECURE=true
+      ZITADEL_EXTERNALDOMAIN: "${ZITADEL_EXTERNALDOMAIN}"
+      ZITADEL_EXTERNALPORT: "${ZITADEL_EXTERNALPORT}"
+      ZITADEL_EXTERNALSECURE: "${ZITADEL_EXTERNALSECURE}"
       ZITADEL_TLS_ENABLED: false
-
-      # Disable Email Notifications
-      ZITADEL_NOTIFICATIONS_SMTP_HOST: ""
-      ZITADEL_NOTIFICATIONS_SMTP_PORT: ""
 
       # Custom Admin User Configuration
       ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME: "${ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME}"
@@ -33,17 +31,21 @@ services:
       ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_ADDRESS: "${ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_ADDRESS}"
       ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME: "${ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME}"
       ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME: "${ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME}"
-      
-      # Default Instance Features
+
+      # Use the login UI built into the API container (no extra login-v2 service needed)
       ZITADEL_DEFAULTINSTANCE_FEATURES_LOGINV2_REQUIRED: false
 
+    healthcheck:
+      test: ["CMD", "/app/zitadel", "ready"]
+      interval: '10s'
+      timeout: '30s'
+      retries: 12
+      start_period: '30s'
     depends_on:
       db:
         condition: 'service_healthy'
-    ports:
-      - '8080'
-    volumes:
-      - zitadel_data:/app/data
+    expose:
+      - 8080
 
   db:
     restart: 'always'
@@ -63,4 +65,3 @@ services:
 
 volumes:
   postgres_data:
-  zitadel_data:

--- a/blueprints/zitadel/meta.json
+++ b/blueprints/zitadel/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "zitadel",
   "name": "Zitadel",
-  "version": "latest",
+  "version": "4.16.0",
   "description": "Open-source identity and access management platform with multi-tenancy, OpenID Connect, SAML, and OAuth 2.0 support.",
   "logo": "zitadel.png",
   "links": {

--- a/blueprints/zitadel/template.toml
+++ b/blueprints/zitadel/template.toml
@@ -7,6 +7,8 @@ admin_email = "${email}"
 admin_password = "AdminPassword123!"
 
 [config]
+mounts = []
+
 [[config.domains]]
 serviceName = "zitadel"
 port = 8080
@@ -16,7 +18,15 @@ path = "/"
 [config.env]
 POSTGRES_PASSWORD = "${postgres_password}"
 ZITADEL_MASTERKEY = "${zitadel_masterkey}"
-EXTERNAL_DOMAIN = "${main_domain}"
+
+# ZITADEL_EXTERNALDOMAIN must always match the domain configured in the
+# Domains tab. If you change the domain, update this variable too (and do it
+# BEFORE the first deploy — Zitadel binds its instance to this domain on
+# first start). For a domain served over HTTPS set ZITADEL_EXTERNALPORT=443
+# and ZITADEL_EXTERNALSECURE=true.
+ZITADEL_EXTERNALDOMAIN = "${main_domain}"
+ZITADEL_EXTERNALPORT = "80"
+ZITADEL_EXTERNALSECURE = "false"
 
 # Custom Admin User Configuration
 ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME = "${admin_username}"
@@ -24,5 +34,3 @@ ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD = "${admin_password}"
 ZITADEL_FIRSTINSTANCE_ORG_HUMAN_EMAIL_ADDRESS = "${admin_email}"
 ZITADEL_FIRSTINSTANCE_ORG_HUMAN_FIRSTNAME = "Admin"
 ZITADEL_FIRSTINSTANCE_ORG_HUMAN_LASTNAME = "User"
-
-[[config.mounts]]


### PR DESCRIPTION
## Problem
Deploying the Zitadel template and opening it on the configured domain ended in `{"code":5,"message":"Not Found"}` (#516). Zitadel resolves its virtual instance and builds every URL (OIDC issuer, console environment, login redirects) from `ZITADEL_EXTERNALDOMAIN` + `ZITADEL_EXTERNALPORT` + `ZITADEL_EXTERNALSECURE`. The template hardcoded `ZITADEL_EXTERNALPORT: 8080` (the internal container port), so all generated URLs pointed at `http://<domain>:8080` instead of the domain/port actually served by Traefik.

## Fix
- Expose `ZITADEL_EXTERNALDOMAIN`, `ZITADEL_EXTERNALPORT` and `ZITADEL_EXTERNALSECURE` as template env vars, defaulting to the generated domain over HTTP (`80` / `false`), matching the [official compose reference](https://zitadel.com/docs/self-hosting/deploy/compose). The domain in the Domains tab and `ZITADEL_EXTERNALDOMAIN` are both derived from `${main_domain}`, so they always match on first deploy. Users on HTTPS or a custom domain can flip the clearly named vars in the Env tab (comments in the compose/toml explain this, and that it must happen before the first deploy since Zitadel binds the instance to the domain on first start).
- Pin the image to `v4.16.0` (was `latest`) and keep the built-in login v1 (`ZITADEL_DEFAULTINSTANCE_FEATURES_LOGINV2_REQUIRED: false`) so no separate login-v2 container is required.
- Add the official readiness healthcheck (`/app/zitadel ready`), remove the unused `/app/data` volume, the bogus empty SMTP env keys, the published random host port and the obsolete `version:` key.

## Evidence (deployed on a Dokploy instance)
- Deploy: `done`, container healthy.
- `http://<generated-domain>/` → `302 /ui/login` → **HTTP 200 «ZITADEL • Management Console»**
- `http://<generated-domain>/debug/healthz` → `200`
- OIDC discovery issuer now exactly matches the routed domain (previously carried `:8080`):
  ```json
  {"issuer":"http://compose-...-31-220-108-27.sslip.io","authorization_endpoint":"http://compose-...-31-220-108-27.sslip.io/oauth/v2/authorize", ...}
  ```

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)