### PR TITLE
fix(rybbit): update to current version (v2.7.0)

### DIFF
--- a/blueprints/rybbit/docker-compose.yml
+++ b/blueprints/rybbit/docker-compose.yml
@@ -1,13 +1,13 @@
 # https://www.rybbit.io/docs/self-hosting-advanced
 
 # NOTE: there are two sample HTTP traefik domain entries created:
-# - rybbit_backend (port 3001, path /api), 
+# - rybbit_backend (port 3001, path /api),
 # - rybbit_client (port 3002, path /)
 #
 # You should treat these as placeholders - Rybbit only supports HTTPS.
 #
-# You should also update the `BASE_URL`, and `DOMAIN_NAME` environment
-# variable when updating the domain entries with your custom domain.
+# You should also update the `BASE_URL` environment variable when
+# updating the domain entries with your custom domain.
 
 services:
   rybbit_clickhouse:
@@ -50,8 +50,41 @@ services:
       retries: 3
     restart: unless-stopped
 
+  rybbit_redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    # Backs session tracking and the BullMQ queues. noeviction is required by
+    # BullMQ (evicting job keys corrupts queues); AOF (everysec) keeps queues
+    # durable across restarts.
+    command:
+      - redis-server
+      - --requirepass
+      - ${REDIS_PASSWORD}
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --maxmemory-policy
+      - noeviction
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "redis-cli",
+          "-a",
+          "${REDIS_PASSWORD}",
+          "--no-auth-warning",
+          "ping",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
   rybbit_backend:
-    image: ghcr.io/rybbit-io/rybbit-backend:v1.5.1
+    image: ghcr.io/rybbit-io/rybbit-backend:v2.7.0
     environment:
       - NODE_ENV=production
       - CLICKHOUSE_HOST=http://rybbit_clickhouse:8123
@@ -63,15 +96,20 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - REDIS_HOST=rybbit_redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
       - BASE_URL=${BASE_URL}
-      - DOMAIN_NAME=${DOMAIN_NAME}
       - DISABLE_SIGNUP=${DISABLE_SIGNUP}
+      - DISABLE_TELEMETRY=${DISABLE_TELEMETRY}
     depends_on:
       rybbit_clickhouse:
         condition: service_healthy
       rybbit_postgres:
         condition: service_started
+      rybbit_redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3001/api/health"]
       interval: 30s
@@ -81,11 +119,10 @@ services:
     restart: unless-stopped
 
   rybbit_client:
-    image: ghcr.io/rybbit-io/rybbit-client:v1.5.1
+    image: ghcr.io/rybbit-io/rybbit-client:v2.7.0
     environment:
       - NODE_ENV=production
       - NEXT_PUBLIC_BACKEND_URL=${BASE_URL}
-      - DOMAIN_NAME=${DOMAIN_NAME}
       - NEXT_PUBLIC_DISABLE_SIGNUP=${DISABLE_SIGNUP}
     depends_on:
       - rybbit_backend
@@ -94,3 +131,4 @@ services:
 volumes:
   clickhouse_data:
   postgres_data:
+  redis_data:

--- a/blueprints/rybbit/meta.json
+++ b/blueprints/rybbit/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "rybbit",
   "name": "Rybbit",
-  "version": "v1.5.1",
+  "version": "v2.7.0",
   "description": "Open-source and privacy-friendly alternative to Google Analytics that is 10x more intuitive",
   "logo": "rybbit.png",
   "links": {

--- a/blueprints/rybbit/template.toml
+++ b/blueprints/rybbit/template.toml
@@ -1,8 +1,9 @@
 [variables]
 main_domain = "${domain}"
-better_auth_secret = "${password:32}"
+better_auth_secret = "${base64:32}"
 clickhouse_password = "${password:32}"
 postgres_password = "${password:32}"
+redis_password = "${password:32}"
 
 [[config.domains]]
 serviceName = "rybbit_backend"
@@ -17,15 +18,16 @@ host = "${main_domain}"
 
 [config.env]
 BASE_URL = "http://${main_domain}"
-DOMAIN_NAME= "${main_domain}"
 BETTER_AUTH_SECRET = "${better_auth_secret}"
 DISABLE_SIGNUP = "false"
+DISABLE_TELEMETRY = "false"
 CLICKHOUSE_DB = "analytics"
 CLICKHOUSE_USER = "default"
 CLICKHOUSE_PASSWORD = "${clickhouse_password}"
 POSTGRES_DB = "analytics"
 POSTGRES_USER = "frog"
 POSTGRES_PASSWORD = "${postgres_password}"
+REDIS_PASSWORD = "${redis_password}"
 
 [[config.mounts]]
 filePath = "./clickhouse_config/enable_json.xml"


### PR DESCRIPTION
## Summary

The rybbit template was pinned to **v1.5.1**, which is no longer supported and is vulnerable to known React2Shell exploits — the "unexpected activity" reported in the client containers in #659. This updates the template to the latest stable upstream release, **v2.7.0** (2026-07-07), and aligns the stack with the current official docker-compose:

- Pin `ghcr.io/rybbit-io/rybbit-backend` and `ghcr.io/rybbit-io/rybbit-client` to `v2.7.0` (kept pinned rather than `latest`, per repo convention; both tags verified on ghcr).
- Add the **redis** service now required by the backend (session tracking and BullMQ queues), configured per upstream: password auth, AOF `everysec` persistence, `noeviction` policy, healthcheck, and a dedicated `redis_data` volume. Backend now depends on redis being healthy.
- Drop `DOMAIN_NAME` from backend/client env — in v2.x it is only consumed by the upstream Caddy webserver, which Dokploy replaces with Traefik.
- Add `DISABLE_TELEMETRY` (default `false`) and generate `BETTER_AUTH_SECRET` with the `base64` generator.
- ClickHouse config mounts, domains (backend `:3001` at `/api`, client `:3002` at `/`) and DB credentials unchanged.

## Test evidence (deployed on a Dokploy instance)

- Deploy: `done` in 62s, logs show `Image ghcr.io/rybbit-io/rybbit-backend:v2.7.0 Pulling` / `rybbit-client:v2.7.0 Pulling`.
- `GET /api/health` → `200 OK` (backend up, connected to postgres/clickhouse/redis).
- `GET /` → `200`, Rybbit client renders (Next.js app).
- `GET /signup` → `200`.
- `GET /api/script.js` → `200` (31.9 KB tracking script served through the `/api` domain route).
- `node build-scripts/generate-meta.js --check` → 476 templates validated.

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)