### PR TITLE
fix: bring scrutiny, stack-auth and vault in line with the compose conventions

### DIFF
--- a/blueprints/scrutiny/docker-compose.yml
+++ b/blueprints/scrutiny/docker-compose.yml
@@ -1,7 +1,9 @@
+version: "3.8"
+
 services:
   scrutiny:
     restart: unless-stopped
-    image: ghcr.io/analogj/scrutiny:master-omnibus
+    image: ghcr.io/analogj/scrutiny:v0.8.3-omnibus
     cap_add:
       - SYS_RAWIO
     ports:

--- a/blueprints/scrutiny/docker-compose.yml
+++ b/blueprints/scrutiny/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   scrutiny:
     restart: unless-stopped
-    container_name: scrutiny
     image: ghcr.io/analogj/scrutiny:master-omnibus
     cap_add:
       - SYS_RAWIO

--- a/blueprints/scrutiny/meta.json
+++ b/blueprints/scrutiny/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "scrutiny",
   "name": "Scrutiny",
-  "version": "latest",
+  "version": "v0.8.3-omnibus",
   "description": "Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Failure Thresholds",
   "logo": "scrutiny.png",
   "links": {

--- a/blueprints/stack-auth/docker-compose.yml
+++ b/blueprints/stack-auth/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       
   stack-auth:
     image: stackauth/server:latest
-    container_name: stack-auth
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/blueprints/vault/docker-compose.yml
+++ b/blueprints/vault/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.8"
 services:
   vault:
     image: hashicorp/vault:latest
-    container_name: vault
     cap_add:
       - IPC_LOCK
     environment:

--- a/blueprints/vault/docker-compose.yml
+++ b/blueprints/vault/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   vault:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:2.0.3
     cap_add:
       - IPC_LOCK
     environment:

--- a/blueprints/vault/meta.json
+++ b/blueprints/vault/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "vault",
   "name": "Vault",
-  "version": "latest",
+  "version": "2.0.3",
   "description": "Vault is a tool for securely accessing secrets. A secret is anything that you want to tightly control access to, such as API keys, passwords, certificates, and more. Vault provides a unified interface to any secret, while providing tight access control and recording a detailed audit log. To sign in: In the Vault UI, select 'Token' as the authentication method (not GitHub), then enter the root token from the VAULT_DEV_ROOT_TOKEN_ID environment variable (auto-generated).",
   "logo": "vault.svg",
   "links": {

--- a/blueprints/vault/template.toml
+++ b/blueprints/vault/template.toml
@@ -12,6 +12,3 @@ host = "${main_domain}"
 [config.env]
 VAULT_DEV_ROOT_TOKEN_ID = "${root_token}"
 VAULT_DEV_LISTEN_ADDRESS = "0.0.0.0:8200"
-
-[[config.mounts]]
-


### PR DESCRIPTION
## What

Brings three blueprints — `scrutiny`, `stack-auth`, `vault` — in line with the repository's documented Docker Compose conventions. Six files, all deletions or one-line edits.

Part of #1047.

> **Note on scope:** this PR started out as just the `container_name` removal, and the title said so. Review feedback correctly pointed out that it had grown past that, so the title and this description now describe the whole change. Everything here is one theme (making these three files satisfy the documented conventions), but I'm happy to split it if you'd rather review the pins separately.

## Changes

**1. Removed no-op `container_name` (all three)**

`validate-docker-compose.ts` rejects `container_name`, and CONTRIBUTING says not to use it. In each of these the value is **identical to the service name**, so removing it changes nothing about service-to-service DNS:

| blueprint | services | `container_name` | referenced elsewhere in the file? |
| --- | --- | --- | --- |
| `scrutiny` | `scrutiny` | `scrutiny` | no |
| `stack-auth` | `stack-auth-db`, `stack-auth` | `stack-auth` | no |
| `vault` | `vault` | `vault` | no |

I checked that last column rather than assuming it: parsed each file, stripped comments, and searched for any use of the name outside its own declaration.

**2. Pinned floating image tags (`scrutiny`, `vault`)**

`.github/copilot-instructions.md`: *"Pin images to specific versions … **NEVER use `latest` tag**"*, and `meta.json.version` must match.

- `vault`: `hashicorp/vault:latest` → **`2.0.3`**. Verified on Docker Hub, multi-arch (386/amd64/arm64), published 2026-06-17.
- `scrutiny`: `master-omnibus` → **`v0.8.3-omnibus`**. Worth noting the upstream *release* is `v0.9.2`, but **there is no `v0.9.x` omnibus image** — the omnibus tags stop at `v0.8.3`. Pinning to the newest release would have produced a template that can't pull. Manifest confirmed HTTP 200 via a GHCR pull token.
- Both `meta.json.version` fields updated to match.

**Not pinned: `stack-auth`.** `stackauth/server` publishes **no semantic version tags at all** — the tag list is commit SHAs (`5186b14`, `27456b8`, `dc2eed6`, …) plus `latest` and `dev`. Pinning to a SHA satisfies the letter of the rule while making the template harder to maintain and impossible to express as a meaningful `meta.json.version`. Left for you to decide.

**3. Added the missing `version: "3.8"` header (`scrutiny`)**

**4. Removed the empty `[[config.mounts]]` block (`vault/template.toml`)**

Not cosmetic, and not something I went looking for — **CI surfaced it**. Editing `vault/docker-compose.yml` made the workflow validate `vault/template.toml` for the first time since the rule tightened, and it failed with `config.mounts[0]: Missing required field 'filePath'`. TOML parses a bare `[[config.mounts]]` as `[{}]` — one mount with no fields. I confirmed it predates this PR by stashing my change and re-running (same two errors).

That is #1047, where **80 blueprints share the same problem**. I fixed only `vault` here, since it was blocking this PR's CI; the other 79 are untouched pending your call on how you'd like them handled.

## Scope I deliberately did not take

- **`:latest` elsewhere.** It appears in **205 of 500 blueprints** (259 of 1109 image lines). This PR happened to touch two of them. A 205-file sweep belongs in its own change.
- **`enshrouded`, `wg-easy`.** Their `container_name` is a no-op too, but both files also fail on `ports` mappings (`15637/udp` game server, `51820/udp` WireGuard) that I am **not** proposing to change — those genuinely need host ports and Dokploy's HTTP routing can't substitute. I didn't want to half-fix a file and leave it red.
- **`datalens`, `elastic-search`, `pre0.22.5-supabase`.** Multi-service, and their container names **differ** from the service names, so removing them could change resolvable hostnames.
- **`systemprompt`** — false positive; the match is inside a comment.

## Testing

```text
$ node build-scripts/generate-meta.js --check
✅ 500 templates validated

scrutiny   compose: PASS   toml: PASS
stack-auth compose: PASS   toml: PASS
vault      compose: PASS   toml: PASS
```

All three failed `validate-docker-compose.ts` before this change. All four CI checks (build-preview, validate, validate-docker-compose, validate-meta) pass.

**What I did not do:** I have no Dokploy instance, so this is validator-level plus static reference and image-manifest checks, not a live redeploy. The image pins are the part with real behavioural risk — `vault:2.0.3` is a major version ahead of whatever `latest` resolved to on any given day, so if you'd prefer a more conservative pin for that one, say the word.
