### PR TITLE
fix(minio): migrate to pgsty/minio community fork (upstream is source-only and archived)

### DIFF
--- a/blueprints/minio/docker-compose.yml
+++ b/blueprints/minio/docker-compose.yml
@@ -1,9 +1,14 @@
 services:
   minio:
-    # after RELEASE.2025-04-22T22-12-26Z, minio removed most of the admin UI, if you want to use the admin UI, uncomment the line below
-    # image: minio/minio:RELEASE.2025-04-22T22-12-26Z
-    # if you uncommented the line above, comment the line below
-    image: minio/minio
+    # MinIO Inc. stopped publishing Docker images and pre-built binaries in October 2025
+    # (https://github.com/minio/minio/issues/21647) and archived the minio/minio repository
+    # in February 2026. The official minio/minio image is frozen at RELEASE.2025-09-07T16-13-09Z
+    # and no longer receives security fixes (e.g. the fix for CVE-2025-62506 was never published
+    # as an image). This template uses pgsty/minio, the actively maintained community fork
+    # (https://github.com/pgsty/minio, AGPLv3). It is a drop-in replacement: same environment
+    # variables, same `server` command, same /data on-disk format (existing minio-data volumes
+    # keep working), and it restores the full web console that upstream removed.
+    image: pgsty/minio:RELEASE.2026-06-18T00-00-00Z
     restart: unless-stopped
     volumes:
       # by default, the MinIO container will use a volume named minio-data
@@ -19,12 +24,10 @@ services:
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
       - MINIO_BROWSER_REDIRECT_URL=${MINIO_BROWSER_REDIRECT_URL}
     command: server /data --console-address ":9001"
-    ports:
-      # by default, the MinIO container will use port 9000 to expose its API
-      # and port 9001 to expose its web console
-      # minio requires port to be specified when making a request to the API
-      - 9000:9000
     expose:
+      # port 9000 serves the S3 API (routed through the api domain defined in template.toml)
+      # port 9001 serves the web console (routed through the main domain)
+      - 9000
       - 9001
 
 # comment the line below if you specified a local directory in the volumes section of the minio service

--- a/blueprints/minio/meta.json
+++ b/blueprints/minio/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "minio",
   "name": "Minio",
-  "description": "Minio is an open source object storage server compatible with Amazon S3 cloud storage service.",
+  "description": "MinIO is an open source object storage server compatible with Amazon S3 cloud storage service. This template uses pgsty/minio, the actively maintained community fork, because MinIO Inc. stopped publishing Docker images in October 2025 and archived the upstream open source project in February 2026.",
   "logo": "minio.png",
-  "version": "latest",
+  "version": "RELEASE.2026-06-18T00-00-00Z",
   "links": {
-    "github": "https://github.com/minio/minio",
-    "website": "https://minio.io/",
-    "docs": "https://docs.minio.io/"
+    "github": "https://github.com/pgsty/minio",
+    "website": "https://silo.pigsty.io/",
+    "docs": "https://silo.pigsty.io/docs/"
   },
   "tags": [
     "storage"

--- a/blueprints/minio/template.toml
+++ b/blueprints/minio/template.toml
@@ -5,10 +5,17 @@ api_domain = "${domain}"
 [config]
 mounts = []
 
+# Web console - log in with the generated root credentials below
 [[config.domains]]
 serviceName = "minio"
 port = 9_001
 host = "${main_domain}"
+
+# S3-compatible API - point AWS CLI / SDKs / rclone / backup tools at this domain
+[[config.domains]]
+serviceName = "minio"
+port = 9_000
+host = "${api_domain}"
 
 [config.env]
 MINIO_ROOT_USER = "minioadmin"


### PR DESCRIPTION
## Problem

MinIO went source-only and the template's image source is dead:

- **October 2025**: MinIO Inc. stopped publishing Docker images and pre-built binaries for the community edition ([minio/minio#21647](https://github.com/minio/minio/issues/21647)). The critical security fix in `RELEASE.2025-10-15T17-29-55Z` (CVE-2025-62506) was released **source-only** — the GitHub release has 0 binary assets.
- **February 2026**: MinIO Inc. archived the `minio/minio` repository entirely ("no longer maintained", pointing users to their commercial AIStor product).
- The official `minio/minio` Docker Hub image is **frozen at `RELEASE.2025-09-07T16-13-09Z`** (last push 2025-09-07, verified via the Docker Hub API) and will never receive another security fix. The template currently pulls `minio/minio` (implicit `latest`), i.e. a permanently vulnerable image.

## Decision: migrate to `pgsty/minio`

Candidates evaluated with real Docker Hub / GitHub data (as of 2026-07-14):

| Option | Verdict |
|---|---|
| **`pgsty/minio`** (Pigsty community fork) | **Chosen.** GitHub [pgsty/minio](https://github.com/pgsty/minio): 1.8k stars, active (last release `RELEASE.2026-06-18T00-00-00Z`, 2026-06-18, 20 binary assets). Docker Hub: 393k pulls, multi-arch (amd64+arm64), regular releases since Feb 2026. AGPLv3, drop-in replacement: same env vars, same `server` command, same `/data` on-disk format, and it restores the full web console upstream had gutted. |
| Pin last official `minio/minio:RELEASE.2025-09-07T16-13-09Z` | Rejected as the primary fix: permanently misses the CVE-2025-62506 fix and everything after it. |
| `coollabsio/minio` | Stalled: one-time rebuild of the 2025-10-15 release, last push 2025-10-27, 38k pulls. |
| OpenMaxIO | Console-UI fork only (no server), no pushes since 2025-06-24. |
| Chainguard / Minimus | Commercial registries, only `latest` on the free tier — unsuitable for a template. |
| Bitnami | Deprecated. |

The image is pinned to `RELEASE.2026-06-18T00-00-00Z` (the fork's latest release) so upgrades are explicit and reproducible.

## Changes

- `docker-compose.yml`: `minio/minio` → `pgsty/minio:RELEASE.2026-06-18T00-00-00Z`, with a comment documenting the upstream situation. Removed the stale comment about the pre-2025-04-22 admin UI (the fork restores the full console). Replaced the `9000:9000` host port publish with `expose` + a dedicated S3 API domain, per repo conventions (same pattern as the `alarik` template).
- `template.toml`: added a second domain for the S3 API on port 9000 (the previously unused `api_domain` variable now does something).
- `meta.json`: version pinned, links point at the maintained fork, description explains the migration.

Data compatibility: the `minio-data` volume, `/data` path, credentials env vars and S3 API are unchanged — existing deployments' data keeps working after the image swap.

## Deploy verification

Deployed on a Dokploy instance from this branch:

- Web console (port 9001 via its domain): **HTTP 200**, MinIO Console loads.
- S3 API (port 9000 via its domain): responds with `Server: MinIO` and a proper S3 XML `AccessDenied` for unauthenticated requests — API fully functional.

```
HTTP/1.1 403 Forbidden
Content-Type: application/xml
Server: MinIO
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code>...
```

`node build-scripts/generate-meta.js --check` passes (476 templates validated).

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)