### PR TITLE
fix: search input icons and scrollbar shift from mode-toggle dropdown

### DIFF
--- a/app/src/components/Search.tsx
+++ b/app/src/components/Search.tsx
@@ -109,20 +109,22 @@ const Search = () => {
             </div>
           </div>
 
-          <Input
-            type="text"
-            placeholder="Search templates..."
-            value={searchQuery}
-            onChange={handleSearchChange}
-            className="w-full p-6"
-          />
-          {searchQuery.length > 0 ? (
-            <div className="cursor-pointer" onClick={handleClearSearch}>
-              <XIcon className="absolute end-3 translate-y-3.5 top-1/2 h-5 w-5 text-gray-400" />
-            </div>
-          ) : (
-            <SearchIcon className="absolute end-3 translate-y-2 top-1/2 lg:size-5 size-4 text-gray-400" />
-          )}
+          <div className="relative">
+            <Input
+              type="text"
+              placeholder="Search templates..."
+              value={searchQuery}
+              onChange={handleSearchChange}
+              className="w-full"
+            />
+            {searchQuery.length > 0 ? (
+              <div className="cursor-pointer" onClick={handleClearSearch}>
+                <XIcon className="absolute end-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
+              </div>
+            ) : (
+              <SearchIcon className="absolute end-3 top-1/2 -translate-y-1/2 lg:size-5 size-4 text-gray-400" />
+            )}
+          </div>
         </div>
 
         <div className="flex flex-row gap-2 justify-between">
@@ -154,7 +156,7 @@ const Search = () => {
                 <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-[200px] p-0">
+            <PopoverContent className="w-50 p-0">
               <Command shouldFilter={false}>
                 <CommandInput
                   placeholder="Search tags...."

--- a/app/src/mode-toggle.tsx
+++ b/app/src/mode-toggle.tsx
@@ -5,7 +5,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuTrigger,  
+  DropdownMenuTrigger,
 } from "./components/ui/dropdown-menu"
 import { useTheme } from "./theme-provider"
 
@@ -13,7 +13,7 @@ export function ModeToggle() {
   const { setTheme } = useTheme()
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="icon">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />


### PR DESCRIPTION
# Seach input UI
- fixed the position of the end-icons to be centered and removed that extra padding
## Before

<img width="641" height="159" alt="image" src="https://github.com/user-attachments/assets/2f08ffa2-cc9c-48be-bb34-0b236d414776" />


## After

<img width="643" height="144" alt="image" src="https://github.com/user-attachments/assets/7c2b0a38-6b36-4388-bd30-e76d5e134758" />

# Mode Toggle Dropdown Menu

By default the dropdown menu causes the scrollbar to appear/disappear which makes an unpleasant layout shift. 
- Added `modal={false}` to fix that

## Before
<img width="184" height="187" alt="image" src="https://github.com/user-attachments/assets/5e83e493-1d3e-4ad0-b046-73b5a6912e2c" />


## After
<img width="185" height="207" alt="image" src="https://github.com/user-attachments/assets/9a165cfb-7f87-46b3-a731-7fb37b4ef63c" />
