### PR TITLE
fix(rustrak-full): bind UI to 0.0.0.0; chore(trmnl-larapaper): bump to 0.40.0

### DIFF
--- a/blueprints/rustrak-full/docker-compose.yml
+++ b/blueprints/rustrak-full/docker-compose.yml
@@ -23,6 +23,9 @@ services:
     restart: unless-stopped
     environment:
       - RUSTRAK_API_URL=${RUSTRAK_API_URL}
+      # Next.js standalone binds to $HOSTNAME (the container id) by default, which is
+      # unreachable from Traefik on the Dokploy network -> 502. Bind to all interfaces.
+      - HOSTNAME=0.0.0.0
     expose:
       - 3000
     depends_on:

--- a/blueprints/trmnl-larapaper/docker-compose.yml
+++ b/blueprints/trmnl-larapaper/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   trmnl-larapaper:
-    image: ghcr.io/usetrmnl/larapaper:0.33.0
+    image: ghcr.io/usetrmnl/larapaper:0.40.0
     environment:
       - APP_URL=${APP_URL}
       - PHP_OPCACHE_ENABLE=${PHP_OPCACHE_ENABLE}

--- a/blueprints/trmnl-larapaper/meta.json
+++ b/blueprints/trmnl-larapaper/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "trmnl-larapaper",
   "name": "TRMNL LaraPaper",
-  "version": "0.33.0",
+  "version": "0.40.0",
   "description": "LaraPaper is a self-hosted application (BYOS) to manage TRMNL e-ink devices.",
   "logo": "larapaper.svg",
   "links": {


### PR DESCRIPTION
Follow-up to #1102 and #1101 (both merged as-is since they work and are improvements).

## rustrak-full
The Next.js standalone UI binds to `$HOSTNAME` (the container id) by default, so Traefik on the Dokploy network gets connection refused and the UI domain returns **502**. This was pre-existing on canary (confirmed by deploying both the #1102 branch and canary — same 502). Adding `HOSTNAME=0.0.0.0` was deploy-verified on hostinger.dokploy.com: UI → **200** "Rustrak - Error Tracking System", API domain 401 (auth, expected), postgres healthy. Same pattern already used by other Next.js templates in the repo (langfuse, etc.).

## trmnl-larapaper
#1101 bumped the image to 0.33.0 (April 2026); upstream is at **0.40.0** (2026-08-24, manifest 200 on GHCR). 0.40.0 was deployed on the same template: healthy, RestartCount 0, migrations done, `/`, `/login`, `/register`, `/up` all **200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)