### PR TITLE
Update SendDock template (track latest, drop deprecated env vars)

### DIFF
--- a/blueprints/senddock/docker-compose.yml
+++ b/blueprints/senddock/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       retries: 5
 
   senddock:
-    image: ghcr.io/arkhe-systems/senddock:0.6.5.1
+    image: ghcr.io/arkhe-systems/senddock:latest
     restart: unless-stopped
     depends_on:
       postgres:
@@ -40,8 +40,6 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - PUBLIC_URL=${PUBLIC_URL}
       - FRONTEND_URL=${PUBLIC_URL}
-      - DEPLOYMENT_MODE=self-hosted
-      - SENDDOCK_LICENSE_KEY=${SENDDOCK_LICENSE_KEY}
       - PORT=8080
     expose:
       - 8080

--- a/blueprints/senddock/meta.json
+++ b/blueprints/senddock/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "senddock",
   "name": "SendDock",
-  "version": "0.6.5.1",
+  "version": "0.8.0",
   "description": "Open-source, self-hosted email marketing platform with BYO SMTP. Manage subscribers, templates, broadcasts, and scheduled campaigns from one place.",
   "logo": "senddock.svg",
   "links": {

--- a/blueprints/senddock/template.toml
+++ b/blueprints/senddock/template.toml
@@ -7,8 +7,7 @@ jwt_secret = "${password:64}"
 env = [
   "POSTGRES_PASSWORD=${postgres_password}",
   "JWT_SECRET=${jwt_secret}",
-  "PUBLIC_URL=https://${main_domain}",
-  "SENDDOCK_LICENSE_KEY="
+  "PUBLIC_URL=https://${main_domain}"
 ]
 
 [[config.domains]]


### PR DESCRIPTION
Keeps the SendDock template current and cleans up two variables deprecated in 0.8.

**Changes**
- Point the image at `ghcr.io/arkhe-systems/senddock:latest` so fresh deploys always get the current release — no per-release PR needed to keep the gallery up to date.
- Remove `DEPLOYMENT_MODE` — self-host is the default now (the hosted flag became the boolean `CLOUD`).
- Remove `SENDDOCK_LICENSE_KEY` (from `docker-compose.yml` and `template.toml`) — the Pro license is activated from the dashboard (Instance settings) in 0.8; the env var is removed in 0.9.
- `meta.json` version set to 0.8.0 as a reference baseline.

No changes to services, ports, domains or volumes. `node build-scripts/generate-meta.js --check` passes (500 templates validated).