### PR TITLE
feat: add Markup template

### DIFF
--- a/blueprints/markup/docker-compose.yml
+++ b/blueprints/markup/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.8"
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    volumes:
+      - markup-postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: markup
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: markup
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U markup -d markup"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  markup:
+    image: ghcr.io/pphilfre/markup:main
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      NEXT_PUBLIC_DB_PROVIDER: postgres
+      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL}
+      # WorkOS AuthKit (optional): required only for user accounts and cloud sync.
+      # Placeholders keep the app running; replace them with real credentials
+      # from https://dashboard.workos.com to enable sign-in.
+      WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID}
+      WORKOS_API_KEY: ${WORKOS_API_KEY}
+      WORKOS_COOKIE_PASSWORD: ${WORKOS_COOKIE_PASSWORD}
+      NEXT_PUBLIC_WORKOS_REDIRECT_URI: ${NEXT_PUBLIC_WORKOS_REDIRECT_URI}
+      NODE_ENV: production
+
+volumes:
+  markup-postgres-data:

--- a/blueprints/markup/markup.svg
+++ b/blueprints/markup/markup.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <rect width="100" height="100" rx="20" fill="#0a0a0a"/>
+  <text x="50" y="68" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-weight="700" font-size="48" fill="#7c3aed">M</text>
+  <rect x="22" y="76" width="56" height="3" rx="1.5" fill="#7c3aed" opacity="0.5"/>
+</svg>

--- a/blueprints/markup/meta.json
+++ b/blueprints/markup/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "markup",
+  "name": "Markup",
+  "version": "main",
+  "description": "Markup is a fast, keyboard-first markdown workspace with live preview, graph view, whiteboards, mind maps, and PostgreSQL-powered cloud sync.",
+  "logo": "markup.svg",
+  "links": {
+    "github": "https://github.com/pphilfre/markup",
+    "website": "https://home.markup.freddiephilpot.dev/",
+    "docs": "https://docs.markup.freddiephilpot.dev/"
+  },
+  "tags": [
+    "markdown",
+    "notes",
+    "editor",
+    "self-hosted"
+  ]
+}

--- a/blueprints/markup/template.toml
+++ b/blueprints/markup/template.toml
@@ -1,0 +1,25 @@
+[variables]
+main_domain = "${domain}"
+postgres_password = "${password:32}"
+cookie_password = "${password:32}"
+
+[config]
+env = [
+  "POSTGRES_PASSWORD=${postgres_password}",
+  "DATABASE_URL=postgresql://markup:${postgres_password}@db:5432/markup",
+  "NEXT_PUBLIC_SITE_URL=https://${main_domain}",
+  "# WorkOS AuthKit is optional: it powers user accounts and cloud sync.",
+  "# The app works without it (local, in-browser storage). To enable sign-in,",
+  "# create an app at https://dashboard.workos.com, set the redirect URI below",
+  "# in the WorkOS dashboard, and replace the placeholder credentials.",
+  "WORKOS_CLIENT_ID=client_id_change_me",
+  "WORKOS_API_KEY=sk_change_me",
+  "WORKOS_COOKIE_PASSWORD=${cookie_password}",
+  "NEXT_PUBLIC_WORKOS_REDIRECT_URI=https://${main_domain}/callback",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "markup"
+port = 3000
+host = "${main_domain}"


### PR DESCRIPTION
## Summary

Adds a template for [Markup](https://github.com/pphilfre/markup) — a fast, keyboard-first markdown workspace built with Next.js, with live preview (GFM, math, Mermaid), graph view, whiteboards, mind maps, and PostgreSQL-powered cloud sync.

- **Image:** `ghcr.io/pphilfre/markup:main` (official GHCR image, multi-arch amd64/arm64; upstream only publishes the `main` tag — no versioned tags exist yet). Latest upstream release: v1.1.5 (May 2026), actively maintained.
- **Services:** `markup` (app, port 3000) + `db` (postgres:16-alpine with healthcheck; the app runs Prisma migrations automatically on startup).
- **Auth note:** WorkOS AuthKit is optional and only needed for user accounts / cloud sync. The template ships non-empty placeholder credentials (the app's middleware crashes with empty values — verified) plus a generated 32-char `WORKOS_COOKIE_PASSWORD` and a pre-filled redirect URI, with comments explaining how to plug in real WorkOS credentials. Without them the editor works fully with local in-browser storage.

## Testing

Deployed and verified on a Dokploy instance:

- Deploy completed in ~31s; Prisma migrations applied against the bundled Postgres.
- `GET /` → HTTP 200, page title "Markup — Fast, Keyboard-First Markdown Editor", editor loads.
- `GET /api/auth/user` → proper `401 {"error":"Not authenticated"}` (server routes and DB functional).
- `node build-scripts/generate-meta.js --check` → 477 templates validated.

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)