### PR TITLE
fix: update 20+ broken links in templates

### DIFF
--- a/blueprints/chiefonboarding/meta.json
+++ b/blueprints/chiefonboarding/meta.json
@@ -6,7 +6,7 @@
   "logo": "logo.png",
   "links": {
     "github": "https://github.com/chiefonboarding/chiefonboarding",
-    "website": "https://demo.chiefonboarding.com/",
+    "website": "https://chiefonboarding.com/",
     "docs": "https://docs.chiefonboarding.com/"
   },
   "tags": [

--- a/blueprints/convex/meta.json
+++ b/blueprints/convex/meta.json
@@ -5,7 +5,7 @@
   "description": "Convex is an open-source reactive database designed to make life easy for web app developers.",
   "logo": "convex.svg",
   "links": {
-    "github": "https://github.com/get-convex/convex",
+    "github": "https://github.com/get-convex/convex-backend",
     "website": "https://www.convex.dev/",
     "docs": "https://www.convex.dev/docs"
   },

--- a/blueprints/creed/meta.json
+++ b/blueprints/creed/meta.json
@@ -5,9 +5,9 @@
   "description": "One personal context file every AI agent reads before answering and proposes updates to as it learns about you. Requires an external Supabase project (see instructions).",
   "logo": "creed.svg",
   "links": {
-    "github": "https://github.com/connorhpbrn/creed",
+    "github": "https://github.com/hpbrn/creed",
     "website": "https://creed.md",
-    "docs": "https://creed.md/docs"
+    "docs": "https://docs.creed.md/"
   },
   "tags": [
     "ai",

--- a/blueprints/cup/meta.json
+++ b/blueprints/cup/meta.json
@@ -6,8 +6,8 @@
   "logo": "image.png",
   "links": {
     "github": "https://github.com/sergi0g/cup",
-    "website": "https://cup.sh",
-    "docs": "https://github.com/sergi0g/cup"
+    "website": "https://cup.sergi0g.dev/",
+    "docs": "https://cup.sergi0g.dev/docs"
   },
   "tags": [
     "docker",

--- a/blueprints/docling-serve/meta.json
+++ b/blueprints/docling-serve/meta.json
@@ -6,8 +6,8 @@
   "logo": "docling-serve.png",
   "links": {
     "github": "https://github.com/docling-project/docling-serve",
-    "website": "https://docling-project.github.io/docling-serve/",
-    "docs": "https://docling-project.github.io/docling-serve/",
+    "website": "",
+    "docs": "https://github.com/docling-project/docling-serve/blob/main/docs/README.md",
     "dockerhub": "https://quay.io/repository/docling-project/docling-serve"
   },
   "tags": [

--- a/blueprints/doublezero/meta.json
+++ b/blueprints/doublezero/meta.json
@@ -6,7 +6,7 @@
   "logo": "doublezero.svg",
   "links": {
     "github": "https://github.com/technomancy-dev/00",
-    "website": "https://www.double-zero.cloud/",
+    "website": "",
     "docs": "https://github.com/technomancy-dev/00"
   },
   "tags": [

--- a/blueprints/dozzle/meta.json
+++ b/blueprints/dozzle/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/amir20/dozzle",
     "website": "https://dozzle.dev",
-    "docs": "https://dozzle.dev/docs"
+    "docs": "https://dozzle.dev/guide/what-is-dozzle"
   },
   "tags": [
     "monitoring",

--- a/blueprints/drawio/meta.json
+++ b/blueprints/drawio/meta.json
@@ -6,8 +6,8 @@
   "logo": "drawio.svg",
   "links": {
     "github": "https://github.com/jgraph/drawio",
-    "website": "https://draw.io/",
-    "docs": "https://www.drawio.com/doc/"
+    "website": "https://www.drawio.com/",
+    "docs": "https://www.drawio.com/docs/"
   },
   "tags": [
     "drawing",

--- a/blueprints/drawnix/meta.json
+++ b/blueprints/drawnix/meta.json
@@ -5,9 +5,10 @@
   "description": "Drawnix is an application for generating and managing visual content, powered by pubuzhixing/drawnix Docker image.",
   "logo": "image.png",
   "links": {
-    "github": "https://github.com/pubuzhixing/drawnix",
-    "website": "https://hub.docker.com/r/pubuzhixing/drawnix",
-    "docs": "https://hub.docker.com/r/pubuzhixing/drawnix"
+    "github": "https://github.com/plait-board/drawnix/",
+    "website": "https://drawnix.com/",
+    "docs": "https://github.com/plait-board/drawnix/blob/develop/README_en.md#docker",
+    "dockerhub": "https://hub.docker.com/r/pubuzhixing/drawnix"
   },
   "tags": [
     "visualization",

--- a/blueprints/drizzle-gateway/meta.json
+++ b/blueprints/drizzle-gateway/meta.json
@@ -5,7 +5,7 @@
   "description": "Drizzle Gateway is a self-hosted database gateway that allows you to connect to your databases from anywhere.",
   "logo": "drizzle-gateway.svg",
   "links": {
-    "github": "https://github.com/drizzle-team/drizzle-gateway",
+    "github": "",
     "website": "https://gateway.drizzle.team/",
     "docs": "https://gateway.drizzle.team/docs/railway"
   },

--- a/blueprints/dumbassets/meta.json
+++ b/blueprints/dumbassets/meta.json
@@ -6,7 +6,7 @@
   "logo": "logo.svg",
   "links": {
     "github": "https://github.com/dumbwareio/dumbassets",
-    "website": "https://www.dumbware.io/software/DumbAssets/",
+    "website": "https://dumbware.io/DumbAssets/",
     "docs": "https://github.com/dumbwareio/dumbassets"
   },
   "tags": [

--- a/blueprints/dumbbudget/meta.json
+++ b/blueprints/dumbbudget/meta.json
@@ -5,9 +5,9 @@
   "description": "DumbBudget is a simple, self-hosted budget tracking service with PIN protection and no database required.",
   "logo": "logo.svg",
   "links": {
-    "github": "https://github.com/dumbwareio/dumbbudget",
-    "website": "https://www.dumbware.io/software/DumbBudget/",
-    "docs": "https://github.com/dumbwareio/dumbbudget"
+    "github": "https://github.com/DumbWareio/DumbBudget",
+    "website": "https://dumbware.io/DumbBudget",
+    "docs": "https://github.com/DumbWareio/DumbBudget/blob/main/README.md"
   },
   "tags": [
     "budget",

--- a/blueprints/dumbdrop/meta.json
+++ b/blueprints/dumbdrop/meta.json
@@ -6,7 +6,7 @@
   "logo": "logo.svg",
   "links": {
     "github": "https://github.com/dumbwareio/dumbdrop",
-    "website": "https://www.dumbware.io/software/DumbDrop/",
+    "website": "https://dumbware.io/DumbDrop/",
     "docs": "https://github.com/dumbwareio/dumbdrop"
   },
   "tags": [

--- a/blueprints/dumbpad/meta.json
+++ b/blueprints/dumbpad/meta.json
@@ -6,7 +6,7 @@
   "logo": "logo.svg",
   "links": {
     "github": "https://github.com/dumbwareio/dumbpad",
-    "website": "https://www.dumbware.io/software/DumbPad/",
+    "website": "https://dumbware.io/DumbPad/",
     "docs": "https://github.com/dumbwareio/dumbpad"
   },
   "tags": [

--- a/blueprints/elastic-search/meta.json
+++ b/blueprints/elastic-search/meta.json
@@ -7,7 +7,7 @@
   "links": {
     "github": "https://github.com/elastic/elasticsearch",
     "website": "https://www.elastic.co/elasticsearch/",
-    "docs": "https://docs.elastic.co/elasticsearch/"
+    "docs": "https://www.elastic.co/docs/solutions/search"
   },
   "tags": [
     "search",

--- a/blueprints/evolutionapi/meta.json
+++ b/blueprints/evolutionapi/meta.json
@@ -5,9 +5,9 @@
   "description": "Evolution API is a robust platform dedicated to empowering small businesses with limited resources, going beyond a simple messaging solution via WhatsApp.",
   "logo": "evolutionapi.png",
   "links": {
-    "github": "https://github.com/EvolutionAPI/evolution-api",
-    "docs": "https://doc.evolution-api.com/v2/en/get-started/introduction",
-    "website": "https://evolution-api.com/opensource-whatsapp-api/"
+    "github": "https://github.com/evolution-foundation/evolution-api",
+    "docs": "https://docs.evolutionfoundation.com.br/en",
+    "website": "https://evolutionfoundation.com.br/"
   },
   "tags": [
     "api",

--- a/blueprints/trailbase/meta.json
+++ b/blueprints/trailbase/meta.json
@@ -5,7 +5,7 @@
   "description": "TrailBase is a blazingly fast, open-source application server with type-safe APIs, built-in WebAssembly runtime, realtime, auth, and admin UI built on Rust, SQLite & Wasmtime.",
   "logo": "logo.svg",
   "links": {
-    "github": "https://github.com/trailbase/trailbase",
+    "github": "https://github.com/trailbaseio/trailbase",
     "website": "https://trailbase.io/",
     "docs": "https://trailbase.io/getting-started/install"
   },

--- a/blueprints/wg-easy/meta.json
+++ b/blueprints/wg-easy/meta.json
@@ -6,8 +6,8 @@
   "logo": "image.png",
   "links": {
     "github": "https://github.com/wg-easy/wg-easy",
-    "website": "https://wg-easy.github.io/",
-    "docs": "https://github.com/wg-easy/wg-easy/wiki"
+    "website": "https://wg-easy.github.io/wg-easy/latest/",
+    "docs": "https://wg-easy.github.io/wg-easy/latest/getting-started/"
   },
   "tags": [
     "vpn",


### PR DESCRIPTION
## Before
<img width="644" height="157" alt="image" src="https://github.com/user-attachments/assets/f9eb3ca0-20b9-4ba3-b0e0-8f9b086628be" />

## After
<img width="647" height="154" alt="image" src="https://github.com/user-attachments/assets/29b9e930-f03f-4f76-bed4-5cd76419d9d9" />



# Notes:
- **Commento** commento.io looks dead, the website is a server 404, and the last activity on the repo is 5 years ago. But the image might still be usable.
- **Snapp**: the author changed their github username from `UraniaDev` to `urania-dev` and their Snapp repository seems to be a url-shortener instead of screenshot sharing service as mention in `snapp/meta.json`
- **velix-api** the website velix.dev is dead and the repository doesn't exist and I couldn't find it anywhere (I just found a railway deployment repo for velix but that's about it)


I was planning to turn all the 404 links into an empty strings so that the button doesn't show up in the UI, but wasn't sure if its something the maintainers prefer. If ya'll are ok with that. I'll make all the 404 links into empty string in the next wave of link fixs in the future.
