### PR TITLE
fix(signoz): fix ClickHouse hostname resolution and IPv6 binding

### DIFF
--- a/blueprints/signoz/docker-compose.yml
+++ b/blueprints/signoz/docker-compose.yml
@@ -1,6 +1,4 @@
 x-common: &common
-  networks:
-    - signoz-net
   restart: unless-stopped
   logging:
     options:
@@ -89,11 +87,12 @@ services:
       - ZOO_PROMETHEUS_METRICS_PORT_NUMBER=9141
   clickhouse:
     !!merge <<: *clickhouse-defaults
-    container_name: signoz-clickhouse
+    hostname: clickhouse
     volumes:
       - ../files/clickhouse/config.xml:/etc/clickhouse-server/config.xml
       - ../files/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/
       - ../files/clickhouse/cluster.xml:/etc/clickhouse-server/config.d/cluster.xml
+      - ../files/clickhouse/docker_related_config.xml:/etc/clickhouse-server/config.d/docker_related_config.xml
       - clickhouse:/var/lib/clickhouse/
   signoz:
     !!merge <<: *db-depend
@@ -156,9 +155,6 @@ services:
       - --dsn=tcp://clickhouse:9000
       - --up=
     restart: on-failure
-networks:
-  signoz-net:
-    name: signoz-net
 volumes:
   clickhouse:
     name: signoz-clickhouse

--- a/blueprints/signoz/template.toml
+++ b/blueprints/signoz/template.toml
@@ -1,5 +1,6 @@
 [variables]
 main_domain = "${domain}"
+otel_domain = "${domain}"
 jwt_secret = "${password:64}"
 
 [config]
@@ -12,7 +13,7 @@ path = "/"
 [[config.domains]]
 serviceName = "otel-collector"
 port = 4318
-host = "${main_domain}"
+host = "${otel_domain}"
 path = "/"
 
 [config.env]
@@ -1246,7 +1247,23 @@ content = """
 """
 
 [[config.mounts]]
-filePath = "/signoz/prometheus.xml"
+filePath = "/clickhouse/docker_related_config.xml"
+content = """
+<?xml version="1.0"?>
+<clickhouse>
+    <!-- Overrides the docker image's default config.d/docker_related_config.xml,
+         which listens on the IPv6 wildcard address ([::]) first. On hosts without
+         IPv6 support the bind fails, so listen on IPv4 only. -->
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+    <!-- Container IPs can change and DNS records (zookeeper-1, clickhouse) may not
+         be ready the moment ClickHouse starts. Do not cache DNS lookup failures. -->
+    <disable_internal_dns_cache>1</disable_internal_dns_cache>
+</clickhouse>
+"""
+
+[[config.mounts]]
+filePath = "/signoz/prometheus.yml"
 content = """
 # my global config
 global:


### PR DESCRIPTION
## Problem

Deploying the SigNoz template on Dokploy fails with ClickHouse errors (#534):

- **DNS resolution**: `Cannot use ZooKeeper host zookeeper-1:2181 due to DNS error: Temporary DNS error while resolving: zookeeper-1`, and the server cannot resolve the cluster host `clickhouse` as itself.
- **IPv6 binding**: the `clickhouse/clickhouse-server` image ships `config.d/docker_related_config.xml` with `<listen_host>::</listen_host>` first, which fails to bind on hosts without IPv6 support (common on VPSes with IPv6 disabled).

While fixing this, two more template bugs surfaced:

- `template.toml` created `files/signoz/prometheus.xml` but the compose mounts `../files/signoz/prometheus.yml`, so Docker silently created and mounted a **directory** as the signoz prometheus config.
- Both `[[config.domains]]` entries shared the same host and path `/`, creating two conflicting Traefik routers (signoz UI vs otel-collector) where one randomly won.

## Fix

- Mount a template-owned `docker_related_config.xml` over the image default: listen on `0.0.0.0` (IPv4) only, keep `listen_try`, and set `disable_internal_dns_cache=1` so ClickHouse does not cache transient startup DNS failures for `zookeeper-1`/`clickhouse`.
- Set `hostname: clickhouse` (replacing `container_name: signoz-clickhouse`) so the server identifies itself as the cluster host declared in `cluster.xml`, and a fixed container name cannot conflict across deployments.
- Remove the explicit fixed-name `signoz-net` network (the repo validator rejects explicit networks; Dokploy wires networks automatically, and a fixed shared network name breaks DNS across deployments).
- Fix the prometheus mount to `/signoz/prometheus.yml`.
- Give the otel-collector domain its own generated host (`otel_domain`), matching the convention used by other multi-domain templates.

## Verification (deployed on a Dokploy instance)

- Deploy finished `done` in 228s; all one-shot containers (`init-clickhouse`, `schema-migrator-sync`, `schema-migrator-async`) exited `0` — the sync migrator runs distributed DDL `ON CLUSTER` through ZooKeeper, which is exactly the path that failed in #534.
- ClickHouse container: `running` / `healthy`, `RestartCount: 0`; log tail contains **0** DNS-error lines and **0** IPv6/bind-error lines.
- SigNoz UI domain: `HTTP 200` — "Open source Observability platform | SigNoz".
- OTLP domain (otel-collector:4318): `POST /v1/traces` and `POST /v1/logs` return `HTTP 200 {"partialSuccess":{}}`; `GET /v1/traces` returns `405 method not allowed, supported: [POST]` (the receiver answering). Note: `GET /` on an OTLP HTTP receiver always returns its own `404 page not found` — that is expected receiver behavior, not a routing failure.
- `node build-scripts/generate-meta.js --check`: 476 templates validated; `validate-template` and `validate-docker-compose` pass for signoz.

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)