### PR TITLE
Update Autobase to version 2.10

### DIFF
--- a/blueprints/autobase/docker-compose.yml
+++ b/blueprints/autobase/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   autobase-console:
-    image: autobase/console:2.7.2
+    image: autobase/console:2.10.0
     restart: unless-stopped
     expose:
       - "80"

--- a/blueprints/autobase/meta.json
+++ b/blueprints/autobase/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "autobase",
   "name": "Autobase",
-  "version": "2.7.2",
+  "version": "2.10.0",
   "description": "Autobase for PostgreSQL® is an open-source alternative to cloud-managed databases (self-hosted DBaaS).",
   "links": {
     "github": "https://github.com/vitabaks/autobase",


### PR DESCRIPTION
Update Autobase Docker image from 2.7.2 to 2.10.0 in docker-compose.yml and sync the blueprint meta.json version to match.

Release notes:
- https://github.com/vitabaks/autobase/releases/tag/2.8.0
- https://github.com/vitabaks/autobase/releases/tag/2.9.0
- https://github.com/vitabaks/autobase/releases/tag/2.10.0

## What is this PR about?

New PR of [Template Name]

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [ ] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

Close automatically the related issues using the keywords: `closes #ISSUE_NUMBER`


## Screenshots or Videos
