### PR TITLE
feat: add Louez template

### DIFF
--- a/blueprints/louez/docker-compose.yml
+++ b/blueprints/louez/docker-compose.yml
@@ -1,0 +1,71 @@
+version: "3.8"
+
+services:
+  louez:
+    image: synapsr/louez:2.1.0
+    restart: unless-stopped
+    environment:
+      LOUEZ_MODE: standalone
+      DATABASE_URL: mysql://louez:${DB_PASSWORD}@mysql:3306/louez
+      AUTH_URL: https://${LOUEZ_HOST}
+      AUTH_TRUST_HOST: "true"
+      NEXT_PUBLIC_APP_URL: https://${LOUEZ_HOST}
+      NEXT_PUBLIC_APP_DOMAIN: ${LOUEZ_HOST}
+      # The bucket stays private: Louez streams images same-origin under /files
+      # with its own credentials, so the store needs no domain of its own.
+      S3_ENDPOINT: http://minio:9000
+      S3_REGION: us-east-1
+      S3_BUCKET: louez
+      S3_ACCESS_KEY_ID: louez
+      S3_SECRET_ACCESS_KEY: ${MINIO_PASSWORD}
+      S3_PUBLIC_URL: /files
+    volumes:
+      # Holds the auth secret generated on first boot, so sessions survive
+      # redeploys.
+      - louez-data:/app/data
+    depends_on:
+      mysql:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+
+  mysql:
+    image: mysql:8.4
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: louez
+      MYSQL_USER: louez
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    restart: unless-stopped
+    # A bucket is a top-level directory of the data drive; creating it here
+    # keeps the stack to three services instead of adding a one-shot job. The
+    # entrypoint is replaced because the image's own prepends `minio` to its
+    # arguments, which would turn the shell into an unknown sub-command.
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["mkdir -p /data/louez && exec minio server /data"]
+    environment:
+      MINIO_ROOT_USER: louez
+      MINIO_ROOT_PASSWORD: ${MINIO_PASSWORD}
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  louez-data:
+  mysql-data:
+  minio-data:

--- a/blueprints/louez/louez.svg
+++ b/blueprints/louez/louez.svg
@@ -1,0 +1,4 @@
+<svg width="128" height="128" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="16" fill="#1f54dd"/>
+  <path d="M10 7V25H22V21H14V7H10Z" fill="white"/>
+</svg>

--- a/blueprints/louez/meta.json
+++ b/blueprints/louez/meta.json
@@ -1,0 +1,13 @@
+{
+  "id": "louez",
+  "name": "Louez",
+  "version": "2.1.0",
+  "description": "Open-source equipment rental platform: a branded booking storefront with live availability, plus a back office for reservations, customers, PDF contracts and revenue statistics. Ships with its database and a private image store, and installs its own schema on first boot.",
+  "links": {
+    "github": "https://github.com/Synapsr/Louez",
+    "website": "https://louez.io",
+    "docs": "https://github.com/Synapsr/Louez#readme"
+  },
+  "logo": "louez.svg",
+  "tags": ["rental", "booking", "reservations", "inventory", "ecommerce", "business"]
+}

--- a/blueprints/louez/template.toml
+++ b/blueprints/louez/template.toml
@@ -1,0 +1,15 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+mounts = []
+[[config.domains]]
+serviceName = "louez"
+port = 3000
+host = "${main_domain}"
+
+[config.env]
+LOUEZ_HOST = "${main_domain}"
+DB_PASSWORD = "${password:32}" # Password of the database user Louez connects with
+DB_ROOT_PASSWORD = "${password:32}" # Password for MySQL root user
+MINIO_PASSWORD = "${password:32}" # Credentials Louez uses to read and write product images


### PR DESCRIPTION
## Louez

[Louez](https://github.com/Synapsr/Louez) is an open-source equipment rental platform (AGPL-3.0). Rent out cameras, tools, bikes, party gear or vehicles from a branded storefront with live availability, and manage products, reservations, pickups and returns, customers, PDF contracts and revenue statistics from one dashboard. UI in 8 languages.

## What the blueprint deploys

| Service | Image | Role |
|---|---|---|
| `louez` | `synapsr/louez:2.1.0` | Storefront, dashboard and API — installs its own schema on first boot |
| `mysql` | `mysql:8.4` | Database |
| `minio` | `minio/minio:RELEASE.2025-09-07T16-13-09Z` | Product images, private bucket streamed same-origin through the app under `/files` |

Generated credentials come from `${password:32}` helpers, the domain from `${domain}`. The app's `AUTH_SECRET` is generated on first boot and persisted in the `louez-data` volume, so sessions survive redeploys.

## Testing

Deployed and exercised locally with this exact `docker-compose.yml` before opening the PR:

- three services healthy, database schema installed automatically on first boot;
- first-run routing verified (`/` lands on the login flow, the store resolver 404s on an empty instance);
- account created through the UI flow, product image uploaded through the app into the MinIO bucket, and served back byte-identical from `/files`;
- `node build-scripts/generate-meta.js --check` → `✅ 515 templates validated`.

One note for reviewers, in case it helps other MinIO-based blueprints: the bucket is created by the storage service's start command rather than a one-shot `mc` job, and that requires replacing the image entrypoint (`entrypoint: ["/bin/sh", "-c"]`). MinIO's own entrypoint prepends `minio` to whatever arguments it receives, so a plain `command: sh -c '…'` silently becomes `minio sh -c '…'` and the container crash-loops.
