### PR TITLE
fix(odoo_17, odoo_18): provide odoo.conf via config mount and enable proxy_mode

### DIFF
--- a/blueprints/odoo_17/template.toml
+++ b/blueprints/odoo_17/template.toml
@@ -3,9 +3,17 @@ main_domain = "${domain}"
 
 [config]
 env = {}
-mounts = []
 
 [[config.domains]]
 serviceName = "web"
 port = 8_069
 host = "${main_domain}"
+
+[[config.mounts]]
+filePath = "config/odoo.conf"
+content = """
+[options]
+addons_path = /mnt/extra-addons
+data_dir = /var/lib/odoo
+proxy_mode = True
+"""

--- a/blueprints/odoo_18/template.toml
+++ b/blueprints/odoo_18/template.toml
@@ -3,9 +3,17 @@ main_domain = "${domain}"
 
 [config]
 env = {}
-mounts = []
 
 [[config.domains]]
 serviceName = "web"
 port = 8_069
 host = "${main_domain}"
+
+[[config.mounts]]
+filePath = "config/odoo.conf"
+content = """
+[options]
+addons_path = /mnt/extra-addons
+data_dir = /var/lib/odoo
+proxy_mode = True
+"""


### PR DESCRIPTION
## Summary

odoo_17 and odoo_18 share the exact bug that broke odoo_19 (#1108, fixed by #1110): the compose file bind-mounts `../files/config` over `/etc/odoo`, but `template.toml` has `mounts = []`, so the empty directory hides the image's `/etc/odoo/odoo.conf`. `wait-for-psql.py` then crashes with `configparser.NoSectionError: No section: 'options'` and the web container exits.

This applies the same fix that landed for odoo_19 in #1110: ship `odoo.conf` through a `[[config.mounts]]` entry (with `proxy_mode = True` so websocket/POS/livechat work behind Traefik). The compose files needed no changes — they already match odoo_19's.

## Evidence (deployed on a live Dokploy instance)

**Before (canary as-is, odoo_17):**
- Web container `exited` (exit code 1), Traefik returns `404 page not found`
- Logs: `grep: /etc/odoo/odoo.conf: No such file or directory` → `configparser.NoSectionError: No section: 'options'` in `wait-for-psql.py`

**After (this branch):**
- odoo_17: HTTP 200 on `/` and `/web/database/selector`, web+db `running`, RestartCount 0
- odoo_18: HTTP 200 on `/` and `/web/database/selector`, web+db `running`, RestartCount 0

Validators pass: `generate-meta.js --check`, `validate-docker-compose.ts`, `validate-template.ts` for both templates.

Refs #1108, #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)