### PR TITLE
feat: add MailCatcher NG template

### DIFF
--- a/blueprints/mailcatcher-ng/docker-compose.yml
+++ b/blueprints/mailcatcher-ng/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  mailcatcher-ng:
+    # Only the "latest" tag is published, so the image is pinned by digest
+    # (v2.3.9 of the image, MailCatcher NG 1.6.8).
+    image: stpaquet/alpinemailcatcher:latest@sha256:499c0eabca5e82b23d030706ba9d5b8b27bba5a5f34a43154ee5e68b07cba52c
+    restart: unless-stopped
+    # Same as the image default CMD, plus --persistence so caught mail
+    # survives container restarts (stored in the named volume below).
+    command: sh -c "mailcatcher --foreground --smtp-port=1025 --http-port=1080 --ip=0.0.0.0 --messages-limit=$$MAIL_LIMIT --persistence --no-quit"
+    environment:
+      - MAIL_LIMIT=${MAIL_LIMIT}
+    expose:
+      # SMTP: reachable from other services in the same Dokploy network
+      # at mailcatcher-ng:1025 (intentionally not published on the host).
+      - 1025
+      # Web UI (routed through the domain below)
+      - 1080
+    volumes:
+      - mailcatcher-data:/home/mailcatcher/.mailcatcher
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://127.0.0.1:1080']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  mailcatcher-data:

--- a/blueprints/mailcatcher-ng/mailcatcher-ng.svg
+++ b/blueprints/mailcatcher-ng/mailcatcher-ng.svg
@@ -1,0 +1,10 @@
+<svg class="logo-icon" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d9488;stop-opacity:1"></stop>
+      <stop offset="100%" style="stop-color:#0f766e;stop-opacity:1"></stop>
+    </linearGradient>
+  </defs>
+  <path d="M 20 30 L 50 55 L 80 30 L 80 75 Q 80 80 75 80 L 25 80 Q 20 80 20 75 Z" fill="url(#logoGradient)"></path>
+  <path d="M 20 30 L 50 55 L 80 30" stroke="white" stroke-width="2" fill="none"></path>
+</svg>

--- a/blueprints/mailcatcher-ng/meta.json
+++ b/blueprints/mailcatcher-ng/meta.json
@@ -1,0 +1,17 @@
+{
+  "id": "mailcatcher-ng",
+  "name": "MailCatcher NG",
+  "version": "1.6.8",
+  "description": "MailCatcher NG runs a super simple SMTP server which catches any message sent to it to display in a web interface. Point your app's SMTP settings at mailcatcher-ng:1025 and inspect every captured email in the browser.",
+  "logo": "mailcatcher-ng.svg",
+  "links": {
+    "github": "https://github.com/spaquet/mailcatcher",
+    "website": "https://spaquet.github.io/mailcatcher/",
+    "docs": "https://spaquet.github.io/docker-alpine-mailcatcher/"
+  },
+  "tags": [
+    "email",
+    "smtp",
+    "development"
+  ]
+}

--- a/blueprints/mailcatcher-ng/template.toml
+++ b/blueprints/mailcatcher-ng/template.toml
@@ -1,0 +1,13 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+env = [
+  "MAIL_LIMIT=50",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "mailcatcher-ng"
+port = 1_080
+host = "${main_domain}"


### PR DESCRIPTION
## What

Adds a template for **MailCatcher NG** ([spaquet/mailcatcher](https://github.com/spaquet/mailcatcher)), a lightweight SMTP catcher for development: it runs a simple SMTP server that captures every message sent to it and displays them in a web UI.

Closes #747

## Decisions

- **Image**: `stpaquet/alpinemailcatcher` (the official Docker image from [spaquet/docker-alpine-mailcatcher](https://github.com/spaquet/docker-alpine-mailcatcher), v2.3.9, MailCatcher NG 1.6.8, Alpine 3.24.1). The registry only publishes a `latest` tag, so the image is **pinned by digest** (`sha256:499c0e...`) for reproducible deploys.
- **SMTP port 1025 is internal only** (`expose`, not published on the host): other apps in the same Dokploy project send mail to `mailcatcher-ng:1025`; the web UI (1080) is routed through the template domain.
- **Persistence enabled**: the default image CMD keeps mail in memory only, so the template overrides the command with the image's own documented `--persistence` flag and mounts a named volume at `/home/mailcatcher/.mailcatcher`, so captured mail survives restarts/redeploys.
- `MAIL_LIMIT=50` exposed as an env var (image default) to cap stored messages.
- Healthcheck via busybox `wget --spider` on the UI port.
- Logo: official SVG from the upstream repo (`website_src/public/favicon.svg`).

## Deploy test (demo instance)

Deployed on a Dokploy instance from this exact blueprint:

```
deploy: done (10s)
✅ mailcatcher-ng:1080 → HTTP 200 «MailCatcher NG»
```

`node build-scripts/generate-meta.js --check` passes (477 templates validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
