### PR TITLE
fix(infisical): update to v0.162.6

### DIFF
--- a/blueprints/infisical/docker-compose.yml
+++ b/blueprints/infisical/docker-compose.yml
@@ -1,58 +1,29 @@
 services:
-  db-migration:
-    depends_on:
-      db:
-        condition: service_healthy
-    image: infisical/infisical:v0.135.0-postgres
-    environment:
-      - NODE_ENV=production
-      - ENCRYPTION_KEY
-      - AUTH_SECRET
-      - SITE_URL
-      - DB_CONNECTION_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
-      - REDIS_URL=redis://redis:6379
-      - SMTP_HOST
-      - SMTP_PORT
-      - SMTP_FROM_NAME
-      - SMTP_USERNAME
-      - SMTP_PASSWORD
-      - SMTP_SECURE=true
-    command: npm run migration:latest
-    pull_policy: always
-
   backend:
+    image: infisical/infisical:v0.162.6
     restart: unless-stopped
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_started
-      db-migration:
-        condition: service_completed_successfully
-    image: infisical/infisical:v0.135.0-postgres
-    pull_policy: always
     environment:
       - NODE_ENV=production
-      - ENCRYPTION_KEY
-      - AUTH_SECRET
-      - SITE_URL
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - AUTH_SECRET=${AUTH_SECRET}
+      - SITE_URL=${SITE_URL}
       - DB_CONNECTION_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       - REDIS_URL=redis://redis:6379
-      - SMTP_HOST
-      - SMTP_PORT
-      - SMTP_FROM_NAME
-      - SMTP_USERNAME
-      - SMTP_PASSWORD
-      - SMTP_SECURE=true
-
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_FROM_ADDRESS=${SMTP_FROM_ADDRESS}
+      - SMTP_FROM_NAME=${SMTP_FROM_NAME}
+      - SMTP_USERNAME=${SMTP_USERNAME}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}
 
   redis:
     image: redis:7.4.1
-    env_file: .env
     restart: always
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-
     volumes:
       - redis_infisical_data:/data
 
@@ -60,12 +31,11 @@ services:
     image: postgres:14-alpine
     restart: always
     environment:
-      - POSTGRES_PASSWORD
-      - POSTGRES_USER
-      - POSTGRES_DB
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB}
     volumes:
       - pg_infisical_data:/var/lib/postgresql/data
-
     healthcheck:
       test: "pg_isready --username=${POSTGRES_USER} && psql --username=${POSTGRES_USER} --list"
       interval: 5s
@@ -75,6 +45,3 @@ services:
 volumes:
   pg_infisical_data:
   redis_infisical_data:
-
-
-

--- a/blueprints/infisical/meta.json
+++ b/blueprints/infisical/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "infisical",
   "name": "Infisical",
-  "version": "0.135.0",
+  "version": "0.162.6",
   "description": "All-in-one platform to securely manage application configuration and secrets across your team and infrastructure.",
   "logo": "infisical.jpg",
   "links": {

--- a/blueprints/infisical/template.toml
+++ b/blueprints/infisical/template.toml
@@ -3,56 +3,27 @@ main_domain = "${domain}"
 postgres_password = "${password}"
 postgres_user = "infisical"
 postgres_db = "infisical"
+encryption_key = "${hash:32}"
+auth_secret = "${base64:32}"
 
 [config]
 env = [
-  "ENCRYPTION_KEY=6c1fe4e407b8911c104518103505b218",
-  "AUTH_SECRET=5lrMXKKWCVocS/uerPsl7V+TX/aaUaI7iDkgl3tSmLE=",
+  "ENCRYPTION_KEY=${encryption_key}",
+  "AUTH_SECRET=${auth_secret}",
   "POSTGRES_PASSWORD=${postgres_password}",
   "POSTGRES_USER=${postgres_user}",
   "POSTGRES_DB=${postgres_db}",
-  "SITE_URL=http://${main_domain}:8080",
+  "SITE_URL=http://${main_domain}",
   "SMTP_HOST=",
-  "SMTP_PORT=",
-  "SMTP_NAME=",
+  "SMTP_PORT=587",
+  "SMTP_FROM_ADDRESS=",
+  "SMTP_FROM_NAME=Infisical",
   "SMTP_USERNAME=",
   "SMTP_PASSWORD=",
-  "CLIENT_ID_HEROKU=",
-  "CLIENT_ID_VERCEL=",
-  "CLIENT_ID_NETLIFY=",
-  "CLIENT_ID_GITHUB=",
-  "CLIENT_ID_GITHUB_APP=",
-  "CLIENT_SLUG_GITHUB_APP=",
-  "CLIENT_ID_GITLAB=",
-  "CLIENT_ID_BITBUCKET=",
-  "CLIENT_SECRET_HEROKU=",
-  "CLIENT_SECRET_VERCEL=",
-  "CLIENT_SECRET_NETLIFY=",
-  "CLIENT_SECRET_GITHUB=",
-  "CLIENT_SECRET_GITHUB_APP=",
-  "CLIENT_SECRET_GITLAB=",
-  "CLIENT_SECRET_BITBUCKET=",
-  "CLIENT_SLUG_VERCEL=",
-  "CLIENT_PRIVATE_KEY_GITHUB_APP=",
-  "CLIENT_APP_ID_GITHUB_APP=",
-  "SENTRY_DSN=",
-  "POSTHOG_HOST=",
-  "POSTHOG_PROJECT_API_KEY=",
-  "CLIENT_ID_GOOGLE_LOGIN=",
-  "CLIENT_SECRET_GOOGLE_LOGIN=",
-  "CLIENT_ID_GITHUB_LOGIN=",
-  "CLIENT_SECRET_GITHUB_LOGIN=",
-  "CLIENT_ID_GITLAB_LOGIN=",
-  "CLIENT_SECRET_GITLAB_LOGIN=",
-  "CAPTCHA_SECRET=",
-  "NEXT_PUBLIC_CAPTCHA_SITE_KEY=",
-  "PLAIN_API_KEY=",
-  "PLAIN_WISH_LABEL_IDS=",
-  "SSL_CLIENT_CERTIFICATE_HEADER_KEY=",
 ]
 mounts = []
 
 [[config.domains]]
 serviceName = "backend"
-port = 8_080
+port = 8080
 host = "${main_domain}"


### PR DESCRIPTION
## Summary

Updates the Infisical template from `v0.135.0-postgres` to **`v0.162.6`** (latest stable as of 2026-07-14).

### Changes

- **Image bump**: `infisical/infisical:v0.135.0-postgres` → `infisical/infisical:v0.162.6`. Upstream stopped publishing the `-postgres` tag suffix after `v0.146.0` — plain `vX.Y.Z` tags are now the (only) Postgres-backed standalone build.
- **Removed the `db-migration` service**: since the standalone image gained `auto-start-migrations`, the backend runs `migration:latest` automatically on boot (guarded by a Postgres advisory lock). This matches the current official [`docker-compose.prod.yml`](https://github.com/Infisical/infisical/blob/main/docker-compose.prod.yml), which no longer ships a migration service.
- **Per-deployment secrets**: `ENCRYPTION_KEY` is now generated via `${hash:32}` (random 16-byte hex, as required by upstream) and `AUTH_SECRET` via `${base64:32}`, instead of the hardcoded example values from upstream's `.env.example` that every deployment shared.
- **Fixed `SITE_URL`**: `http://${main_domain}` instead of `http://${main_domain}:8080` — the domain is proxied by Traefik on port 80, so the `:8080` suffix produced wrong absolute URLs (email links, OAuth redirects).
- **Refreshed SMTP env**: added `SMTP_FROM_ADDRESS`, fixed `SMTP_FROM_NAME` (the toml previously set a nonexistent `SMTP_NAME`), and dropped `SMTP_SECURE` (removed upstream in favor of `SMTP_REQUIRE_TLS`/`SMTP_IGNORE_TLS` defaults).
- **Cleanup**: removed the ~30 empty `CLIENT_*`/`POSTHOG_*`/`CAPTCHA_*` env placeholders from `template.toml` — they were never passed to the container (the compose `environment:` list doesn't include them), so this is a no-op functionally. Also removed `pull_policy: always` (tag is pinned) and the stray `env_file`/`ALLOW_EMPTY_PASSWORD` on redis.

### Migration notes

- Volume names (`pg_infisical_data`, `redis_infisical_data`) and Postgres 14 are unchanged, so existing deployments that re-apply the compose keep their data; on first boot of the new image the backend migrates the DB schema automatically.
- Existing deployments keep their env (Dokploy templates only seed env at creation), so the new generated secrets only affect fresh installs. **Do not** change `ENCRYPTION_KEY`/`AUTH_SECRET` on an existing install.

### Verification (deployed on hostinger.dokploy.com)

- Deploy status: `done` in 103s, migrations auto-ran on boot
- `GET /` → HTTP 200, Infisical frontend served through the generated domain
- `GET /api/status` → `{"message":"Ok","redisConfigured":true,...}`
- `GET /api/v1/admin/config` → `{"initialized":false,"allowSignUp":true,...}` and `/admin/signup` → 200 (fresh instance is bootstrappable)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
