### PR TITLE
fix(phpmyadmin): raise PHP upload limit so SQL imports over 2MB work

### DIFF
--- a/blueprints/phpmyadmin/docker-compose.yml
+++ b/blueprints/phpmyadmin/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: tu_base_de_datos
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     volumes:
@@ -19,6 +19,8 @@ services:
       PMA_USER: ${MYSQL_USER}
       PMA_PASSWORD: ${MYSQL_PASSWORD}
       PMA_ARBITRARY: 1
+      UPLOAD_LIMIT: ${UPLOAD_LIMIT}
+      MAX_EXECUTION_TIME: ${MAX_EXECUTION_TIME}
     depends_on:
       - db
 

--- a/blueprints/phpmyadmin/template.toml
+++ b/blueprints/phpmyadmin/template.toml
@@ -13,6 +13,8 @@ host = "${main_domain}"
 
 [config.env]
 MYSQL_ROOT_PASSWORD = "${root_password}"
-MYSQL_DATABASE = "mysql"
+MYSQL_DATABASE = "phpmyadmin"
 MYSQL_USER = "phpmyadmin"
 MYSQL_PASSWORD = "${user_password}"
+UPLOAD_LIMIT = "512M"
+MAX_EXECUTION_TIME = "600"


### PR DESCRIPTION
## Problem

Issue #236 reports the phpmyadmin template failing with (screenshots in the issue):

```
Warning: POST Content-Length of 5412256 bytes exceeds the limit of 2097152 bytes in Unknown on line 0
phpMyAdmin - Error
session_start(): Session cannot be started after headers have already been sent
```

Root cause: the template does not set `UPLOAD_LIMIT`, so the official phpMyAdmin image keeps PHP's default `post_max_size` / `upload_max_filesize` of 2M (2097152 bytes). Any SQL import larger than 2MB is rejected by PHP before phpMyAdmin runs, and the emitted warning then breaks `session_start()`, producing the error page in the screenshots.

## Fix

- Add `UPLOAD_LIMIT` (default **512M**) and `MAX_EXECUTION_TIME` (default **600**) to the phpmyadmin service, both configurable from the template env so users can tune them from the Dokploy UI.
- Wire the previously unused `MYSQL_DATABASE` env var into the compose file, replacing the hardcoded `tu_base_de_datos` placeholder, and default it to `phpmyadmin` instead of the system `mysql` schema.

## Verification (deployed on a live Dokploy instance)

- Deploy: `done`; both containers running.
- `GET /` → HTTP 200, auto-login into the bundled MySQL works: `<title>... / db | phpMyAdmin 5.2.1</title>`.
- Reproduced the exact failing scenario from the issue: a **5,412,256-byte** multipart POST to `index.php?route=/import` now returns HTTP 200 with a normal phpMyAdmin page — no `exceeds the limit` warning and no `session_start` error.
- `node build-scripts/generate-meta.js --check` → 476 templates validated.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)