### PR TITLE
fix(evolutionapi): enable integration env flags (n8n/openai/evoai) and update

### DIFF
--- a/blueprints/evolutionapi/docker-compose.yml
+++ b/blueprints/evolutionapi/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   evolution-api:
-    image: evoapicloud/evolution-api:latest
+    image: evoapicloud/evolution-api:v2.3.7
     restart: always
     volumes:
       - evolution-instances:/evolution/instances
@@ -29,6 +29,13 @@ services:
       - CACHE_REDIS_URI=${CACHE_REDIS_URI}
       - CACHE_REDIS_PREFIX_KEY=${CACHE_REDIS_PREFIX_KEY}
       - CACHE_REDIS_SAVE_INSTANCES=${CACHE_REDIS_SAVE_INSTANCES}
+      - TYPEBOT_ENABLED=${TYPEBOT_ENABLED}
+      - TYPEBOT_API_VERSION=${TYPEBOT_API_VERSION}
+      - CHATWOOT_ENABLED=${CHATWOOT_ENABLED}
+      - OPENAI_ENABLED=${OPENAI_ENABLED}
+      - DIFY_ENABLED=${DIFY_ENABLED}
+      - N8N_ENABLED=${N8N_ENABLED}
+      - EVOAI_ENABLED=${EVOAI_ENABLED}
 
   evolution-postgres:
     image: postgres:16-alpine

--- a/blueprints/evolutionapi/meta.json
+++ b/blueprints/evolutionapi/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "evolutionapi",
   "name": "Evolution API",
-  "version": "v2.1.2",
+  "version": "v2.3.7",
   "description": "Evolution API is a robust platform dedicated to empowering small businesses with limited resources, going beyond a simple messaging solution via WhatsApp.",
   "logo": "evolutionapi.png",
   "links": {

--- a/blueprints/evolutionapi/template.toml
+++ b/blueprints/evolutionapi/template.toml
@@ -31,6 +31,13 @@ env = [
   "CACHE_REDIS_URI=redis://evolution-redis:6379",
   "CACHE_REDIS_PREFIX_KEY=evolution",
   "CACHE_REDIS_SAVE_INSTANCES=true",
+  "TYPEBOT_ENABLED=true",
+  "TYPEBOT_API_VERSION=latest",
+  "CHATWOOT_ENABLED=true",
+  "OPENAI_ENABLED=true",
+  "DIFY_ENABLED=true",
+  "N8N_ENABLED=true",
+  "EVOAI_ENABLED=true",
 ]
 mounts = []
 


### PR DESCRIPTION
## Problem

After Evolution API v2.3.x, integrations (n8n, OpenAI, EvoAI, Dify) must be explicitly enabled via environment variables. The template did not set any of these flags, so every attempt to configure an integration failed with errors like **\`Error: N8n is disabled\`** (#430).

The template was also pulling \`evoapicloud/evolution-api:latest\` (unpinned) while \`meta.json\` still claimed \`v2.1.2\`.

## Changes

- **template.toml / docker-compose.yml**: add the integration enable flags introduced in Evolution API v2.3.x, defaulting to \`true\` and exposed as template env vars so users can toggle them:
  - \`N8N_ENABLED\`, \`OPENAI_ENABLED\`, \`EVOAI_ENABLED\`, \`DIFY_ENABLED\`, \`TYPEBOT_ENABLED\` (+ \`TYPEBOT_API_VERSION\`), \`CHATWOOT_ENABLED\`
- **docker-compose.yml**: pin image to \`evoapicloud/evolution-api:v2.3.7\` (latest stable release of the now-canonical \`evolution-foundation/evolution-api\` repo; 2.4.0 is still RC)
- **meta.json**: bump version \`v2.1.2\` → \`v2.3.7\`

## Verification (deployed on demo instance)

- \`GET /\` → \`{"status":200,"message":"Welcome to the Evolution API, it is working!","version":"2.3.7",...}\`
- Created a test instance, then \`GET /n8n/find/:instance\`, \`/openai/find\`, \`/evoai/find\`, \`/dify/find\` → all return \`200 []\` instead of the "disabled" error
- \`POST /n8n/create/:instance\` (the exact flow from the issue screenshot) → **201, bot created successfully**
- \`node build-scripts/generate-meta.js --check\` → 476 templates validated

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)