### PR TITLE
fix: Update outdated website URL

### DIFF
--- a/blueprints/wanderer/meta.json
+++ b/blueprints/wanderer/meta.json
@@ -6,7 +6,7 @@
   "logo": "image.png",
   "links": {
     "github": "https://github.com/flomp/wanderer",
-    "website": "https://wanderer.app",
+    "website": "https://wanderer.to",
     "docs": "https://github.com/flomp/wanderer#readme"
   },
   "tags": [


### PR DESCRIPTION
## What is this PR about?
Fixing outdated website URL for the Wanderer template.

The old website URL redirects to godaddy "domain for sale" page.

## Checklist
- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

## Screenshots or Videos