### PR TITLE
fix(wordpress): route loopback requests through Traefik to fix cURL error 28 timeouts

### DIFF
--- a/blueprints/wordpress/docker-compose.yml
+++ b/blueprints/wordpress/docker-compose.yml
@@ -1,6 +1,27 @@
 services:
   wordpress:
     image: wordpress:latest
+    # Resolve the site's own domain to the Traefik container instead of the
+    # server's public IP. Loopback requests (REST API, WP-Cron, Site Health)
+    # otherwise depend on hairpin NAT, which times out on many hosts
+    # (cURL error 28). See https://github.com/Dokploy/templates/issues/128
+    command:
+      - bash
+      - -c
+      - |
+        if [ -n "$$WP_DOMAIN" ]; then
+          (
+            for i in $$(seq 1 60); do
+              TRAEFIK_IP="$$(getent hosts dokploy-traefik | awk '{print $$1; exit}')"
+              if [ -n "$$TRAEFIK_IP" ]; then
+                grep -q "[[:space:]]$$WP_DOMAIN\$$" /etc/hosts || echo "$$TRAEFIK_IP $$WP_DOMAIN" >> /etc/hosts
+                break
+              fi
+              sleep 2
+            done
+          ) &
+        fi
+        exec docker-entrypoint.sh apache2-foreground
     volumes:
       - wp_app:/var/www/html
       - ../files/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
@@ -10,6 +31,7 @@ services:
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: $DB_PASSWORD
       WORDPRESS_DEBUG: ${WORDPRESS_DEBUG:-0}
+      WP_DOMAIN: ${WP_DOMAIN}
       WORDPRESS_CONFIG_EXTRA: |
         define('WP_MEMORY_LIMIT', '256M');
         define('DISALLOW_FILE_EDIT', true);

--- a/blueprints/wordpress/template.toml
+++ b/blueprints/wordpress/template.toml
@@ -9,7 +9,8 @@ env = [
   "WORDPRESS_DEBUG=0",
   "DB_NAME=${db_name}",
   "DB_USER=${db_user}",
-  "DB_PASSWORD=${db_password}"
+  "DB_PASSWORD=${db_password}",
+  "WP_DOMAIN=${main_domain}"
 ]
 
 [[config.domains]]


### PR DESCRIPTION
## Problem

Fresh WordPress deployments report two Site Health errors (#128):

- **The REST API encountered an error** — `(http_request_failed) cURL error 28: Connection timed out after 10000 milliseconds`
- **Your site could not complete a loopback request** — `cURL error 28: Connection timed out after 10000 milliseconds`

This breaks WP-Cron, the block editor checks, and plugin/theme management.

## Root cause

Inside the container, WordPress resolves its own public domain to the **server's public IP**, so every loopback request (REST API self-check, WP-Cron, Site Health) has to leave the container and hairpin back through the host to Traefik. Whether that works depends entirely on the host's hairpin-NAT/firewall setup — on many VPS/cloud configurations the packets are dropped and the request times out with cURL error 28.

Verified empirically on a live Dokploy deployment by running diagnostics inside the container:

```
== domain DNS ==
31.220.108.27   compose-...sslip.io      <- resolves to the public IP (hairpin dependency)
== traefik DNS ==
10.100.17.4     dokploy-traefik          <- Traefik IS reachable on the shared Docker network
== http GET via traefik ip (Host: <domain>) ==
HTTP/1.1 302 Found in 0.34s              <- Traefik routes the domain correctly when addressed directly
```

## Fix

At container startup, resolve `dokploy-traefik` on the shared Docker network and pin `<traefik-ip> <domain>` in `/etc/hosts`. Loopback traffic then goes container → Traefik → container entirely inside the Docker network — no hairpin NAT involved — and works for both HTTP and HTTPS (Traefik serves the real certificate).

Details:

- The resolution runs in a background retry loop (up to 2 min): Dokploy connects Traefik to the per-compose network shortly *after* the container starts, so a single lookup at t=0 misses it (observed: `pinned after 2 tries`). Apache startup is never delayed.
- Graceful no-op if `dokploy-traefik` is not resolvable — behavior falls back to exactly what it is today.
- `WP_DOMAIN` is passed from the template's `${main_domain}` so the pinned host always matches the generated domain.

## Verification (live deploy on Dokploy)

In-container diagnostics after the fix:

```
== etc hosts ==
10.100.22.4 compose-...sslip.io          <- pinned to Traefik
== loopback GET http://domain/ ==
HTTP/1.1 200 OK in 0.11s
== loopback GET http://domain/wp-json/ ==
HTTP/1.1 200 OK in 0.05s
== loopback GET http://domain/wp-cron.php ==
HTTP/1.1 200 OK in 0.03s
```

WordPress's own Site Health loopback test (the exact check from the issue), run as an authenticated admin against the final template:

```json
{"label":"Your site can perform loopback requests","status":"good", ...}
```

Fresh install flow, external REST API (`/wp-json/` → 200) and admin login all verified working. `node build-scripts/generate-meta.js --check` passes (476 templates validated).

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)