### PR TITLE
fix(automatisch): switch to official image and wire up DOMAIN to fix Bad Gateway

### DIFF
--- a/blueprints/automatisch/docker-compose.yml
+++ b/blueprints/automatisch/docker-compose.yml
@@ -1,17 +1,15 @@
-version: "3.8"
 services:
   automatisch:
-    image: dockeriddonuts/automatisch:2.0
+    image: automatischio/automatisch:0.15.0
     restart: unless-stopped
-    ports:
-      - 3000
     environment:
       - HOST=${DOMAIN}
       - PROTOCOL=http
       - PORT=3000
+      - API_URL=http://${DOMAIN}
+      - WEB_APP_URL=http://${DOMAIN}
       - APP_ENV=production
       - REDIS_HOST=automatisch-redis
-      - REDIS_USERNAME=default
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - POSTGRES_HOST=automatisch-postgres
       - POSTGRES_DATABASE=automatisch
@@ -23,11 +21,13 @@ services:
     volumes:
       - storage:/automatisch/storage
     depends_on:
-      - automatisch-postgres
-      - automatisch-redis
+      automatisch-postgres:
+        condition: service_healthy
+      automatisch-redis:
+        condition: service_started
 
   automatisch-worker:
-    image: dockeriddonuts/automatisch:2.0
+    image: automatischio/automatisch:0.15.0
     restart: unless-stopped
     environment:
       - APP_ENV=production
@@ -44,8 +44,7 @@ services:
     volumes:
       - storage:/automatisch/storage
     depends_on:
-      - automatisch-postgres
-      - automatisch-redis
+      - automatisch
 
   automatisch-postgres:
     image: postgres:15-alpine
@@ -56,18 +55,20 @@ services:
       - POSTGRES_DB=automatisch
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d automatisch"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   automatisch-redis:
     image: redis:7-alpine
     restart: unless-stopped
     command: redis-server --requirepass ${REDIS_PASSWORD}
-    environment:
-      - REDIS_USERNAME=default
-      - REDIS_PASSWORD=${REDIS_PASSWORD}
     volumes:
       - redis_data:/data
 
 volumes:
   storage: {}
   postgres_data: {}
-  redis_data: {} 
+  redis_data: {}

--- a/blueprints/automatisch/meta.json
+++ b/blueprints/automatisch/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "automatisch",
   "name": "Automatisch",
-  "version": "2.0",
+  "version": "0.15.0",
   "description": "Automatisch is a powerful, self-hosted workflow automation tool designed for connecting your apps and automating repetitive tasks. With Automatisch, you can create workflows to sync data, send notifications, and perform various actions seamlessly across different services.",
   "logo": "logo.png",
   "links": {

--- a/blueprints/automatisch/template.toml
+++ b/blueprints/automatisch/template.toml
@@ -13,6 +13,7 @@ port = 3000
 host = "${main_domain}"
 
 [config.env]
+DOMAIN = "${main_domain}"
 DB_PASSWORD = "${db_password}"
 REDIS_PASSWORD = "${redis_password}"
 ENCRYPTION_KEY = "${encryption_key}"


### PR DESCRIPTION
## Problem

Issue #97 reports a persistent "Bad gateway" when opening the URL after deploying the base Automatisch template.

The original trigger (app listening on 443 while the domain targeted 3000) was patched in #470, but the template still had several defects that break or degrade fresh deploys:

- **Unofficial, stale image**: `dockeriddonuts/automatisch:2.0` is a third-party mirror last pushed in Nov 2024 (Automatisch has no 2.x release — the tag is arbitrary). The official image is `automatischio/automatisch`, currently `0.15.0`.
- **`${DOMAIN}` was never defined**: the compose references `${DOMAIN}` for `HOST`, but `template.toml` never provided it, so it resolved empty and the app generated `http://localhost:3000` URLs for the web app and webhooks.
- **Internal port leaked into generated URLs**: Automatisch builds its base URL as `${PROTOCOL}://${HOST}:${PORT}`, so even with a domain it produced `http://<domain>:3000` links behind Traefik.
- **Migration race**: the app runs `knex migrate` at boot but only had a bare `depends_on`, so on slower servers it could hit Postgres before it accepts connections and crash-loop (which surfaces as Bad Gateway).

## Fix

- Switch main + worker to the official `automatischio/automatisch:0.15.0` image.
- Add `DOMAIN = "${main_domain}"` to `[config.env]` and set `API_URL`/`WEB_APP_URL` to `http://${DOMAIN}` so generated URLs are correct behind the proxy.
- Add a `pg_isready` healthcheck on Postgres and gate the app on `service_healthy`; the worker now starts after the main service (same ordering as the official compose).
- Remove the published port (Traefik routes via the Dokploy network) and the no-op `REDIS_*` env vars on the Redis service.
- Bump `meta.json` version to `0.15.0`.

## Verification

Deployed on a Dokploy instance via template import:

- Deploy finished with status `done` in 133s.
- All 4 containers (`automatisch`, `automatisch-worker`, `automatisch-postgres`, `automatisch-redis`) running.
- Generated domain responds `HTTP 200` and serves the Automatisch web app (no more Bad Gateway).

Also verified with plain `docker compose up` locally: migrations run, seed user created, server listens on 3000 and answers `HTTP 200` from inside the network.

`node build-scripts/generate-meta.js --check` passes (476 templates validated).

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
