### PR TITLE
fix: audit-clean the remaining port-convention violations

### DIFF
--- a/blueprints/adguardhome/docker-compose.yml
+++ b/blueprints/adguardhome/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — DNS (53/tcp+udp), DHCP (67/68) and DNS-over-TLS/QUIC (853) are not HTTP protocols; clients must reach them directly on the host, Traefik cannot route them.
 version: "3.8"
 services:
   adguardhome:
@@ -10,7 +11,8 @@ services:
       - "68:68/tcp" # DHCP Client
       - "853:853/tcp" # DNS over TLS, DNS-over-QUIC
       - "853:853/udp" # DNS over TLS, DNS-over-QUIC
-      - "6060:6060/tcp" # HTTP (pprof)
+    expose:
+      - 6060 # HTTP (pprof) — debug endpoint, no need to publish it on the host
     volumes:
       - adguardhome-work:/opt/adguardhome/work
       - adguardhome-conf:/opt/adguardhome/conf

--- a/blueprints/anytype/docker-compose.yml
+++ b/blueprints/anytype/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — Anytype clients speak the any-sync protocol (TCP 33010, UDP/QUIC 33020) directly against the server; it is not HTTP, so Traefik cannot route it.
 # Example: Any-Sync-Bundle with embedded MongoDB and Redis (all-in-one image)
 #
 # Usage:

--- a/blueprints/chibisafe/docker-compose.yml
+++ b/blueprints/chibisafe/docker-compose.yml
@@ -6,8 +6,6 @@
 services:
   chibisafe:
     image: chibisafe/chibisafe:latest
-    networks:
-      - chibinet
     environment:
       - BASE_API_URL=http://chibisafe_server:8000
     restart: unless-stopped
@@ -20,8 +18,6 @@ services:
 
   chibisafe_server:
     image: chibisafe/chibisafe-server:latest
-    networks:
-      - chibinet
     volumes:
       - database:/app/database:rw
       - uploads:/app/uploads:rw
@@ -43,8 +39,6 @@ services:
 
   caddy:
     image: caddy:2-alpine
-    networks:
-      - chibinet
     volumes:
       - ../files/Caddyfile:/etc/caddy/Caddyfile:ro
       - uploads:/app/uploads:ro
@@ -62,8 +56,3 @@ volumes:
   database:
   uploads:
   logs:
-
-networks:
-  chibinet:
-    driver: bridge
-    internal: true

--- a/blueprints/datalens/docker-compose.yml
+++ b/blueprints/datalens/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - us
 
   data-api:
-    container_name: datalens-data-api
     image: ghcr.io/datalens-tech/datalens-data-api:0.2192.0
     restart: always
     environment:
@@ -43,7 +42,6 @@ services:
       - pg-compeng
 
   pg-us:
-    container_name: datalens-pg-us
     image: postgres:16-alpine
     restart: always
     environment:
@@ -75,8 +73,8 @@ services:
   datalens:
     image: ghcr.io/datalens-tech/datalens-ui:0.2601.0
     restart: always
-    ports:
-      - ${UI_PORT:-8080}:8080
+    expose:
+      - 8080 # web UI — routed through Traefik via the template domain
     depends_on:
       - us
       - control-api

--- a/blueprints/dragonfly-db/docker-compose.yml
+++ b/blueprints/dragonfly-db/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: 'docker.dragonflydb.io/dragonflydb/dragonfly'
     ulimits:
       memlock: -1
-    ports:
-      - "6379:6379"
+    expose:
+      - 6379
     volumes:
       - dragonflydata:/data
     environment: 

--- a/blueprints/drizzle-gateway/docker-compose.yml
+++ b/blueprints/drizzle-gateway/docker-compose.yml
@@ -8,12 +8,6 @@ services:
       MASTERPASS: ${MASTERPASS}
     volumes:
       - drizzle-gateway:/app
-    networks:
-      - dokploy-network
 
 volumes:
   drizzle-gateway:
-
-networks:
-  dokploy-network:
-    external: true

--- a/blueprints/elastic-search/docker-compose.yml
+++ b/blueprints/elastic-search/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.8'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
-    container_name: elasticsearch
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
@@ -20,7 +19,6 @@ services:
 
   kibana:
     image: docker.elastic.co/kibana/kibana:8.10.2
-    container_name: kibana
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
     expose:

--- a/blueprints/emqx/docker-compose.yml
+++ b/blueprints/emqx/docker-compose.yml
@@ -21,10 +21,6 @@ services:
     volumes:
       - emqx_data:/opt/emqx/data
       - emqx_log:/opt/emqx/log
-    networks:
-      dokploy-network:
-        aliases:
-          - emqx-service
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "/opt/emqx/bin/emqx_ctl", "status"]
@@ -52,7 +48,3 @@ services:
 volumes:
   emqx_data:
   emqx_log:
-
-networks:
-  dokploy-network:
-    external: true

--- a/blueprints/enshrouded/docker-compose.yml
+++ b/blueprints/enshrouded/docker-compose.yml
@@ -1,7 +1,7 @@
+# dokploy: allow-host-ports — Enshrouded game clients connect over raw UDP (15637 game, 27015 Steam query); Traefik cannot route UDP game traffic.
 services:
   enshrouded:
     image: mornedhels/enshrouded-server:latest
-    container_name: enshrouded
     hostname: enshrouded
     restart: unless-stopped
     stop_grace_period: 90s

--- a/blueprints/erpnext/docker-compose.yml
+++ b/blueprints/erpnext/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     <<: *custom_image
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -42,8 +40,6 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
 
-    networks:
-      - bench-network
     
     healthcheck:
       test:
@@ -63,8 +59,6 @@ services:
       - default
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -87,8 +81,6 @@ services:
       - long
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -111,8 +103,6 @@ services:
       - short
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -145,8 +135,6 @@ services:
         required: true
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
 
   websocket:
     <<: *custom_image
@@ -167,8 +155,6 @@ services:
         required: true
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
 
   configurator:
     <<: *custom_image
@@ -197,8 +183,6 @@ services:
       REGENERATE_APPS_TXT: "${REGENERATE_APPS_TXT:-0}"
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
 
   create-site:
     <<: *custom_image
@@ -237,8 +221,6 @@ services:
       DB_PORT: "${DB_PORT:-3306}"
       DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       INSTALL_APP_ARGS: ${INSTALL_APP_ARGS}
-    networks:
-      - bench-network
 
   migration:
     <<: *custom_image
@@ -258,8 +240,6 @@ services:
         bench --site all set-config -p pause_scheduler 0;
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
 
   db:
     image: mariadb:10.6
@@ -282,8 +262,6 @@ services:
       - MARIADB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
     volumes:
       - db-data:/var/lib/mysql
-    networks:
-      - bench-network
 
   redis-cache:
     deploy:
@@ -292,8 +270,6 @@ services:
     image: redis:6.2-alpine
     volumes:
       - redis-cache-data:/data
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -310,8 +286,6 @@ services:
     image: redis:6.2-alpine
     volumes:
       - redis-queue-data:/data
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -328,8 +302,6 @@ services:
     image: redis:6.2-alpine
     volumes:
       - redis-socketio-data:/data
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -349,6 +321,3 @@ volumes:
       type: "${SITE_VOLUME_TYPE}"
       o: "${SITE_VOLUME_OPTS}"
       device: "${SITE_VOLUME_DEV}"
-
-networks:
-  bench-network:

--- a/blueprints/fivem/docker-compose.yml
+++ b/blueprints/fivem/docker-compose.yml
@@ -1,5 +1,6 @@
+# dokploy: allow-host-ports — FiveM game clients connect over raw TCP/UDP on 30120; Traefik cannot route game traffic.
 # docker-compose.yml
-# 
+#
 # IMPORTANT: FiveM Template - Two Deployment Modes
 # 
 # MODE 1: Standard FiveM Server

--- a/blueprints/fonoster/docker-compose.yml
+++ b/blueprints/fonoster/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — VoIP stack: SIP signaling (5060-5063 TCP/UDP), RTP media (10000-10100/udp) and the gRPC API endpoints (envoy 8449, rtpengine control 8080) are reached directly by phones/SDKs; these protocols cannot be routed by Traefik.
 services:
   dashboard:
     image: fonoster/dashboard:0.15.15

--- a/blueprints/frappe-hr/docker-compose.yml
+++ b/blueprints/frappe-hr/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     <<: *custom_image
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -42,8 +40,6 @@ services:
     volumes:
       - sites:/home/frappe/frappe-bench/sites
 
-    networks:
-      - bench-network
     
     healthcheck:
       test:
@@ -63,8 +59,6 @@ services:
       - default
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -87,8 +81,6 @@ services:
       - long
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -111,8 +103,6 @@ services:
       - short
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -145,8 +135,6 @@ services:
         required: true
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
 
   websocket:
     <<: *custom_image
@@ -167,8 +155,6 @@ services:
         required: true
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
 
   configurator:
     <<: *custom_image
@@ -197,8 +183,6 @@ services:
       REGENERATE_APPS_TXT: "${REGENERATE_APPS_TXT:-0}"
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
 
   create-site:
     <<: *custom_image
@@ -237,8 +221,6 @@ services:
       DB_PORT: "${DB_PORT:-3306}"
       DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       INSTALL_APP_ARGS: ${INSTALL_APP_ARGS}
-    networks:
-      - bench-network
 
   migration:
     <<: *custom_image
@@ -258,8 +240,6 @@ services:
         bench --site all set-config -p pause_scheduler 0;
     volumes:
       - sites:/home/frappe/frappe-bench/sites
-    networks:
-      - bench-network
 
   db:
     image: mariadb:10.6
@@ -282,8 +262,6 @@ services:
       - MARIADB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
     volumes:
       - db-data:/var/lib/mysql
-    networks:
-      - bench-network
 
   redis-cache:
     deploy:
@@ -292,8 +270,6 @@ services:
     image: redis:6.2-alpine
     volumes:
       - redis-cache-data:/data
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -310,8 +286,6 @@ services:
     image: redis:6.2-alpine
     volumes:
       - redis-queue-data:/data
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -328,8 +302,6 @@ services:
     image: redis:6.2-alpine
     volumes:
       - redis-socketio-data:/data
-    networks:
-      - bench-network
     healthcheck:
       test:
         - CMD
@@ -349,6 +321,3 @@ volumes:
       type: "${SITE_VOLUME_TYPE}"
       o: "${SITE_VOLUME_OPTS}"
       device: "${SITE_VOLUME_DEV}"
-
-networks:
-  bench-network:

--- a/blueprints/lodestone/docker-compose.yml
+++ b/blueprints/lodestone/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — Lodestone hosts game servers (Minecraft et al.) on 25565-25590 (raw TCP) and the dashboard talks to the core agent on 16662 directly by server address; neither is routable through Traefik.
 version: '3.8'
 
 services:

--- a/blueprints/mailpit/docker-compose.yml
+++ b/blueprints/mailpit/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   mailpit:
     image: axllent/mailpit:v1.22.3
     restart: unless-stopped
-    ports:
-      - '1025:1025'
+    expose:
+      - 1025 # SMTP — other services reach it over the internal Docker network (mailpit:1025)
     volumes:
       - 'mailpit-data:/data'
     environment:

--- a/blueprints/mailu/docker-compose.yml
+++ b/blueprints/mailu/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — mail protocols (SMTP 25, SMTPS 465, Submission 587, IMAPS 993) are not HTTP; mail servers and clients must reach them directly on the host.
 version: "3.8"
 
 # Shared Mailu configuration (equivalent to the upstream mailu.env file)

--- a/blueprints/oryx/docker-compose.yml
+++ b/blueprints/oryx/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — RTMP (1935/tcp), WebRTC (8000/udp) and SRT (10080/udp) are streaming protocols Traefik cannot route; they must be published on the host.
 version: "3.8"
 services:
   oryx:

--- a/blueprints/poste.io/docker-compose.yml
+++ b/blueprints/poste.io/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — mail protocols (SMTP 25/465/587, POP3 110/995, IMAP 143/993, Sieve 4190) are not HTTP; mail servers and clients must reach them directly on the host.
 version: "3.8"
 services:
   mailserver:

--- a/blueprints/pre0.22.5-supabase/docker-compose.yml
+++ b/blueprints/pre0.22.5-supabase/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-container-names — frozen legacy template (pre-Dokploy 0.22.5). Supabase functionally depends on container names: Kong routes Realtime via its container DNS name and Vector derives log routing from container names. The ${CONTAINER_PREFIX} per-deploy hash prevents name collisions.
 # Usage
 #   Start:              docker compose up
 #   With helpers:       docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up

--- a/blueprints/pterodactyl/docker-compose.yml
+++ b/blueprints/pterodactyl/docker-compose.yml
@@ -38,12 +38,6 @@ services:
       MYSQL_ROOT_PASSWORD:
       DB_CONNECTION: "mysql"
 
-networks:
-  default:
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16
-
 volumes:
   pterodb:
   pterovar:

--- a/blueprints/qbittorrent/docker-compose.yml
+++ b/blueprints/qbittorrent/docker-compose.yml
@@ -1,5 +1,6 @@
+# dokploy: allow-host-ports — BitTorrent peer connections (6881 TCP/UDP) must reach the host directly; the peering protocol is not HTTP, so Traefik cannot route it.
 # docker-compose.yml
-# 
+#
 # IMPORTANT: First-time setup information
 # - Default username: admin
 # - Password: Check container logs for temporary password on first startup

--- a/blueprints/seafile/docker-compose.yml
+++ b/blueprints/seafile/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       - MARIADB_AUTO_UPGRADE=1
     volumes:
       - seafile-mysql-db:/var/lib/mysql"
-    networks:
-      - seafile-net
     healthcheck:
       test:
         [
@@ -39,8 +37,6 @@ services:
   memcached:
     image: memcached:1.6.29
     entrypoint: memcached -m 256
-    networks:
-      - seafile-net
     healthcheck:
       test:
         [
@@ -78,17 +74,11 @@ services:
         condition: service_healthy
       memcached:
         condition: service_started
-    networks:
-      - seafile-net
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:80/api2/ping"]
       interval: 20s
       timeout: 5s
       retries: 10
-
-networks:
-  seafile-net:
-    name: seafile-net
 
 volumes:
   seafile-mysql-db:

--- a/blueprints/triggerdotdev/docker-compose.yml
+++ b/blueprints/triggerdotdev/docker-compose.yml
@@ -14,9 +14,6 @@ volumes:
   postgres-data:
   redis-data:
 
-networks:
-  webapp:
-
 services:
   webapp:
     image: ghcr.io/triggerdotdev/trigger.dev:${TRIGGER_IMAGE_TAG:-v3}
@@ -30,8 +27,6 @@ services:
     depends_on:
       - postgres
       - redis
-    networks:
-      - webapp
 
   postgres:
     image: postgres:${POSTGRES_IMAGE_TAG:-16}
@@ -40,8 +35,6 @@ services:
       - postgres-data:/var/lib/postgresql/data/
     env_file:
       - .env
-    networks:
-      - webapp
     expose:
       - 5432
     command:
@@ -53,8 +46,6 @@ services:
     restart: ${RESTART_POLICY:-unless-stopped}
     volumes:
       - redis-data:/data
-    networks:
-      - webapp
     expose:
       - 6379
   docker-provider:
@@ -63,8 +54,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     user: root
-    networks:
-      - webapp
     depends_on:
       - webapp
     expose:
@@ -81,8 +70,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     user: root
-    networks:
-      - webapp
     depends_on:
       - webapp
     expose:
@@ -98,8 +85,6 @@ services:
     restart: ${RESTART_POLICY:-unless-stopped}
     environment:
       DATABASE_URL: ${DATABASE_URL}?sslmode=disable
-    networks:
-      - webapp
     depends_on:
       - postgres
     expose:

--- a/blueprints/unifi/docker-compose.yml
+++ b/blueprints/unifi/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — the UniFi controller serves its portal over HTTPS with a self-signed certificate on 8443 and this template defines no Traefik domain; users and UniFi devices reach the controller directly on the host.
 services:
   unifi-network-application:
     image: lscr.io/linuxserver/unifi-network-application:latest

--- a/blueprints/wg-easy/docker-compose.yml
+++ b/blueprints/wg-easy/docker-compose.yml
@@ -1,3 +1,4 @@
+# dokploy: allow-host-ports — WireGuard VPN traffic is raw UDP on 51820; Traefik cannot route it, so the port must be published on the host.
 volumes:
   etc_wireguard:
 
@@ -12,13 +13,13 @@ services:
       - INIT_DNS=1.1.1.1,8.8.8.8
       - PORT=51821
     image: ghcr.io/wg-easy/wg-easy:15
-    container_name: wg-easy
     volumes:
       - etc_wireguard:/etc/wireguard
       - /lib/modules:/lib/modules:ro
     ports:
       - "51820:51820/udp"
-      - "51821:51821/tcp"
+    expose:
+      - 51821 # web UI — routed through Traefik via the template domain
     restart: unless-stopped
     cap_add:
       - NET_ADMIN

--- a/build-scripts/validate-docker-compose.ts
+++ b/build-scripts/validate-docker-compose.ts
@@ -26,6 +26,7 @@ type LogLevel = "info" | "success" | "warning" | "error" | "debug";
 
 class DockerComposeValidator {
 	private allowHostPorts = false;
+	private allowContainerNames = false;
 	private options: Required<DockerComposeValidatorOptions>;
 	private errors: string[] = [];
 	private warnings: string[] = [];
@@ -77,6 +78,11 @@ class DockerComposeValidator {
 			// Opt-out marker for templates whose protocols require host-published ports
 			// (mail/SMTP, game servers, streaming, VPN, remote-desktop relays...).
 			this.allowHostPorts = /^#\s*dokploy:\s*allow-host-ports\b/m.test(content);
+			// Opt-out marker for templates that functionally depend on container_name
+			// (e.g. legacy Supabase: Kong routes Realtime via its container DNS name and
+			// Vector derives log routing from container names). Only use it when the
+			// names are deployment-unique (e.g. include a per-deploy hash/prefix).
+			this.allowContainerNames = /^#\s*dokploy:\s*allow-container-names\b/m.test(content);
 			const compose = yaml.parse(content) as ComposeSpecification;
 
 			if (!compose || typeof compose !== "object") {
@@ -107,9 +113,15 @@ class DockerComposeValidator {
 	private validateNoContainerName(services: Record<string, DefinitionsService>): void {
 		Object.entries(services).forEach(([serviceName, service]) => {
 			if (service.container_name) {
-				this.error(
-					`Service '${serviceName}': Found 'container_name' field. According to README, container_name should not be used. Dokploy manages container names automatically.`
-				);
+				if (this.allowContainerNames) {
+					this.warning(
+						`Service '${serviceName}': uses 'container_name' (allowed by '# dokploy: allow-container-names' marker)`
+					);
+				} else {
+					this.error(
+						`Service '${serviceName}': Found 'container_name' field. According to README, container_name should not be used. Dokploy manages container names automatically.`
+					);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
This PR brings the last 25 blueprints in line with the port/network conventions so `validate-docker-compose.ts` is green across the whole repo (`rustdesk` was already annotated earlier).

For every blueprint I looked at what the ports actually carry and applied one of three decisions:

- **annotated** — the host-published ports carry a non-HTTP protocol (mail, game, VPN, DNS, streaming, VoIP) that Traefik cannot route, so they are intentional. The compose gets the `# dokploy: allow-host-ports — <reason>` marker (same mechanism introduced for rustdesk).
- **converted** — the mapping published a plain HTTP UI (or an internal-only protocol) on the host by accident; it is now `expose`, and the UI keeps working through the Traefik domain defined in `template.toml`.
- **fixed** — removed `container_name` / custom `networks` (Dokploy manages names and attaches services to its network automatically).

| Blueprint | Decision | Rationale |
|---|---|---|
| adguardhome | annotated + converted | DNS 53 tcp/udp, DHCP 67/68, DoT/DoQ 853 stay host-published (not HTTP). The pprof debug port `6060:6060` was an accidental HTTP publish → `expose`. |
| anytype | annotated | Anytype clients speak the any-sync protocol (TCP 33010, UDP/QUIC 33020) directly against the server. |
| chibisafe | fixed | Removed custom `chibinet` network (root + 3 services). Services keep talking via service names on the Dokploy network. |
| datalens | fixed + converted | Removed 2 `container_name` (nothing references them; all env URLs use service names). UI `${UI_PORT:-8080}:8080` → `expose: 8080` (domain in template.toml routes to `datalens:8080`). |
| dragonfly-db | converted | `6379:6379` → `expose`. Redis wire protocol, consumed by other services over the internal Docker network; no reason to publish it on the host. |
| drizzle-gateway | fixed | Removed explicit `dokploy-network` (Dokploy injects it automatically). |
| elastic-search | fixed | Removed 2 `container_name`; `ELASTICSEARCH_HOSTS` already uses the service name. |
| emqx | fixed | Removed explicit `dokploy-network` + alias. The Traefik TCP labels for MQTTS are unaffected (docker provider resolves the container directly); MQTT/WS/dashboard were already `expose`. |
| enshrouded | annotated + fixed | Game traffic is raw UDP (15637 game, 27015 Steam query). Also removed `container_name`. |
| erpnext | fixed | Removed `bench-network` from all 14 services + root. All inter-service refs use service names. |
| fivem | annotated | FiveM clients connect over raw TCP/UDP 30120. |
| fonoster | annotated | VoIP stack: SIP 5060-5063 tcp/udp, RTP 10000-10100/udp, gRPC endpoints (envoy 8449, rtpengine 8080) reached directly by phones/SDKs. |
| frappe-hr | fixed | Same as erpnext (identical compose, different image). |
| lodestone | annotated | Hosts game servers on 25565-25590 (raw TCP) and the dashboard talks to the core agent on 16662 by server address. |
| mailpit | converted | `1025:1025` → `expose`. Other services reach SMTP via `mailpit:1025` on the internal/Dokploy network; UI 8025 already routed via Traefik. |
| mailu | annotated | SMTP 25, SMTPS 465, Submission 587, IMAPS 993. |
| oryx | annotated | RTMP 1935/tcp, WebRTC 8000/udp, SRT 10080/udp. |
| poste.io | annotated | SMTP 25/465/587, POP3 110/995, IMAP 143/993, Sieve 4190. |
| pre0.22.5-supabase | annotated (new marker) | Frozen legacy template that *functionally depends* on `container_name`: Kong routes Realtime via its container DNS name (`realtime-dev.supabase-realtime`) and Vector derives log routing from container names (the toml itself documents this). The `${CONTAINER_PREFIX}` per-deploy hash already prevents collisions, so stripping the names would break the template for no gain. Added a `# dokploy: allow-container-names — <reason>` marker plus a small validator extension (mirrors `allow-host-ports`: errors become warnings only when the marker is present). |
| pterodactyl | fixed | Removed root `networks: default: ipam` subnet override. |
| qbittorrent | annotated | BitTorrent peering 6881 tcp/udp must reach the host directly; Web UI 8080 was already unmapped. |
| seafile | fixed | Removed `seafile-net` (root + 3 services). |
| triggerdotdev | fixed | Removed `webapp` network (root + 6 services). |
| unifi | annotated | Controller portal is HTTPS with a self-signed cert on 8443 and the template defines no Traefik domain; users/devices reach it directly on the host. |
| wg-easy | annotated + converted + fixed | WireGuard 51820/udp stays host-published (raw UDP). Web UI `51821:51821/tcp` → `expose` (template domain routes to 51821 via Traefik). Removed `container_name`. |

**Validator change** (`build-scripts/validate-docker-compose.ts`): added the `# dokploy: allow-container-names` opt-out marker, used only by the frozen `pre0.22.5-supabase` template, with the same semantics as the existing `allow-host-ports` marker (violation downgraded to a warning, justification required in the marker line).

**Note for deployed templates**: the `ports → expose` conversions (dragonfly-db, mailpit, datalens UI, wg-easy UI, adguardhome pprof) only stop publishing those ports on the host on the next redeploy — Traefik routing via the template domain is unaffected because it goes over the Docker network. Anyone who relied on hitting `server-ip:port` directly for those five ports should use the domain (or re-add the mapping in their own deployment).

**Verification**
- `validate-docker-compose.ts` over all blueprints: 0 failures.
- `node generate-meta.js --check`: clean.
- Spot deploys on the demo instance (fresh import of the modified blueprints, deploy, HTTP check through the generated domain):
  - `mailpit` (SMTP 1025 converted to expose): deployed, UI reachable through Traefik — HTTP 200.
  - `datalens` (UI host-port converted to expose): deployed, UI reachable through Traefik — HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
