### PR TITLE
Add Yuvomi template

### DIFF
--- a/blueprints/yuvomi/docker-compose.yml
+++ b/blueprints/yuvomi/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  yuvomi:
+    image: ghcr.io/ulsklyc/yuvomi:0.71.10
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      DB_PATH: /data/yuvomi.db
+      BACKUP_DIR: /backups
+      DOCUMENT_STORAGE_LOCAL_ENABLED: ${DOCUMENT_STORAGE_LOCAL_ENABLED}
+      DOCUMENT_STORAGE_LOCAL_PATH: /documents
+      SESSION_SECURE: "true"
+      TRUST_PROXY: "1"
+      SESSION_SECRET: ${SESSION_SECRET}
+    volumes:
+      - yuvomi-data:/data
+      - yuvomi-backups:/backups
+      - yuvomi-modules:/app/modules
+      - yuvomi-documents:/documents
+    expose:
+      - 3000
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  yuvomi-data:
+  yuvomi-backups:
+  yuvomi-modules:
+  yuvomi-documents:

--- a/blueprints/yuvomi/docker-compose.yml
+++ b/blueprints/yuvomi/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yuvomi:
-    image: ghcr.io/ulsklyc/yuvomi:0.71.10
+    image: ghcr.io/ulsklyc/yuvomi:1.85.0
     restart: unless-stopped
     environment:
       NODE_ENV: production

--- a/blueprints/yuvomi/meta.json
+++ b/blueprints/yuvomi/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "yuvomi",
   "name": "Yuvomi",
-  "version": "0.71.10",
+  "version": "1.85.0",
   "description": "Privacy-first, self-hosted family planner. Tasks, shopping, meals, calendar sync, budget — one private home for everything your household runs on. No cloud, no subscriptions.",
   "logo": "yuvomi.svg",
   "links": {

--- a/blueprints/yuvomi/meta.json
+++ b/blueprints/yuvomi/meta.json
@@ -1,0 +1,19 @@
+{
+  "id": "yuvomi",
+  "name": "Yuvomi",
+  "version": "0.71.10",
+  "description": "Privacy-first, self-hosted family planner. Tasks, shopping, meals, calendar sync, budget — one private home for everything your household runs on. No cloud, no subscriptions.",
+  "logo": "yuvomi.svg",
+  "links": {
+    "github": "https://github.com/ulsklyc/yuvomi",
+    "website": "https://yuvomi.cloud/",
+    "docs": "https://github.com/ulsklyc/yuvomi#readme"
+  },
+  "tags": [
+    "open-source",
+    "family",
+    "productivity",
+    "calendar",
+    "tasks"
+  ]
+}

--- a/blueprints/yuvomi/template.toml
+++ b/blueprints/yuvomi/template.toml
@@ -1,0 +1,15 @@
+[variables]
+main_domain = "${domain}"
+session_secret = "${password:64}"
+
+[config]
+mounts = []
+
+[[config.domains]]
+serviceName = "yuvomi"
+port = 3000
+host = "${main_domain}"
+
+[config.env]
+SESSION_SECRET = "${session_secret}"
+DOCUMENT_STORAGE_LOCAL_ENABLED = "false"

--- a/blueprints/yuvomi/template.toml
+++ b/blueprints/yuvomi/template.toml
@@ -12,4 +12,6 @@ host = "${main_domain}"
 
 [config.env]
 SESSION_SECRET = "${session_secret}"
+SESSION_SECURE = "true"
+TRUST_PROXY = "1"
 DOCUMENT_STORAGE_LOCAL_ENABLED = "false"

--- a/blueprints/yuvomi/yuvomi.svg
+++ b/blueprints/yuvomi/yuvomi.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="160" y2="160" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6c3aed"/>
+    </linearGradient>
+    <linearGradient id="sheen" x1="0" y1="0" x2="0" y2="160" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.14"/>
+      <stop offset="0.55" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="36" fill="url(#bg)"/>
+  <rect width="160" height="160" rx="36" fill="url(#sheen)"/>
+  <!-- Three translucent, overlapping circles (family); overlaps read as brighter lenses -->
+  <g fill="#ffffff" fill-opacity="0.82">
+    <circle cx="64" cy="72" r="27"/>
+    <circle cx="100" cy="78" r="25"/>
+    <circle cx="80" cy="106" r="24"/>
+  </g>
+</svg>


### PR DESCRIPTION
## What this adds

New template: **Yuvomi** — privacy-first, self-hosted family planner.

Tasks, shopping, meals, calendar sync (Google/Apple/CalDAV), budget — one private home for everything the household runs on. No cloud, no subscriptions.

- **Upstream**: https://github.com/ulsklyc/yuvomi
- **Website**: https://yuvomi.cloud/
- **License**: MIT

## Template details

| | |
|---|---|
| Image | `ghcr.io/ulsklyc/yuvomi:0.71.10` (pinned to latest stable GHCR tag) |
| Services | 1 (`yuvomi`) |
| Volumes | 4 named (`yuvomi-data`, `yuvomi-backups`, `yuvomi-modules`, `yuvomi-documents`) |
| Domain | Single, port 3000 |
| Env | `SESSION_SECRET` generated via `${password:64}` helper; `SESSION_SECURE=true` + `TRUST_PROXY=1` baked in (HTTPS reverse proxy assumption) |
| Healthcheck | wired (`GET /health` → 200) |

## Verified

- [x] `generate-meta.js --check` → 507 templates valid
- [x] Compose + TOML + meta.json syntactically valid
- [x] Deployed on personal Dokploy instance at `yuvomi.skedia.io` — health endpoint returns `{"status":"ok"}` over HTTPS
- [x] Logo rendered in dev server catalog
- [x] Image tag pinned to exact semver (no `latest`)
- [x] No `ports:`, `container_name:`, or `networks:` block (per template rules)
- [x] Service name `yuvomi` consistent across docker-compose.yml + template.toml

## Files

```
blueprints/yuvomi/
├── docker-compose.yml   (image only, named volumes, expose:3000)
├── template.toml        (1 domain, env block)
├── meta.json            (id/name/version/description/logo/links/tags)
└── yuvomi.svg           (logo from upstream repo)
```