### PR TITLE
feat(wupnext): add new env vars for mcp server

### DIFF
--- a/blueprints/wupnext/docker-compose.yml
+++ b/blueprints/wupnext/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   wupnext:
-    image: docker.io/javierlnmn/wupnext:latest
+    image: docker.io/javierlnmn/wupnext:0.3.0
     restart: unless-stopped
     environment:
       SECRET_KEY: ${SECRET_KEY}

--- a/blueprints/wupnext/docker-compose.yml
+++ b/blueprints/wupnext/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       DEBUG: "False"
       ALLOWED_HOSTS: ${ALLOWED_HOSTS}
       CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS}
+      # Public base URL, used for links in emails
+      SITE_URL: ${SITE_URL}
+      # Public origin the MCP server advertises to clients during discovery
+      MCP_BASE_URL: ${MCP_BASE_URL}
       EMAIL_BACKEND: anymail.backends.resend.EmailBackend
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL}
       RESEND_API_KEY: ${RESEND_API_KEY}
@@ -31,9 +35,14 @@ services:
       DEBUG: "False"
       ALLOWED_HOSTS: ${ALLOWED_HOSTS}
       CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS}
+      SITE_URL: ${SITE_URL}
       EMAIL_BACKEND: anymail.backends.resend.EmailBackend
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL}
       RESEND_API_KEY: ${RESEND_API_KEY}
+      # Django Q2 cluster (ORM broker, no Redis)
+      Q_WORKERS: ${Q_WORKERS}
+      Q_TIMEOUT: ${Q_TIMEOUT}
+      Q_RETRY: ${Q_RETRY}
     volumes:
       - wupnext-db:/app/db
     depends_on:

--- a/blueprints/wupnext/meta.json
+++ b/blueprints/wupnext/meta.json
@@ -2,7 +2,7 @@
   "id": "wupnext",
   "name": "WupNext",
   "version": "latest",
-  "description": "WupNext is a self-hosted to-do and task queue app: groups, subtasks, deadlines, a built-in pomodoro timer, and daily email reminders. Server-rendered Django with HTMX, backed by SQLite.",
+  "description": "WupNext is a self-hosted to-do and task queue app: groups, subtasks, deadlines, a built-in pomodoro timer, email reminders, and an MCP server so an AI client can work the board. Server-rendered Django with HTMX, backed by SQLite.",
   "logo": "logo.svg",
   "links": {
     "github": "https://github.com/javierlnmn/wupnext",
@@ -14,6 +14,7 @@
     "tasks",
     "productivity",
     "pomodoro",
+    "mcp",
     "django",
     "self-hosted"
   ]

--- a/blueprints/wupnext/template.toml
+++ b/blueprints/wupnext/template.toml
@@ -12,11 +12,16 @@ env = [
   "SECRET_KEY=${secret_key}",
   "ALLOWED_HOSTS=${main_domain}",
   "CSRF_TRUSTED_ORIGINS=https://${main_domain}",
+  "SITE_URL=https://${main_domain}",
+  "MCP_BASE_URL=https://${main_domain}",
   "DEFAULT_FROM_EMAIL=${from_email}",
   "RESEND_API_KEY=${resend_api_key}",
   "DJANGO_SUPERUSER_USERNAME=${admin_username}",
   "DJANGO_SUPERUSER_EMAIL=${admin_email}",
-  "DJANGO_SUPERUSER_PASSWORD=${admin_password}"
+  "DJANGO_SUPERUSER_PASSWORD=${admin_password}",
+  "Q_WORKERS=2",
+  "Q_TIMEOUT=60",
+  "Q_RETRY=120"
 ]
 mounts = []
 


### PR DESCRIPTION
## What is this PR about?

Adds new env vars for MCP server + Django Q config missing ones.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

Close automatically the related issues using the keywords: `closes #ISSUE_NUMBER`


## Screenshots or Videos
<img width="1653" height="906" alt="image" src="https://github.com/user-attachments/assets/02d406a8-fb8d-4af0-bcdd-e90d79196276" />
