### PR TITLE
chore: update Windshift to v0.8.5

### DIFF
--- a/blueprints/windshift/docker-compose.yml
+++ b/blueprints/windshift/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   windshift:
-    image: ghcr.io/windshiftapp/windshift:v0.8.2
+    image: ghcr.io/windshiftapp/windshift:v0.8.5
     restart: unless-stopped
     environment:
       - BASE_URL=https://${DOMAIN}

--- a/blueprints/windshift/meta.json
+++ b/blueprints/windshift/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "windshift",
   "name": "Windshift",
-  "version": "v0.8.2",
+  "version": "v0.8.5",
   "description": "Self-hosted work management platform with projects, tasks, sprints, and team collaboration.",
   "logo": "windshift.png",
   "links": {


### PR DESCRIPTION
Update the Windshift template to the v0.8.5 release and keep the catalog metadata in sync. The image is available for amd64 and arm64, and the Dokploy Compose and template validators pass.