### PR TITLE
chore: update Windshift to v0.8.2

### DIFF
--- a/blueprints/windshift/docker-compose.yml
+++ b/blueprints/windshift/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   windshift:
-    image: ghcr.io/windshiftapp/windshift:v0.5.3
+    image: ghcr.io/windshiftapp/windshift:v0.8.2
     restart: unless-stopped
     environment:
       - BASE_URL=https://${DOMAIN}

--- a/blueprints/windshift/meta.json
+++ b/blueprints/windshift/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "windshift",
   "name": "Windshift",
-  "version": "v0.5.0",
+  "version": "v0.8.2",
   "description": "Self-hosted work management platform with projects, tasks, sprints, and team collaboration.",
   "logo": "windshift.png",
   "links": {


### PR DESCRIPTION
## Summary

- update the Windshift container image from `v0.5.3` to `v0.8.2`
- synchronize the template metadata version with the image tag

## Validation

- confirmed the published `v0.8.2` image contains `linux/amd64` and `linux/arm64` manifests
- `node build-scripts/generate-meta.js --check` (500 templates validated)
- `npm run validate-docker-compose -- --file ../blueprints/windshift/docker-compose.yml --verbose`
- `npm run validate-template -- --dir ../blueprints/windshift --verbose`
- `docker compose config -q` with generated-equivalent environment values
- started the complete Windshift and PostgreSQL Compose stack locally and received HTTP 200 from `http://windshift:8080/` over the Compose network
