### PR TITLE
fix(openpanel): pin verified 2.2.1 images to prevent broken-release breakage

### DIFF
--- a/blueprints/openpanel/docker-compose.yml
+++ b/blueprints/openpanel/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       retries: 5
 
   op-api:
-    image: lindesvard/openpanel-api:2
+    image: lindesvard/openpanel-api:2.2.1
     restart: always
     command: >
       sh -c "
@@ -97,7 +97,7 @@ services:
         condition: service_healthy
 
   op-dashboard:
-    image: lindesvard/openpanel-dashboard:2
+    image: lindesvard/openpanel-dashboard:2.2.1
     restart: always
     depends_on:
       op-api:
@@ -111,7 +111,7 @@ services:
       retries: 5
 
   op-worker:
-    image: lindesvard/openpanel-worker:2
+    image: lindesvard/openpanel-worker:2.2.1
     restart: always
     depends_on:
       op-api:

--- a/blueprints/openpanel/meta.json
+++ b/blueprints/openpanel/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "openpanel",
   "name": "OpenPanel",
-  "version": "latest",
+  "version": "2.2.1",
   "description": "An open-source web and product analytics platform that combines the power of Mixpanel with the ease of Plausible and one of the best Google Analytics replacements.",
   "logo": "logo.svg",
   "links": {

--- a/blueprints/openpanel/template.toml
+++ b/blueprints/openpanel/template.toml
@@ -26,7 +26,7 @@ content = """
     <part_log remove="remove"/>
     <listen_host>0.0.0.0</listen_host>
     <interserver_listen_host>0.0.0.0</interserver_listen_host>
-    <interserver_http_host>opch</interserver_http_host>
+    <interserver_http_host>op-ch</interserver_http_host>
     <!-- Disable cgroup memory observer -->
     <cgroups_memory_usage_observer_wait_time>0</cgroups_memory_usage_observer_wait_time>
     <!-- Not used anymore, but kept for backwards compatibility -->


### PR DESCRIPTION
## What is this PR about?

Fixes the OpenPanel template reported broken in #615 ("It's error when use OpenPanel 2.0.0").

### Root cause

When #615 was filed (Dec 2025), the template had just been migrated to the freshly released `2.0.0` images (#594), which were broken/unstable at that point; the template later moved to the mutable `:2` tag (#680), which leaves it exposed to the same failure mode whenever upstream pushes a new 2.x release. The reporter's environment (CentOS 7, kernel 3.10, EOL) is also below what modern ClickHouse supports, which can independently cause the deploy-time error.

### Changes

- Pin `lindesvard/openpanel-api|dashboard|worker` to **2.2.1** (current upstream stable, released 2026-03-21) instead of the mutable `:2` tag, so a future broken 2.x release cannot silently break the template again.
- Fix ClickHouse `interserver_http_host` from `opch` to the actual service name `op-ch` (matches upstream self-hosting config).
- Set `meta.json` version to the pinned `2.2.1`.

### Verification (deployed on a Dokploy instance)

Fresh template deploy with the pinned images completes successfully:

- Deploy status: `done`, all 6 containers running with 0 restarts (op-db, op-kv, op-ch, op-api, op-dashboard, op-worker)
- `GET /` → 302 → `/login`, renders "Login | OpenPanel.dev"
- `GET /onboarding` → 200, renders "Create an account | Getting Started | OpenPanel.dev"
- `GET /api/healthcheck` → `{"ready":true,"redis":true,"db":true,"ch":true}` (Postgres migrations, Redis and ClickHouse init all OK)

For reference, the template was also re-deployed with `2.0.0` pinned (the version from the issue) on the same instance and it now deploys fine too — confirming the original failure came from the early 2.0.0 images / unsupported host OS rather than the template structure. `node build-scripts/generate-meta.js --check` passes (476 templates validated).

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)
