### PR TITLE
Add BlogFactory template

### DIFF
--- a/blueprints/blogfactory/README.md
+++ b/blueprints/blogfactory/README.md
@@ -1,0 +1,12 @@
+# BlogFactory on Dokploy
+
+Dokploy creates independent database, storage, JWT, encryption, and scheduler secrets during import. Only the `web` service receives a public domain; the API, scheduler, PostgreSQL, and MinIO remain private.
+
+## First administrator
+
+1. Open the Compose service's environment settings and copy the generated `ADMIN_EMAILS` value.
+2. Open the generated BlogFactory domain and register with that exact email address.
+3. Return to the Compose environment settings, change `BLOGFACTORY_ALLOW_SIGNUP` to `false`, and redeploy.
+4. Add OpenRouter, CMS, or Google Search Console credentials from BlogFactory only when you need those optional integrations.
+
+BlogFactory sends reviewed content to connected CMS providers as drafts. The template does not grant live-publish or delete authority.

--- a/blueprints/blogfactory/blogfactory.svg
+++ b/blueprints/blogfactory/blogfactory.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#fff"/>
+  <rect x="1" y="1" width="62" height="62" rx="7" fill="none" stroke="#d7d8d4" stroke-width="2"/>
+  <circle cx="50" cy="14" r="5" fill="#ff5a1f"/>
+  <rect x="13" y="31" width="10" height="18" fill="#202224"/>
+  <rect x="27" y="20" width="10" height="29" fill="#202224"/>
+  <rect x="41" y="26" width="10" height="23" fill="#202224"/>
+</svg>

--- a/blueprints/blogfactory/docker-compose.yml
+++ b/blueprints/blogfactory/docker-compose.yml
@@ -1,0 +1,102 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:17.6-alpine3.22
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: blogfactory
+      POSTGRES_USER: blogfactory
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U blogfactory -d blogfactory"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    restart: unless-stopped
+    command: server /data --console-address :9001
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  api:
+    image: ghcr.io/blogfactoryhq/blogfactory-api:v0.1.0
+    restart: unless-stopped
+    command: >-
+      sh -c "bun run src/init-s3-bucket.ts && bun run src/db/migrate.ts && exec bun run src/index.ts"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    expose:
+      - 3000
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      BLOGFACTORY_SELF_HOSTED: "true"
+      DATABASE_URL: postgresql://blogfactory:${POSTGRES_PASSWORD}@postgres:5432/blogfactory
+      JWT_SECRET: ${JWT_SECRET}
+      API_KEY_ENCRYPTION_SECRET: ${API_KEY_ENCRYPTION_SECRET}
+      ADMIN_EMAILS: ${ADMIN_EMAILS}
+      BLOGFACTORY_ALLOW_SIGNUP: ${BLOGFACTORY_ALLOW_SIGNUP}
+      CRON_SECRET: ${CRON_SECRET}
+      WEB_APP_URL: ${BLOGFACTORY_URL}
+      MCP_APP_URL: http://web/mcp-review.html
+      MCP_ALLOWED_ORIGINS: ${BLOGFACTORY_URL}
+      S3_ENDPOINT: http://minio:9000
+      S3_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      S3_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      S3_BUCKET: blogfactory
+      S3_REGION: us-east-1
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:3000/api/ready').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  web:
+    image: ghcr.io/blogfactoryhq/blogfactory-web:v0.1.0
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    expose:
+      - 80
+    environment:
+      API_UPSTREAM: http://api:3000
+    healthcheck:
+      test: ["CMD-SHELL", "nginx -t >/dev/null 2>&1 && wget -q -O /dev/null http://api:3000/api/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  scheduler:
+    image: curlimages/curl:8.15.0
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      CRON_SECRET: ${CRON_SECRET}
+      CRON_INTERVAL_SECONDS: 21600
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        while true; do curl --fail --silent --show-error --output /dev/null -H "Authorization: Bearer $${CRON_SECRET}" http://api:3000/api/cron/drain && echo "Scheduler drain completed"; sleep "$${CRON_INTERVAL_SECONDS}"; done
+
+volumes:
+  postgres-data:
+  minio-data:

--- a/blueprints/blogfactory/meta.json
+++ b/blueprints/blogfactory/meta.json
@@ -1,0 +1,13 @@
+{
+  "id": "blogfactory",
+  "name": "BlogFactory",
+  "version": "v0.1.0",
+  "description": "Self-hosted control plane for AI-assisted content operations and human-approved CMS draft delivery.",
+  "logo": "blogfactory.svg",
+  "links": {
+    "github": "https://github.com/BlogFactoryHQ/blogfactory",
+    "website": "https://blogfactory.io/",
+    "docs": "https://github.com/BlogFactoryHQ/blogfactory/blob/main/docs/self-hosting.md"
+  },
+  "tags": ["ai", "automation", "content-management"]
+}

--- a/blueprints/blogfactory/template.toml
+++ b/blueprints/blogfactory/template.toml
@@ -1,0 +1,28 @@
+[variables]
+main_domain = "${domain}"
+postgres_password = "${password:48}"
+minio_root_user = "blogfactory"
+minio_root_password = "${password:48}"
+jwt_secret = "${base64:48}"
+encryption_secret = "${base64:48}"
+cron_secret = "${base64:48}"
+admin_email = "${email}"
+
+[config]
+env = [
+  "POSTGRES_PASSWORD=${postgres_password}",
+  "MINIO_ROOT_USER=${minio_root_user}",
+  "MINIO_ROOT_PASSWORD=${minio_root_password}",
+  "JWT_SECRET=${jwt_secret}",
+  "API_KEY_ENCRYPTION_SECRET=${encryption_secret}",
+  "CRON_SECRET=${cron_secret}",
+  "ADMIN_EMAILS=${admin_email}",
+  "BLOGFACTORY_ALLOW_SIGNUP=true",
+  "BLOGFACTORY_URL=https://${main_domain}",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "web"
+port = 80
+host = "${main_domain}"


### PR DESCRIPTION
## What this adds

BlogFactory is an AGPL-3.0 self-hosted control plane for multi-site content operations. This template deploys five services: web, API, scheduler, PostgreSQL, and MinIO. Only web receives a public Dokploy domain.

The template generates independent PostgreSQL, MinIO, JWT, encryption, cron, and initial-admin values. AI provider, CMS, and Google Search Console credentials are intentionally configured after installation.

## Verification

- Dokploy: v0.30.2 on a disposable GitHub Actions Ubuntu runner
- Final BlogFactory images: v0.1.0
- Real deployment status: done
- Verified: all five containers, public web, `/api/ready`, MCP 401 Bearer challenge, signup/login, site creation, MinIO upload/readback, 22-tool MCP catalog, scheduler drain, restart persistence, and closed signup
- Official template validator, Compose validator, and preview build: passed
- Acceptance run: https://github.com/BlogFactoryHQ/blogfactory/actions/runs/32890291524
- Release image run: https://github.com/BlogFactoryHQ/blogfactory/actions/runs/32889710136