### PR TITLE
fix: update Pocket ID template to v2.14.0

### DIFF
--- a/blueprints/pocket-id/docker-compose.yml
+++ b/blueprints/pocket-id/docker-compose.yml
@@ -1,15 +1,19 @@
+version: "3.8"
+
 services:
   pocket-id:
-    image: ghcr.io/pocket-id/pocket-id:v1
+    image: pocketid/pocket-id:v2.14.0
     restart: unless-stopped
     environment:
-      - APP_URL
-      - TRUST_PROXY
-      - ENCRYPTION_KEY
+      APP_URL: ${APP_URL}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      TRUST_PROXY: ${TRUST_PROXY}
     volumes:
       - pocket-id-data:/app/data
+    expose:
+      - "1411"
     healthcheck:
-      test: [ "CMD", "/app/pocket-id", "healthcheck" ]
+      test: ["CMD", "/app/pocket-id", "healthcheck"]
       interval: 1m30s
       timeout: 5s
       retries: 2

--- a/blueprints/pocket-id/meta.json
+++ b/blueprints/pocket-id/meta.json
@@ -1,16 +1,22 @@
 {
   "id": "pocket-id",
   "name": "Pocket ID",
-  "version": "v1",
-  "description": "A simple and easy-to-use OIDC provider that allows users to authenticate with their passkeys to your services.",
+  "version": "2.14.0",
+  "description": "Pocket ID is a simple OpenID Connect and OAuth 2.0 provider that lets users authenticate to applications with passkeys.",
   "logo": "pocket-id.svg",
   "links": {
     "github": "https://github.com/pocket-id/pocket-id",
     "website": "https://pocket-id.org/",
-    "docs": "https://pocket-id.org/docs"
+    "docs": "https://pocket-id.org/docs/"
   },
   "tags": [
+    "authentication",
     "identity",
-    "auth"
+    "sso",
+    "oidc",
+    "oauth2",
+    "passkeys",
+    "security",
+    "self-hosted"
   ]
 }

--- a/blueprints/pocket-id/template.toml
+++ b/blueprints/pocket-id/template.toml
@@ -1,5 +1,6 @@
 [variables]
 main_domain = "${domain}"
+encryption_key = "${base64:32}"
 
 [config]
 mounts = []
@@ -10,6 +11,6 @@ port = 1411
 host = "${main_domain}"
 
 [config.env]
-ENCRYPTION_KEY = "CHANGEME: openssl rand -base64 32"
-APP_URL = "http://${main_domain}"
+APP_URL = "https://${main_domain}"
+ENCRYPTION_KEY = "${encryption_key}"
 TRUST_PROXY = "true"


### PR DESCRIPTION
## Summary

- upgrade Pocket ID from v1 to the pinned v2.14.0 release
- generate a secure encryption key during template creation and use an HTTPS application URL
- expose the v2 application port and refresh template metadata

## Testing

- `pnpm exec tsx validate-docker-compose.ts --file ../blueprints/pocket-id/docker-compose.yml --verbose`
- `pnpm exec tsx validate-template.ts --dir ../blueprints/pocket-id --verbose`
- `node build-scripts/generate-meta.js --check`
- pulled and started `pocketid/pocket-id:v2.14.0`; the built-in health check passed and the service initialized successfully on port 1411