### PR TITLE
feat: add Kotonoba template

### DIFF
--- a/blueprints/kotonoba/docker-compose.yml
+++ b/blueprints/kotonoba/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+
+services:
+  kotonoba:
+    image: ghcr.io/trixtylab/kotonoba:latest
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      DB_PATH: ${DB_PATH}
+      UPLOAD_DIR: ${UPLOAD_DIR}
+      JWT_SECRET: ${JWT_SECRET}
+      SITE_URL: ${SITE_URL}
+      ADMIN_DOMAIN: ${ADMIN_DOMAIN}
+    volumes:
+      - blog_data:/app/data
+
+volumes:
+  blog_data: {}
+

--- a/blueprints/kotonoba/docker-compose.yml
+++ b/blueprints/kotonoba/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   kotonoba:
-    image: ghcr.io/trixtylab/kotonoba:latest
+    image: ghcr.io/trixtylab/kotonoba:1.0.19
     restart: unless-stopped
     environment:
       NODE_ENV: production

--- a/blueprints/kotonoba/icon.svg
+++ b/blueprints/kotonoba/icon.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="100%" height="100%">
+  <defs>
+    <!-- Primary Accent Gradient (Electric Indigo to Violet) -->
+    <linearGradient id="iconAccent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818CF8" />
+      <stop offset="100%" stop-color="#4F46E5" />
+    </linearGradient>
+
+    <!-- Cyan Highlight Gradient -->
+    <linearGradient id="iconCyan" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38BDF8" />
+      <stop offset="100%" stop-color="#0284C7" />
+    </linearGradient>
+  </defs>
+
+  <!-- Pure Standalone Vector Symbol without Background Container -->
+  <g transform="translate(14, 10)">
+    <!-- Top Spark Dot (Kanji 言 Radical Spark) -->
+    <circle cx="80" cy="36" r="10" fill="url(#iconCyan)" />
+
+    <!-- Vertical Spine Pillar (CMS Core Column) -->
+    <rect x="68" y="58" width="24" height="144" rx="12" fill="url(#iconAccent)" />
+
+    <!-- Upper Speech Bar (Horizontal Japanese Radical Stroke) -->
+    <rect x="110" y="68" width="44" height="12" rx="6" fill="url(#iconCyan)" opacity="0.95" />
+
+    <!-- Geometric Dynamic Chevrons forming 'K' -->
+    <path
+      d="M 110 120 
+         C 110 112, 116 105, 124 101 
+         L 168 76 
+         C 178 70, 191 78, 191 89 
+         C 191 95, 187 101, 182 104 
+         L 142 126 
+         C 135 130, 135 136, 142 140 
+         L 183 162 
+         C 188 165, 191 171, 191 177 
+         C 191 188, 178 196, 168 190 
+         L 124 165 
+         C 116 161, 110 154, 110 146 
+         Z"
+      fill="url(#iconAccent)"
+    />
+
+    <!-- Central Dialogue Focal Point Node -->
+    <circle cx="130" cy="133" r="9" fill="url(#iconCyan)" />
+  </g>
+</svg>

--- a/blueprints/kotonoba/meta.json
+++ b/blueprints/kotonoba/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "kotonoba",
   "name": "Kotonoba",
-  "version": "latest",
+  "version": "1.0.19",
   "description": "A high-performance, self-hosted, multi-tenant blog CMS built with Next.js 16, SQLite, Tailwind CSS v4, and Docker.",
   "logo": "icon.svg",
   "links": {

--- a/blueprints/kotonoba/meta.json
+++ b/blueprints/kotonoba/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "kotonoba",
+  "name": "Kotonoba",
+  "version": "latest",
+  "description": "A high-performance, self-hosted, multi-tenant blog CMS built with Next.js 16, SQLite, Tailwind CSS v4, and Docker.",
+  "logo": "icon.svg",
+  "links": {
+    "github": "https://github.com/trixtylab/kotonoba",
+    "website": "https://github.com/trixtylab/kotonoba",
+    "docs": "https://github.com/TrixtyLab/kotonoba/tree/master/docs"
+  },
+  "tags": [
+    "blog",
+    "i18n",
+    "nextjs",
+    "web"
+  ]
+}

--- a/blueprints/kotonoba/template.toml
+++ b/blueprints/kotonoba/template.toml
@@ -9,7 +9,7 @@ env = [
   "UPLOAD_DIR=/app/data/uploads",
   "JWT_SECRET=${jwt_secret}",
   "SITE_URL=https://${main_domain}",
-  "ADMIN_DOMAIN=https://${main_domain}"
+  "ADMIN_DOMAIN=${main_domain}"
 ]
 mounts = []
 

--- a/blueprints/kotonoba/template.toml
+++ b/blueprints/kotonoba/template.toml
@@ -1,0 +1,20 @@
+[variables]
+main_domain = "${domain}"
+jwt_secret = "${password:32}"
+
+[config]
+env = [
+  "NODE_ENV=production",
+  "DB_PATH=/app/data/kotonoba.db",
+  "UPLOAD_DIR=/app/data/uploads",
+  "JWT_SECRET=${jwt_secret}",
+  "SITE_URL=https://${main_domain}",
+  "ADMIN_DOMAIN=https://${main_domain}"
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "kotonoba"
+port = 3000
+host = "${main_domain}"
+


### PR DESCRIPTION
## What is this PR about?

New PR of Kotonoba template.

**Kotonoba** is a high-performance, self-hosted, multi-tenant blog CMS built with Next.js 16 (App Router), SQLite via Drizzle ORM, Tailwind CSS v4, and Docker.

### Key Highlights:
- **Zero Heavy Dependencies**: Runs on embedded SQLite with automatic WAL mode, storing the database and uploads in `/app/data`.
- **Multi-Tenant Architecture**: Supports multiple blogs and custom domains from a single deployment.
- **Full Internationalization (i18n)**: Native bilingual routing, localized metadata, and RSS/Atom/LLMs.txt feeds.
- **Container**: `ghcr.io/trixtylab/kotonoba:latest` exposing port `3000`.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

N/A

## Screenshots or Videos

<img width="1916" height="991" alt="imagen" src="https://github.com/user-attachments/assets/cbc869b2-3bff-4ff3-b9bf-67e53f2886f2" />

<img width="1916" height="997" alt="imagen" src="https://github.com/user-attachments/assets/abafbfb5-ff50-4bde-9990-04a952dee6ed" />
