### PR TITLE
feat: add LFSX template

### DIFF
--- a/blueprints/lfsx/docker-compose.yml
+++ b/blueprints/lfsx/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  lfsx:
+    image: ghcr.io/ferrlabs/lfsx:1.14.1
+    restart: unless-stopped
+    environment:
+      - LFSX_AUTH=github
+    volumes:
+      - lfsx-data:/var/lib/lfsx
+    expose:
+      - "8080"
+
+volumes:
+  lfsx-data: {}

--- a/blueprints/lfsx/lfsx.svg
+++ b/blueprints/lfsx/lfsx.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#1d6b52" />
+  <rect x="3" y="3" width="12" height="12" fill="#f3f2f2" />
+  <rect x="17" y="3" width="12" height="12" fill="#f3f2f2" />
+  <rect x="3" y="17" width="12" height="12" fill="#f3f2f2" />
+  <rect x="17" y="17" width="12" height="12" fill="#7fa896" />
+</svg>

--- a/blueprints/lfsx/meta.json
+++ b/blueprints/lfsx/meta.json
@@ -1,0 +1,18 @@
+{
+  "id": "lfsx",
+  "name": "LFSX",
+  "version": "1.14.1",
+  "description": "Self-hosted Git LFS server that keeps large binaries off your forge's metered storage.",
+  "logo": "lfsx.svg",
+  "links": {
+    "github": "https://github.com/FerrLabs/LFSX",
+    "website": "https://lfsx.dev",
+    "docs": "https://lfsx.dev/docs/quickstart"
+  },
+  "tags": [
+    "git",
+    "developer-tools",
+    "storage",
+    "self-hosted"
+  ]
+}

--- a/blueprints/lfsx/template.toml
+++ b/blueprints/lfsx/template.toml
@@ -1,0 +1,13 @@
+[variables]
+main_domain = "${domain}"
+
+[config]
+mounts = []
+[[config.domains]]
+serviceName = "lfsx"
+port = 8080
+host = "${main_domain}"
+
+[config.env]
+LFSX_PUBLIC_URL = "https://${main_domain}"
+LFSX_AUTH = "github"


### PR DESCRIPTION
LFSX is a self-hosted Git LFS server: objects stored once across repositories, optional
compression and encryption at rest, file locking, and permissions delegated to the upstream forge
(GitHub, GitLab, Gitea, Forgejo).

Tested locally with docker compose, the container starts and /health answers 200.
`node build-scripts/generate-meta.js --check` passes with 533 templates.

No healthcheck in the compose file: the image is distroless, so it has no shell and no curl for a
CMD probe. The server exposes /health and /ready over HTTP for an external check.
