### PR TITLE
libredb-studio: bump version to 0.9.59

### DIFF
--- a/blueprints/libredb-studio/docker-compose.yml
+++ b/blueprints/libredb-studio/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   libredb-studio:
-    image: ghcr.io/libredb/libredb-studio:0.9.27
+    image: ghcr.io/libredb/libredb-studio:0.9.59
     restart: unless-stopped
     environment:
       - ADMIN_EMAIL=admin@libredb.org

--- a/blueprints/libredb-studio/meta.json
+++ b/blueprints/libredb-studio/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "libredb-studio",
   "name": "LibreDB Studio",
-  "version": "0.9.27",
+  "version": "0.9.59",
   "description": "The modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
   "logo": "libredb-studio.svg",
   "links": {


### PR DESCRIPTION
## What is this PR about?

Bumps the LibreDB Studio template from `0.9.27` to the current release `0.9.59`. Only the image tag and the template version change.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works.

Tested locally with the template compose: the container comes up healthy on `/api/db/health`, login works with the compose credentials, and a saved connection survives a restart on the mounted volume. `node build-scripts/generate-meta.js --check` passes (500 templates).
