### PR TITLE
chore(plausible): update to v3.2.1

### DIFF
--- a/blueprints/plausible/docker-compose.yml
+++ b/blueprints/plausible/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   plausible_events_db:
-    image: clickhouse/clickhouse-server:24.3.3.102-alpine
+    image: clickhouse/clickhouse-server:24.12-alpine
     restart: always
 
     volumes:
@@ -21,19 +21,30 @@ services:
       nofile:
         soft: 262144
         hard: 262144
+    environment:
+      # Required since ClickHouse 24.11+ images: skip the default-user setup so
+      # Plausible can connect as "default" without a password (matches the
+      # official CE v3 compose.yml).
+      - CLICKHOUSE_SKIP_USER_SETUP=1
 
   plausible:
-    image: ghcr.io/plausible/community-edition:v2.1.5
+    image: ghcr.io/plausible/community-edition:v3.2.1
     restart: always
     command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run"
     depends_on:
       - plausible_db
       - plausible_events_db
+    volumes:
+      - plausible-data:/var/lib/plausible
+    environment:
+      - TMPDIR=/var/lib/plausible/tmp
     env_file:
       - .env
 
 volumes:
   db-data:
+    driver: local
+  plausible-data:
     driver: local
   event-data:
     driver: local

--- a/blueprints/plausible/meta.json
+++ b/blueprints/plausible/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "plausible",
   "name": "Plausible",
-  "version": "v2.1.5",
+  "version": "v3.2.1",
   "description": "Plausible is a open source, self-hosted web analytics platform that lets you track website traffic and user behavior.",
   "logo": "logo.svg",
   "links": {


### PR DESCRIPTION
The template was pinned to `v2.1.5` (May 2024); upstream's latest stable is **v3.2.1** (2026-05-15).

## Changes
- `ghcr.io/plausible/community-edition`: `v2.1.5` → `v3.2.1` (manifest verified on GHCR)
- `clickhouse-server`: `24.3.3.102-alpine` → `24.12-alpine`, matching the [official CE v3.2.1 compose.yml](https://github.com/plausible/community-edition/blob/v3.2.1/compose.yml)
- `CLICKHOUSE_SKIP_USER_SETUP=1` on `plausible_events_db` — required by ClickHouse 24.11+ images; without it Plausible crash-loops with `AUTHENTICATION_FAILED` (reproduced during testing)
- `plausible-data` volume + `TMPDIR` per the official v3 compose
- `meta.json` version → `v3.2.1`

## Verification
Deploy-tested on hostinger.dokploy.com via base64 import with fresh volumes: all 3 containers running, domain → **HTTP 200** «Plausible · Simple, privacy-friendly alternative to Google Analytics». Note: fresh installs only — this template change doesn't attempt in-place v2→v3 data migrations for existing deployments (upstream has a documented upgrade path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)