### PR TITLE
feat: add freellmapi template

### DIFF
--- a/blueprints/freellmapi/docker-compose.yml
+++ b/blueprints/freellmapi/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+
+services:
+  freellmapi:
+    image: ghcr.io/tashfeenahmed/freellmapi:v0.8.4
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      PORT: ${PORT}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+    expose:
+      - 3001
+    volumes:
+      - freellmapi-data:/app/server/data
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3001/api/ping').then((res) => { if (!res.ok) process.exit(1); }).catch(() => process.exit(1));"
+        ]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+volumes:
+  freellmapi-data:

--- a/blueprints/freellmapi/freellmapi.svg
+++ b/blueprints/freellmapi/freellmapi.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <circle cx="16" cy="16" r="11" fill="#ffffff"></circle>
+  <circle cx="16" cy="16" r="4" fill="#10b981"></circle>
+</svg>

--- a/blueprints/freellmapi/meta.json
+++ b/blueprints/freellmapi/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "freellmapi",
   "name": "FreeLLMAPI",
-  "version": "v0.8.2",
+  "version": "v0.8.4",
   "description": "FreeLLMAPI aggregates free tiers from 29 LLM providers into a single OpenAI-compatible endpoint with smart routing, automatic failover, per-key rate tracking, and encrypted key storage.",
   "logo": "freellmapi.svg",
   "links": {

--- a/blueprints/freellmapi/meta.json
+++ b/blueprints/freellmapi/meta.json
@@ -1,0 +1,13 @@
+{
+  "id": "freellmapi",
+  "name": "FreeLLMAPI",
+  "version": "v0.8.2",
+  "description": "FreeLLMAPI aggregates free tiers from 29 LLM providers into a single OpenAI-compatible endpoint with smart routing, automatic failover, per-key rate tracking, and encrypted key storage.",
+  "logo": "freellmapi.svg",
+  "links": {
+    "github": "https://github.com/tashfeenahmed/freellmapi",
+    "website": "https://freellmapi.co",
+    "docs": "https://github.com/tashfeenahmed/freellmapi/blob/main/docs/install.md"
+  },
+  "tags": ["ai", "proxy", "llm", "openai-compatible", "developer-tools"]
+}

--- a/blueprints/freellmapi/template.toml
+++ b/blueprints/freellmapi/template.toml
@@ -1,0 +1,14 @@
+[variables]
+main_domain = "${domain}"
+encryption_key = "${password:64}"
+
+[config]
+[[config.domains]]
+serviceName = "freellmapi"
+port = 3001
+host = "${main_domain}"
+
+[config.env]
+NODE_ENV = "production"
+PORT = "3001"
+ENCRYPTION_KEY = "${encryption_key}"

--- a/blueprints/freellmapi/template.toml
+++ b/blueprints/freellmapi/template.toml
@@ -1,6 +1,6 @@
 [variables]
 main_domain = "${domain}"
-encryption_key = "${password:64}"
+encryption_key = "${hash:64}"
 
 [config]
 [[config.domains]]


### PR DESCRIPTION
## Add FreeLLMAPI template

Adds a blueprint for [FreeLLMAPI](https://github.com/tashfeenahmed/freellmapi) — a self-hosted, OpenAI-compatible proxy that aggregates free tiers from 29 LLM providers behind a single `/v1` endpoint, with smart routing (6 strategies), automatic failover with cooldowns, per-key rate tracking, and AES-256-GCM encrypted key storage in SQLite.

### Template details

- **Image:** pinned to `ghcr.io/tashfeenahmed/freellmapi:v0.8.4` (multi-arch: linux/amd64 + linux/arm64)
- **Port:** service listens on `3001`, exposed via `expose` only; domain routed through `[[config.domains]]`
- **Secrets:** `ENCRYPTION_KEY` auto-generated via `${password:64}` — required because the image runs with `NODE_ENV=production`
- **Persistence:** SQLite DB lives in the `freellmapi-data` named volume at `/app/server/data`
- **Healthcheck:** uses the upstream `node -e fetch('http://127.0.0.1:3001/api/ping')` pattern — the Node slim image ships no curl/wget, so a curl-based check would always fail
- Follows repo conventions: no `ports`, no `container_name`, no `networks`; service name matches the blueprint folder; per-folder `meta.json`

### Testing

- `node build-scripts/generate-meta.js --check` passes (518 templates validated)
- Deployed the exact compose file on rootless Podman 6.1.0 against `v0.8.4`: container reaches `healthy`, `/api/ping` → 200, `/v1/models` returns the catalog with the unified key, dashboard serves, and data persists across restarts

### Note for testers

On first run the dashboard requires creating an account. Since Dokploy serves templates via a domain (not localhost), the one-time setup code is printed in the container logs at startup (`First-run setup code: XXXXXXXXXX`) and must be entered to claim the install.