### PR TITLE
ci: audit every blueprint on a schedule

### DIFF
--- a/.github/workflows/audit-all-blueprints.yml
+++ b/.github/workflows/audit-all-blueprints.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Audit every blueprint
         id: audit
         run: |
+          # $RUNNER_TEMP is per-job; also cleared explicitly so a re-run or a
+          # partially-executed earlier step can never leak into the summary.
+          WORK="${RUNNER_TEMP:-/tmp}"
+          OUT="$WORK/validator-out.txt"
+          REPORT="$WORK/audit-report.md"
+          SUMMARY="$WORK/audit-summary.md"
+          rm -f "$OUT" "$REPORT" "$SUMMARY"
+
           COMPOSE_FAILED=""
           TOML_FAILED=""
 
@@ -58,27 +66,27 @@ jobs:
 
             if [ -f "$dir/docker-compose.yml" ]; then
               if ! (cd build-scripts && pnpm exec tsx validate-docker-compose.ts \
-                     --file "../$dir/docker-compose.yml") > /tmp/out.txt 2>&1; then
+                     --file "../$dir/docker-compose.yml") > "$OUT" 2>&1; then
                 COMPOSE_FAILED="$COMPOSE_FAILED $id"
                 {
                   echo "### \`$id\` — docker-compose.yml"
                   echo '```'
-                  grep '❌' /tmp/out.txt || cat /tmp/out.txt
+                  grep '❌' "$OUT" || cat "$OUT"
                   echo '```'
-                } >> /tmp/report.md
+                } >> "$REPORT"
               fi
             fi
 
             if [ -f "$dir/template.toml" ]; then
               if ! (cd build-scripts && pnpm exec tsx validate-template.ts \
-                     --dir "../$dir") > /tmp/out.txt 2>&1; then
+                     --dir "../$dir") > "$OUT" 2>&1; then
                 TOML_FAILED="$TOML_FAILED $id"
                 {
                   echo "### \`$id\` — template.toml"
                   echo '```'
-                  grep '❌' /tmp/out.txt || cat /tmp/out.txt
+                  grep '❌' "$OUT" || cat "$OUT"
                   echo '```'
-                } >> /tmp/report.md
+                } >> "$REPORT"
               fi
             fi
           done
@@ -95,15 +103,15 @@ jobs:
             echo "| \`validate-docker-compose.ts\` | $COMPOSE_COUNT | $TOTAL |"
             echo "| \`validate-template.ts\` | $TOML_COUNT | $TOTAL |"
             echo ""
-          } > /tmp/summary.md
+          } > "$SUMMARY"
 
-          if [ -f /tmp/report.md ]; then
-            cat /tmp/report.md >> /tmp/summary.md
+          if [ -f "$REPORT" ]; then
+            cat "$REPORT" >> "$SUMMARY"
           else
-            echo "No findings." >> /tmp/summary.md
+            echo "No findings." >> "$SUMMARY"
           fi
 
-          cat /tmp/summary.md >> "$GITHUB_STEP_SUMMARY"
+          cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
 
           echo "compose_failed=$COMPOSE_COUNT" >> "$GITHUB_OUTPUT"
           echo "toml_failed=$TOML_COUNT" >> "$GITHUB_OUTPUT"
@@ -113,7 +121,13 @@ jobs:
           fi
 
       - name: Fail if requested
-        if: inputs.fail_on_findings && (steps.audit.outputs.compose_failed != '0' || steps.audit.outputs.toml_failed != '0')
+        # `inputs` is only populated for workflow_dispatch; on a schedule run it
+        # is not available, so gate on the event first and read the value through
+        # github.event.inputs, which is an empty string when absent.
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.fail_on_findings == 'true' &&
+          (steps.audit.outputs.compose_failed != '0' || steps.audit.outputs.toml_failed != '0')
         run: |
           echo "❌ Findings present and fail_on_findings was requested."
           exit 1

--- a/.github/workflows/audit-all-blueprints.yml
+++ b/.github/workflows/audit-all-blueprints.yml
@@ -64,30 +64,30 @@ jobs:
           for dir in blueprints/*/; do
             id="$(basename "$dir")"
 
-            if [ -f "$dir/docker-compose.yml" ]; then
-              if ! (cd build-scripts && pnpm exec tsx validate-docker-compose.ts \
-                     --file "../$dir/docker-compose.yml") > "$OUT" 2>&1; then
-                COMPOSE_FAILED="$COMPOSE_FAILED $id"
-                {
-                  echo "### \`$id\` — docker-compose.yml"
-                  echo '```'
-                  grep '❌' "$OUT" || cat "$OUT"
-                  echo '```'
-                } >> "$REPORT"
-              fi
+            # Run unconditionally: a blueprint with no docker-compose.yml or no
+            # template.toml is itself a finding, and the validators already
+            # report a missing file clearly. Skipping them would hide exactly
+            # the blueprints most likely to be broken.
+            if ! (cd build-scripts && pnpm exec tsx validate-docker-compose.ts \
+                   --file "../$dir/docker-compose.yml") > "$OUT" 2>&1; then
+              COMPOSE_FAILED="$COMPOSE_FAILED $id"
+              {
+                echo "### \`$id\` — docker-compose.yml"
+                echo '```'
+                grep '❌' "$OUT" || cat "$OUT"
+                echo '```'
+              } >> "$REPORT"
             fi
 
-            if [ -f "$dir/template.toml" ]; then
-              if ! (cd build-scripts && pnpm exec tsx validate-template.ts \
-                     --dir "../$dir") > "$OUT" 2>&1; then
-                TOML_FAILED="$TOML_FAILED $id"
-                {
-                  echo "### \`$id\` — template.toml"
-                  echo '```'
-                  grep '❌' "$OUT" || cat "$OUT"
-                  echo '```'
-                } >> "$REPORT"
-              fi
+            if ! (cd build-scripts && pnpm exec tsx validate-template.ts \
+                   --dir "../$dir") > "$OUT" 2>&1; then
+              TOML_FAILED="$TOML_FAILED $id"
+              {
+                echo "### \`$id\` — template.toml"
+                echo '```'
+                grep '❌' "$OUT" || cat "$OUT"
+                echo '```'
+              } >> "$REPORT"
             fi
           done
 
@@ -118,12 +118,13 @@ jobs:
           SUMMARY_BYTES=$(wc -c < "$SUMMARY" | tr -d ' ')
 
           if [ "$SUMMARY_BYTES" -gt "$SUMMARY_LIMIT" ]; then
-            head -c "$SUMMARY_LIMIT" "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+            # Emit the header table only, never a byte-sliced prefix: cutting
+            # mid-``` leaves an unclosed code fence, which swallows the notice
+            # below it and makes the truncation invisible in the rendered summary.
             {
+              head -n 7 "$SUMMARY"
               echo ""
-              echo "---"
-              echo ""
-              echo "_Report truncated at $SUMMARY_LIMIT bytes (full size: $SUMMARY_BYTES)._"
+              echo "_Report omitted: $SUMMARY_BYTES bytes exceeds the $SUMMARY_LIMIT byte budget for a job summary._"
               echo "_Download the \`blueprint-audit\` artifact for the complete output._"
             } >> "$GITHUB_STEP_SUMMARY"
           else

--- a/.github/workflows/audit-all-blueprints.yml
+++ b/.github/workflows/audit-all-blueprints.yml
@@ -111,7 +111,28 @@ jobs:
             echo "No findings." >> "$SUMMARY"
           fi
 
-          cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+          # The step summary caps at ~1MB and truncates silently past it, which
+          # would hide findings exactly as the backlog grows. Bound what we
+          # append and point at the artifact for the rest.
+          SUMMARY_LIMIT=$((512 * 1024))
+          SUMMARY_BYTES=$(wc -c < "$SUMMARY" | tr -d ' ')
+
+          if [ "$SUMMARY_BYTES" -gt "$SUMMARY_LIMIT" ]; then
+            head -c "$SUMMARY_LIMIT" "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo ""
+              echo "---"
+              echo ""
+              echo "_Report truncated at $SUMMARY_LIMIT bytes (full size: $SUMMARY_BYTES)._"
+              echo "_Download the \`blueprint-audit\` artifact for the complete output._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Always published, so the full report survives regardless of size.
+          cp "$SUMMARY" "$WORK/blueprint-audit.md"
+          echo "report_path=$WORK/blueprint-audit.md" >> "$GITHUB_OUTPUT"
 
           echo "compose_failed=$COMPOSE_COUNT" >> "$GITHUB_OUTPUT"
           echo "toml_failed=$TOML_COUNT" >> "$GITHUB_OUTPUT"
@@ -119,6 +140,14 @@ jobs:
           if [ "$COMPOSE_COUNT" != "0" ] || [ "$TOML_COUNT" != "0" ]; then
             echo "::warning::$COMPOSE_COUNT compose and $TOML_COUNT template.toml findings across $TOTAL blueprints"
           fi
+
+      - name: Upload the full report
+        if: always() && steps.audit.outputs.report_path != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: blueprint-audit
+          path: ${{ steps.audit.outputs.report_path }}
+          retention-days: 30
 
       - name: Fail if requested
         # `inputs` is only populated for workflow_dispatch; on a schedule run it

--- a/.github/workflows/audit-all-blueprints.yml
+++ b/.github/workflows/audit-all-blueprints.yml
@@ -1,0 +1,119 @@
+name: Audit All Blueprints
+
+# The per-PR validators only look at blueprints a PR touches, which is the right
+# call for CI cost but means a template is checked when it lands and then never
+# again. When a rule is added or tightened, every existing blueprint that breaks
+# it stays broken with nothing surfacing it (see #1047).
+#
+# This job runs the same validators over ALL blueprints on a schedule, so drift
+# is reported instead of accumulating. It never runs on pull_request, so it
+# cannot block a contributor for a pre-existing problem they did not introduce.
+
+on:
+  schedule:
+    # Mondays, 04:00 UTC
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      fail_on_findings:
+        description: "Exit non-zero when findings exist (default: report only)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.16.0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: cd build-scripts && pnpm install
+
+      - name: Validate per-template metadata
+        run: node build-scripts/generate-meta.js --check
+
+      - name: Audit every blueprint
+        id: audit
+        run: |
+          COMPOSE_FAILED=""
+          TOML_FAILED=""
+
+          for dir in blueprints/*/; do
+            id="$(basename "$dir")"
+
+            if [ -f "$dir/docker-compose.yml" ]; then
+              if ! (cd build-scripts && pnpm exec tsx validate-docker-compose.ts \
+                     --file "../$dir/docker-compose.yml") > /tmp/out.txt 2>&1; then
+                COMPOSE_FAILED="$COMPOSE_FAILED $id"
+                {
+                  echo "### \`$id\` — docker-compose.yml"
+                  echo '```'
+                  grep '❌' /tmp/out.txt || cat /tmp/out.txt
+                  echo '```'
+                } >> /tmp/report.md
+              fi
+            fi
+
+            if [ -f "$dir/template.toml" ]; then
+              if ! (cd build-scripts && pnpm exec tsx validate-template.ts \
+                     --dir "../$dir") > /tmp/out.txt 2>&1; then
+                TOML_FAILED="$TOML_FAILED $id"
+                {
+                  echo "### \`$id\` — template.toml"
+                  echo '```'
+                  grep '❌' /tmp/out.txt || cat /tmp/out.txt
+                  echo '```'
+                } >> /tmp/report.md
+              fi
+            fi
+          done
+
+          COMPOSE_COUNT=$(echo $COMPOSE_FAILED | wc -w | tr -d ' ')
+          TOML_COUNT=$(echo $TOML_FAILED | wc -w | tr -d ' ')
+          TOTAL=$(ls -d blueprints/*/ | wc -l | tr -d ' ')
+
+          {
+            echo "## Blueprint audit"
+            echo ""
+            echo "| check | failing | of |"
+            echo "| --- | --- | --- |"
+            echo "| \`validate-docker-compose.ts\` | $COMPOSE_COUNT | $TOTAL |"
+            echo "| \`validate-template.ts\` | $TOML_COUNT | $TOTAL |"
+            echo ""
+          } > /tmp/summary.md
+
+          if [ -f /tmp/report.md ]; then
+            cat /tmp/report.md >> /tmp/summary.md
+          else
+            echo "No findings." >> /tmp/summary.md
+          fi
+
+          cat /tmp/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+          echo "compose_failed=$COMPOSE_COUNT" >> "$GITHUB_OUTPUT"
+          echo "toml_failed=$TOML_COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$COMPOSE_COUNT" != "0" ] || [ "$TOML_COUNT" != "0" ]; then
+            echo "::warning::$COMPOSE_COUNT compose and $TOML_COUNT template.toml findings across $TOTAL blueprints"
+          fi
+
+      - name: Fail if requested
+        if: inputs.fail_on_findings && (steps.audit.outputs.compose_failed != '0' || steps.audit.outputs.toml_failed != '0')
+        run: |
+          echo "❌ Findings present and fail_on_findings was requested."
+          exit 1


### PR DESCRIPTION
## What

Adds a scheduled workflow that runs `validate-docker-compose.ts` and `validate-template.ts` over **every** blueprint, so rule drift gets reported instead of accumulating silently.

Implements the CI suggestion from #1047.

## Why

The per-PR validators only look at blueprints a PR touches — which is the right call for CI cost, but it means a template is checked when it lands and then never again. When a rule is added or tightened, every existing blueprint that breaks it stays broken with nothing surfacing it.

That is not hypothetical. Running the validators across all 500 today:

| check | failing | of |
| --- | --- | --- |
| `validate-docker-compose.ts` | 30 | 500 |
| `validate-template.ts` | 80 | 500 |

And #1048 demonstrated the mechanism live: editing `vault/docker-compose.yml` made CI look at `vault/template.toml` for the first time since a rule tightened, and it failed on a problem that had nothing to do with that PR.

## Design decisions

**Scheduled + manual only, never on `pull_request`.** A contributor must not be blocked by a pre-existing failure they did not introduce. That is exactly what happened on #1048, and it should not be the default experience.

**Reports rather than fails.** The default run emits a `::warning::` and writes a full breakdown to the job summary. `workflow_dispatch` takes a `fail_on_findings` boolean for when you want it to gate — so you can flip it on once the backlog is cleared, without editing the workflow.

**Reuses the existing validators unchanged.** No new checking logic to keep in sync; it runs the same two scripts the PR workflows do, with the same `pnpm exec tsx` invocation and pinned Node 20.16.0 / pnpm 8 setup as `validate-docker-compose.yml`.

**`permissions: contents: read`** — it only reads.

## The job summary it produces

Ran the workflow's audit step verbatim against the current tree. It renders a summary table plus one section per finding, with the validator's real output:

```markdown
## Blueprint audit

| check | failing | of |
| --- | --- | --- |
| `validate-docker-compose.ts` | 30 | 500 |
| `validate-template.ts` | 80 | 500 |

### `adguardhome` — docker-compose.yml
❌ Service 'adguardhome': ports[0] uses port mapping format '53:53/tcp'. …

### `vault` — docker-compose.yml
❌ Service 'vault': Found 'container_name' field. …
```

110 finding sections in total.

## Testing

I extracted the `run:` block from the workflow and executed it as a shell script against the real repo, rather than eyeballing the YAML:

```text
$ bash /tmp/audit.sh
::warning::30 compose and 80 template.toml findings across 500 blueprints

compose_failed=30
toml_failed=80
```

Those numbers **match what I counted by hand** when filing #1047, which is the check that matters — the script isn't just exiting cleanly, it is finding the right things. The YAML also parses (triggers `schedule` + `workflow_dispatch`, 7 steps).

**One caveat I want to be straight about.** My local pnpm is broken (`corepack` tries to reinstall on every `pnpm exec` and errors), so my local run substituted `npx tsx` for `pnpm exec tsx`. The committed workflow keeps `pnpm exec` to match `validate-docker-compose.yml`, and the surrounding setup steps are copied from that workflow verbatim — but the `pnpm exec` path specifically is the one line I verified by consistency with the existing working workflow rather than by executing it myself. Worth a look on the first scheduled run.

## Note on the current findings

To be clear, I am **not** proposing to fix the 110 in this PR. Some are almost certainly intentional — the port-mapping findings are `adguardhome` (53/udp DNS), `poste.io` (SMTP/POP/IMAP), `wg-easy` (51820/udp), `enshrouded` (game server), all of which genuinely need host ports. Those may argue for an allowance in the validator rather than a change to the templates. This PR just makes the number visible.
