### PR TITLE
fix(supabase): move the API gateway to Envoy and close five parity gaps with official self-host

### DIFF
--- a/blueprints/supabase/docker-compose.yml
+++ b/blueprints/supabase/docker-compose.yml
@@ -59,8 +59,8 @@ services:
       SNIPPETS_MANAGEMENT_FOLDER: /app/snippets
       EDGE_FUNCTIONS_MANAGEMENT_FOLDER: /app/edge-functions
     volumes:
-      - ../files/volumes/snippets:/app/snippets:Z
-      - ../files/volumes/functions:/app/edge-functions:Z
+      - ../files/volumes/snippets:/app/snippets:z
+      - ../files/volumes/functions:/app/edge-functions:ro,z
 
   api-gw:
     image: envoyproxy/envoy:v1.39.0
@@ -309,7 +309,7 @@ services:
     image: supabase/edge-runtime:v1.74.0
     restart: unless-stopped
     volumes:
-      - ../files/volumes/functions:/home/deno/functions:Z
+      - ../files/volumes/functions:/home/deno/functions:z
       - deno-cache:/root/.cache/deno
     depends_on:
       api-gw:

--- a/blueprints/supabase/docker-compose.yml
+++ b/blueprints/supabase/docker-compose.yml
@@ -3,8 +3,9 @@
 #   Stop:               docker compose down
 #   Reset everything:   ./reset.sh
 #
-# Dokploy: Kong is exposed on port 8000 for domain routing. Storage uses local file
-# backend by default; edit the storage service env in this file to switch to S3/MinIO.
+# Dokploy: the Envoy API gateway (api-gw) is exposed on port 8000 for domain routing.
+# Storage uses the local file backend by default; edit the storage service env in
+# this file to switch to S3/MinIO.
 
 name: supabase
 
@@ -44,7 +45,7 @@ services:
       DEFAULT_PROJECT_NAME: ${STUDIO_DEFAULT_PROJECT}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
 
-      SUPABASE_URL: http://kong:8000
+      SUPABASE_URL: http://api-gw:8000
       SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
@@ -61,44 +62,36 @@ services:
       - ../files/volumes/snippets:/app/snippets:Z
       - ../files/volumes/functions:/app/edge-functions:Z
 
-  kong:
-    image: kong/kong:3.9.3
+  api-gw:
+    image: envoyproxy/envoy:v1.39.0
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "kong", "health"]
-      interval: 5s
+      # Using a TCP port check because this image does not include curl or wget.
+      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 3
     depends_on:
       studio:
         condition: service_healthy
     expose:
       - 8000
-      - 8443
     volumes:
-      - ../files/volumes/api/kong.yml:/home/kong/temp.yml:ro,z
-      - ../files/volumes/api/kong-entrypoint.sh:/home/kong/kong-entrypoint.sh:ro,z
+      - ../files/volumes/api/envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro,z
+      - ../files/volumes/api/envoy/cds.yaml:/etc/envoy/cds.yaml:ro,z
+      - ../files/volumes/api/envoy/lds.template.yaml:/etc/envoy/lds.template.yaml:ro,z
+      - ../files/volumes/api/envoy/docker-entrypoint.sh:/docker-entrypoint.sh:ro,z
     environment:
-      KONG_DATABASE: "off"
-      KONG_DECLARATIVE_CONFIG: /usr/local/kong/kong.yml
-      KONG_ROUTER_FLAVOR: expressions
-      KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_DNS_NOT_FOUND_TTL: 1
-      KONG_DNS_VALID_TTL: 5
-      KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth,request-termination,ip-restriction,post-function
-      KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
-      KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
-      KONG_PROXY_ACCESS_LOG: /dev/stdout combined
-      SUPABASE_ANON_KEY: ${ANON_KEY}
-      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      ANON_KEY: ${ANON_KEY}
+      SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
       SUPABASE_PUBLISHABLE_KEY: ${SUPABASE_PUBLISHABLE_KEY:-}
       SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY:-}
       ANON_KEY_ASYMMETRIC: ${ANON_KEY_ASYMMETRIC:-}
       SERVICE_ROLE_KEY_ASYMMETRIC: ${SERVICE_ROLE_KEY_ASYMMETRIC:-}
+      SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
       DASHBOARD_USERNAME: ${DASHBOARD_USERNAME}
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
-    entrypoint: ["/bin/bash", "/home/kong/kong-entrypoint.sh"]
+    entrypoint: ["/bin/sh", "/docker-entrypoint.sh"]
 
   auth:
     image: supabase/gotrue:v2.189.0
@@ -120,7 +113,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      GOTRUE_MAILER_EXTERNAL_HOSTS: kong,${SUPABASE_HOST}
+      GOTRUE_MAILER_EXTERNAL_HOSTS: api-gw,${SUPABASE_HOST}
       GOTRUE_API_HOST: 0.0.0.0
       GOTRUE_API_PORT: 9999
       API_EXTERNAL_URL: ${API_EXTERNAL_URL}
@@ -319,14 +312,19 @@ services:
       - ../files/volumes/functions:/home/deno/functions:Z
       - deno-cache:/root/.cache/deno
     depends_on:
-      kong:
+      api-gw:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/127.0.0.1/9000'"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
     environment:
       # Legacy symmetric HS256 key
       JWT_SECRET: ${JWT_SECRET}
       # JWKS for token verification (EC public + legacy symmetric)
       SUPABASE_JWKS: ${JWT_JWKS:-{"keys":[]}}
-      SUPABASE_URL: http://kong:8000
+      SUPABASE_URL: http://api-gw:8000
       SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}

--- a/blueprints/supabase/docker-compose.yml
+++ b/blueprints/supabase/docker-compose.yml
@@ -325,6 +325,12 @@ services:
       # JWKS for token verification (EC public + legacy symmetric)
       SUPABASE_JWKS: ${JWT_JWKS:-{"keys":[]}}
       SUPABASE_URL: http://api-gw:8000
+      # Auth signs tokens with API_EXTERNAL_URL as the issuer, but SUPABASE_URL
+      # above is the INTERNAL gateway address. A function that derives its
+      # expected issuer from SUPABASE_URL - which is what the official
+      # _shared/jwt/default.ts example does - therefore rejects every valid
+      # token. SB_JWT_ISSUER is the override that example already prefers.
+      SB_JWT_ISSUER: ${API_EXTERNAL_URL}
       SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}

--- a/blueprints/supabase/instructions.md
+++ b/blueprints/supabase/instructions.md
@@ -39,6 +39,36 @@ values into `lds.yaml` when the container starts, and the listener does the tran
 on every request. Both styles stay valid at the same time — existing apps on `ANON_KEY` /
 `SERVICE_ROLE_KEY` keep working.
 
+## Upgrading an existing Supabase service (Kong → Envoy)
+
+⚠️ **Only if you already run this template on its Kong version.** A fresh install can skip this.
+
+The API gateway service is renamed `kong` → `api-gw`. Dokploy checks the domain's service
+name against the compose file, so a redeploy fails with
+`Domain ... is attached to service "kong" which does not exist in the compose` until you
+fix the domain first.
+
+1. Open **Domains**, edit the domain, change **Service Name** from `kong` to `api-gw`.
+   Leave the port at `8000`.
+2. Deploy. The stale `kong` container is removed automatically (`--remove-orphans`).
+
+No data is lost by the rename — the database lives in a separate volume.
+
+## Backing up the database
+
+The Postgres data directory is a **bind mount** (`files/volumes/db/data`), not a named
+Docker volume. Two consequences:
+
+- **Dokploy's Volume Backups cannot see it.** The panel will only offer the `db-config` and
+  `deno-cache` volumes, neither of which holds your data.
+- **Deleting the service deletes the database**, whether or not you tick *delete volumes* —
+  the data sits inside the application directory that Dokploy removes.
+- **Redeploy with fresh volumes does NOT reset the database.** It clears `db-config` and
+  `deno-cache` only. A true reset means deleting the service.
+
+Back up with `pg_dump` through the pooler, or copy
+`/etc/dokploy/compose/<appName>/files/volumes/db/data` off the host.
+
 ## Optional: sign tokens with an ES256 key pair
 
 Everything is signed with the symmetric `JWT_SECRET` (HS256) by default. Moving

--- a/blueprints/supabase/instructions.md
+++ b/blueprints/supabase/instructions.md
@@ -8,18 +8,21 @@
 
 ## Log in to Supabase Studio
 
-The main domain of the template points to the `kong` API gateway (port `8000`), which protects Supabase Studio with basic authentication:
+The main domain of the template points to the `api-gw` API gateway — Envoy, on port `8000` — which protects Supabase Studio with basic authentication:
 
 - **Username**: the value of `DASHBOARD_USERNAME` (default: `supabase`)
 - **Password**: the value of `DASHBOARD_PASSWORD`
 
-Both values are in the **Environment** tab of the service in Dokploy.
+Both values are in the **Environment** tab of the service in Dokploy. Envoy computes
+the basic-auth credential at startup, as a SHA1 hash of `DASHBOARD_PASSWORD` encoded in
+base64, so the password itself still comes from the Environment tab and nothing else
+needs to change when you edit it.
 
 ## API URL and keys
 
 To connect an application (for example with `supabase-js`):
 
-- **API URL**: `https://<your-domain>` (requests are routed through Kong)
+- **API URL**: `https://<your-domain>` (requests are routed through Envoy)
 - **anon key**: the value of `ANON_KEY` in the Environment tab
 - **service_role key**: the value of `SERVICE_ROLE_KEY` in the Environment tab (server-side only, never expose it to browsers)
 
@@ -30,9 +33,11 @@ Dokploy also generates the newer opaque API keys, so you can use either style:
 - **publishable key**: the value of `SUPABASE_PUBLISHABLE_KEY` (browser-safe, replaces the anon key)
 - **secret key**: the value of `SUPABASE_SECRET_KEY` (server-side only, replaces the service_role key)
 
-Kong exchanges these for the matching JWT before the request reaches Supabase,
-so clients never hold a decodable token. Both styles stay valid at the same time
-— existing apps on `ANON_KEY` / `SERVICE_ROLE_KEY` keep working.
+Envoy exchanges these for the matching JWT before the request reaches Supabase, so
+clients never hold a decodable token. Its `docker-entrypoint.sh` substitutes the six key
+values into `lds.yaml` when the container starts, and the listener does the translation
+on every request. Both styles stay valid at the same time — existing apps on `ANON_KEY` /
+`SERVICE_ROLE_KEY` keep working.
 
 ## Optional: sign tokens with an ES256 key pair
 

--- a/blueprints/supabase/instructions.md
+++ b/blueprints/supabase/instructions.md
@@ -39,6 +39,41 @@ values into `lds.yaml` when the container starts, and the listener does the tran
 on every request. Both styles stay valid at the same time — existing apps on `ANON_KEY` /
 `SERVICE_ROLE_KEY` keep working.
 
+## ⚠️ If your domain has no TLS certificate, change the scheme to `http`
+
+The template generates `SUPABASE_PUBLIC_URL`, `API_EXTERNAL_URL` and
+`ADDITIONAL_REDIRECT_URLS` with an **`https://`** scheme, because that is right for the
+usual case — a public domain with a Let's Encrypt certificate.
+
+**Dokploy creates the template's domain with no certificate.** Until you enable one, the
+domain answers on `http` only, and those three values point at a scheme that does not
+respond. The stack comes up healthy and the gateway answers, so nothing looks broken — but:
+
+- Studio's browser-side calls go to `SUPABASE_PUBLIC_URL` and fail.
+- Envoy compares the request `Origin` against `SUPABASE_PUBLIC_URL`, so **CORS refuses every
+  cross-origin call**, including `/pg/`.
+- GoTrue signs tokens with `API_EXTERNAL_URL` as the issuer and builds OAuth redirects and
+  email links from it, so all of them point at the dead scheme.
+
+Two ways out:
+
+1. **Enable a certificate** — Domains → your domain → Certificate → Let's Encrypt. This needs
+   the domain to be **reachable from the public internet**. It will not work for a private
+   address: an `sslip.io` name pointing at a Tailscale `100.x.y.z` or a LAN `192.168.x.y`
+   cannot be validated, because Let's Encrypt cannot connect to it.
+2. **Switch the three values to `http://`** in the Environment tab, then redeploy. This is the
+   right choice for a private or tailnet-only instance.
+
+```
+SUPABASE_PUBLIC_URL=http://<your-domain>
+API_EXTERNAL_URL=http://<your-domain>/auth/v1
+ADDITIONAL_REDIRECT_URLS=http://<your-domain>/*,http://localhost:3000/*
+```
+
+Keep `API_EXTERNAL_URL` ending in `/auth/v1`. Without that path GoTrue advertises
+`<domain>/callback` as its OAuth `redirect_uri`, and the gateway routes a bare `/callback` to
+Studio rather than to auth, so every social sign-in dead-ends on the dashboard login prompt.
+
 ## Upgrading an existing Supabase service (Kong → Envoy)
 
 ⚠️ **Only if you already run this template on its Kong version.** A fresh install can skip this.

--- a/blueprints/supabase/instructions.md
+++ b/blueprints/supabase/instructions.md
@@ -110,11 +110,13 @@ Everything is signed with the symmetric `JWT_SECRET` (HS256) by default. Moving
 to an asymmetric key pair needs an EC P-256 key, which Dokploy's variable
 helpers cannot generate, so `JWT_KEYS` and `JWT_JWKS` ship empty. To switch:
 
-1. Clone the Supabase repo and go to its `docker/` directory:
+1. Fetch Supabase's key generator. Only this one script is needed — cloning the
+   whole repository pulls a very large monorepo for a 7 KB file. It needs `node`
+   (>= 16), or Docker as a fallback:
 
    ```bash
-   git clone --depth 1 https://github.com/supabase/supabase
-   cd supabase/docker
+   mkdir supabase-keys && cd supabase-keys
+   curl -fsSLO https://raw.githubusercontent.com/supabase/supabase/master/docker/utils/add-new-auth-keys.sh
    ```
 
 2. Put **this deployment's** `JWT_SECRET` (from the Environment tab) into a local `.env`:
@@ -123,15 +125,23 @@ helpers cannot generate, so `JWT_KEYS` and `JWT_JWKS` ship empty. To switch:
    echo "JWT_SECRET=<your-JWT_SECRET>" > .env
    ```
 
-3. Generate the keys:
+3. Generate the keys. `--update-env` is required: without it the script prints
+   only four of the six values, and writes `ANON_KEY_ASYMMETRIC` and
+   `SERVICE_ROLE_KEY_ASYMMETRIC` to `.env` alone.
 
    ```bash
-   sh utils/add-new-auth-keys.sh
+   sh add-new-auth-keys.sh --update-env
    ```
 
-4. Replace all six values in the Environment tab with the ones it prints, then
-   redeploy: `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SECRET_KEY`,
-   `ANON_KEY_ASYMMETRIC`, `SERVICE_ROLE_KEY_ASYMMETRIC`, `JWT_KEYS`, `JWT_JWKS`.
+   It exits with status **1** after writing the keys, because it then looks for a
+   `docker-compose.yml` to patch and there is none in this directory. That is
+   expected here — this blueprint already wires `GOTRUE_JWT_KEYS`,
+   `API_JWT_JWKS`, `JWT_JWKS` and `SUPABASE_JWKS`. Check `.env` for the six
+   values rather than the exit code.
+
+4. Copy all six values from `.env` into the Environment tab, then redeploy:
+   `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SECRET_KEY`, `ANON_KEY_ASYMMETRIC`,
+   `SERVICE_ROLE_KEY_ASYMMETRIC`, `JWT_KEYS`, `JWT_JWKS`.
 
 Set them **all together**. `JWT_KEYS` makes Auth sign tokens with ES256, while
 `JWT_JWKS` is what PostgREST, Realtime, Storage and Edge Functions use to verify
@@ -146,6 +156,16 @@ Review these variables in the **Environment** tab before using Supabase in produ
 - `SUPABASE_PUBLIC_URL` and `API_EXTERNAL_URL`: must point to your Supabase domain with the correct `http`/`https` scheme (the template sets them from your domain automatically).
 - `SITE_URL` and `ADDITIONAL_REDIRECT_URLS`: must point to the application that uses Supabase for authentication.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_ADMIN_EMAIL`, `SMTP_SENDER_NAME`: required for auth emails (sign-up confirmations, password resets). The template ships with placeholder values, so no real emails are sent until you configure a real SMTP provider.
+
+**Enable `pg_graphql` if you use the GraphQL endpoint.** `/graphql/v1` is routed by
+the gateway, but the extension is not installed on a fresh database, so the endpoint
+answers `pg_graphql extension is not enabled`. Supabase's hosted platform ships it
+enabled, so code that works there needs one statement here — run it once from
+Studio's SQL editor:
+
+```sql
+create extension if not exists pg_graphql with schema graphql;
+```
 
 ## Warning: changing POSTGRES_PASSWORD after the first deploy
 

--- a/blueprints/supabase/meta.json
+++ b/blueprints/supabase/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "supabase",
   "name": "SupaBase",
-  "version": "2026.08.17-envoy / dokploy >= 0.22.5",
+  "version": "2026.08.03-3 / dokploy >= 0.22.5",
   "description": "The open source Firebase alternative. Supabase gives you a dedicated Postgres database to build your web, mobile, and AI applications. This require at least version 0.22.5 of dokploy.",
   "links": {
     "github": "https://github.com/supabase/supabase",

--- a/blueprints/supabase/meta.json
+++ b/blueprints/supabase/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "supabase",
   "name": "SupaBase",
-  "version": "2026.08.03-2 / dokploy >= 0.22.5",
+  "version": "2026.08.17-envoy / dokploy >= 0.22.5",
   "description": "The open source Firebase alternative. Supabase gives you a dedicated Postgres database to build your web, mobile, and AI applications. This require at least version 0.22.5 of dokploy.",
   "links": {
     "github": "https://github.com/supabase/supabase",

--- a/blueprints/supabase/template.toml
+++ b/blueprints/supabase/template.toml
@@ -126,7 +126,9 @@ env = [
 '',
 '############',
 '# API Proxy - Configuration for the Envoy reverse proxy.',
-'# Following ports should not be changed for a dokploy config unless you know what you are doing.',
+'# The gateway port is fixed at 8000 by the compose expose list and by the domain',
+'# block of this template, so editing API_GW_HTTP_PORT has no effect. It is kept',
+'# only for parity with the upstream Supabase .env.',
 '############',
 '',
 'API_GW_HTTP_PORT=8000',
@@ -150,7 +152,7 @@ env = [
 'ADDITIONAL_REDIRECT_URLS=https://${main_domain}/*,http://localhost:3000/*',
 'JWT_EXPIRY=3600',
 'DISABLE_SIGNUP=false',
-'API_EXTERNAL_URL=https://${main_domain}',
+'API_EXTERNAL_URL=https://${main_domain}/auth/v1',
 '',
 '## Mailer Config',
 'MAILER_URLPATHS_CONFIRMATION="/auth/v1/verify"',
@@ -1891,24 +1893,54 @@ COMMIT;
 
 [[config.mounts]]
 filePath = "/volumes/functions/hello/index.ts"
-content = """
-// Follow this setup guide to integrate the Deno language server with your editor:
+content = '''// Follow this setup guide to integrate the Deno language server with your editor:
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { serve } from "https://deno.land/std@0.177.1/http/server.ts"
+// Setup type definitions for built-in Supabase Runtime APIs
+import "@supabase/functions-js/edge-runtime.d.ts"
+import { withSupabase } from "@supabase/server"
 
-serve(async () => {
-  return new Response(
-    `"Hello from Edge Functions!"`,
-    { headers: { "Content-Type": "application/json" } },
-  )
-})
+// Logs are visible from 'functions' container inspector
+console.log("Hello from Functions!");
+
+// This endpoint uses 'publishable' | 'secret' access, apiKey is required.
+// Use publishable for Client-facing, key-validated endpoints
+// Use secret for Server-to-server, internal calls
+export default {
+  fetch: withSupabase({ auth: ["publishable", "secret"] }, async (req, ctx) => {
+    // Called by another service with a secret key
+    // ctx.supabaseAdmin bypasses RLS — use for privileged operations
+    /*
+    if (ctx.authMode === "secret") {
+      const { user_id } = await req.json();
+      const { data } = await ctx.supabaseAdmin.auth.admin.getUserById(user_id);
+
+      return Response.json({
+        email: data?.user?.email,
+      });
+    }
+    */
+
+    return Response.json({ message: "Hello from Edge Functions!" });
+  }),
+};
 
 // To invoke:
 // curl 'http://localhost:<API_GW_HTTP_PORT>/functions/v1/hello' \
-//   --header 'Authorization: Bearer <anon/service_role API key>'
-"""
+//   --header 'apiKey: <sb_publishable/sb_secret key>'
+
+'''
+
+[[config.mounts]]
+filePath = "/volumes/functions/deno.jsonc"
+content = '''{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2",
+    "@supabase/server": "npm:@supabase/server@^1"
+  }
+}
+'''
 
 [[config.mounts]]
 filePath = "/volumes/functions/main/index.ts"
@@ -2027,8 +2059,12 @@ Deno.serve(async (req: Request) => {
   const memoryLimitMb = 150
   const workerTimeoutMs = 1 * 60 * 1000
   const noModuleCache = false
-  const importMapPath = null
-  const envVarsObj = Deno.env.toObject()
+  // A common import map for all functions; a per-function scope would have to be
+  // resolved dynamically from service_name.
+  const importMapPath = `/home/deno/functions/deno.jsonc`
+  // SUPABASE_FUNCTION_SLUG is per-request, because only this worker knows which
+  // function the request resolved to.
+  const envVarsObj = { ...Deno.env.toObject(), SUPABASE_FUNCTION_SLUG: service_name }
   const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]])
 
   try {

--- a/blueprints/supabase/template.toml
+++ b/blueprints/supabase/template.toml
@@ -25,7 +25,7 @@ service_role_key_payload = """{
 }
 """
 # Defined here (not inline in env) so each JWT is generated once and can be
-# reused: Kong swaps the opaque API keys below for these exact tokens.
+# reused: the gateway swaps the opaque API keys below for these exact tokens.
 anon_key = "${jwt:jwt_secret:anon_key_payload}"
 service_role_key = "${jwt:jwt_secret:service_role_key_payload}"
 # Opaque API keys, shaped like Supabase's: sb_<role>_<22 chars>_<8 char suffix>.
@@ -33,7 +33,7 @@ publishable_key = "sb_publishable_${hash:22}_${hash:8}"
 secret_key = "sb_secret_${hash:22}_${hash:8}"
 
 [[config.domains]]
-serviceName = "kong"
+serviceName = "api-gw"
 port = 8_000
 host = "${main_domain}"
 
@@ -67,7 +67,7 @@ env = [
 '',
 '############',
 '# New API keys. These are opaque strings: clients never see a decodable JWT,',
-'# Kong swaps them for the *_ASYMMETRIC tokens below before proxying.',
+'# Envoy swaps them for the *_ASYMMETRIC tokens below before proxying.',
 '#',
 '# Those tokens are HS256, signed with JWT_SECRET, so they verify against the',
 '# same key everything else already uses. Real ES256 keys would need an EC P-256',
@@ -125,12 +125,11 @@ env = [
 '',
 '',
 '############',
-'# API Proxy - Configuration for the Kong Reverse proxy.',
+'# API Proxy - Configuration for the Envoy reverse proxy.',
 '# Following ports should not be changed for a dokploy config unless you know what you are doing.',
 '############',
 '',
-'KONG_HTTP_PORT=8000',
-'KONG_HTTPS_PORT=8443',
+'API_GW_HTTP_PORT=8000',
 '',
 '',
 '############',
@@ -207,453 +206,1406 @@ env = [
 'FUNCTIONS_VERIFY_JWT=false']
 
 [[config.mounts]]
-filePath = "/volumes/api/kong-entrypoint.sh"
-content = """#!/bin/bash
-# Custom entrypoint for Kong that builds Lua expressions for request-transformer
-# and performs environment variable substitution in the declarative config.
+filePath = "/volumes/api/envoy/envoy.yaml"
+content = '''dynamic_resources:
+  cds_config:
+    path_config_source:
+      path: /etc/envoy/cds.yaml
+    resource_api_version: V3
+  lds_config:
+    path_config_source:
+      path: /etc/envoy/lds.yaml
+    resource_api_version: V3
 
-if [ -n "$SUPABASE_SECRET_KEY" ] && [ -n "$SUPABASE_PUBLISHABLE_KEY" ]; then
-    export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or (headers.apikey == '$SUPABASE_SECRET_KEY' and 'Bearer $SERVICE_ROLE_KEY_ASYMMETRIC') or (headers.apikey == '$SUPABASE_PUBLISHABLE_KEY' and 'Bearer $ANON_KEY_ASYMMETRIC') or headers.apikey)"
-    export LUA_RT_WS_EXPR="\$((query_params.apikey == '$SUPABASE_SECRET_KEY' and '$SERVICE_ROLE_KEY_ASYMMETRIC') or (query_params.apikey == '$SUPABASE_PUBLISHABLE_KEY' and '$ANON_KEY_ASYMMETRIC') or query_params.apikey)"
-else
-    export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or headers.apikey)"
-    export LUA_RT_WS_EXPR="\$(query_params.apikey)"
-fi
+node:
+  cluster: supabase_cluster
+  id: supabase_node
 
-awk '{
-  result = ""
-  rest = $0
-  while (match(rest, /\$[A-Za-z_][A-Za-z_0-9]*/)) {
-    varname = substr(rest, RSTART + 1, RLENGTH - 1)
-    if (varname in ENVIRON) {
-      result = result substr(rest, 1, RSTART - 1) ENVIRON[varname]
-    } else {
-      result = result substr(rest, 1, RSTART + RLENGTH - 1)
-    }
-    rest = substr(rest, RSTART + RLENGTH)
-  }
-  print result rest
-}' /home/kong/temp.yml > "$KONG_DECLARATIVE_CONFIG"
+overload_manager:
+  resource_monitors:
+    - name: envoy.resource_monitors.global_downstream_max_connections
+      typed_config:
+        '@type': >-
+          type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+        max_active_downstream_connections: 30000
 
-sed -i '/^[[:space:]]*- key:[[:space:]]*$/d' "$KONG_DECLARATIVE_CONFIG"
-
-exec /entrypoint.sh kong docker-start
-"""
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901
+'''
 
 [[config.mounts]]
-filePath = "/volumes/api/kong.yml"
-content = """_format_version: '2.1'
-_transform: true
+filePath = "/volumes/api/envoy/cds.yaml"
+content = '''resources:
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: auth
+    connect_timeout: 5s
+    type: STRICT_DNS
+    dns_refresh_rate: 5s
+    dns_failure_refresh_rate:
+      base_interval: 1s
+      max_interval: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: auth
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: auth
+                    port_value: 9999
+    health_checks:
+      - timeout: 2s
+        interval: 5s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: /health
+    circuit_breakers:
+      thresholds:
+        - priority: DEFAULT
+          max_connections: 10000
+          max_pending_requests: 10000
+          max_requests: 10000
 
-###
-### Consumers / Users
-###
-consumers:
-  - username: DASHBOARD
-  - username: anon
-    keyauth_credentials:
-      - key: $SUPABASE_ANON_KEY
-      - key: $SUPABASE_PUBLISHABLE_KEY
-  - username: service_role
-    keyauth_credentials:
-      - key: $SUPABASE_SERVICE_KEY
-      - key: $SUPABASE_SECRET_KEY
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: rest
+    connect_timeout: 5s
+    type: STRICT_DNS
+    dns_refresh_rate: 5s
+    dns_failure_refresh_rate:
+      base_interval: 1s
+      max_interval: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: rest
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: rest
+                    port_value: 3000
+    health_checks:
+      - timeout: 2s
+        interval: 5s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: /
+    circuit_breakers:
+      thresholds:
+        - priority: DEFAULT
+          max_connections: 10000
+          max_pending_requests: 10000
+          max_requests: 10000
 
-###
-### Access Control List
-###
-acls:
-  - consumer: anon
-    group: anon
-  - consumer: service_role
-    group: admin
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: realtime
+    connect_timeout: 5s
+    type: STRICT_DNS
+    dns_refresh_rate: 5s
+    dns_failure_refresh_rate:
+      base_interval: 1s
+      max_interval: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: realtime
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: realtime
+                    port_value: 4000
+    health_checks:
+      - timeout: 2s
+        interval: 5s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: /
+    circuit_breakers:
+      thresholds:
+        - priority: DEFAULT
+          max_connections: 10000
+          max_pending_requests: 10000
+          max_requests: 10000
 
-###
-### Dashboard credentials
-###
-basicauth_credentials:
-  - consumer: DASHBOARD
-    username: '$DASHBOARD_USERNAME'
-    password: '$DASHBOARD_PASSWORD'
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: storage
+    connect_timeout: 5s
+    type: STRICT_DNS
+    dns_refresh_rate: 5s
+    dns_failure_refresh_rate:
+      base_interval: 1s
+      max_interval: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: storage
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: storage
+                    port_value: 5000
+    health_checks:
+      - timeout: 2s
+        interval: 5s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: /status
+    circuit_breakers:
+      thresholds:
+        - priority: DEFAULT
+          max_connections: 10000
+          max_pending_requests: 10000
+          max_requests: 10000
 
-###
-### API Routes
-###
-services:
-  ## Open Auth routes
-  - name: auth-v1-open
-    url: http://auth:9999/verify
-    routes:
-      - name: auth-v1-open
-        strip_path: true
-        paths:
-          - /auth/v1/verify
-    plugins:
-      - name: cors
-  - name: auth-v1-open-callback
-    url: http://auth:9999/callback
-    routes:
-      - name: auth-v1-open-callback
-        strip_path: true
-        paths:
-          - /auth/v1/callback
-    plugins:
-      - name: cors
-  - name: auth-v1-open-authorize
-    url: http://auth:9999/authorize
-    routes:
-      - name: auth-v1-open-authorize
-        strip_path: true
-        paths:
-          - /auth/v1/authorize
-    plugins:
-      - name: cors
-  - name: auth-v1-open-jwks
-    url: http://auth:9999/.well-known/jwks.json
-    routes:
-      - name: auth-v1-open-jwks
-        strip_path: true
-        paths:
-          - /auth/v1/.well-known/jwks.json
-    plugins:
-      - name: cors
-  - name: auth-v1-open-sso-acs
-    url: http://auth:9999/sso/saml/acs
-    routes:
-      - name: auth-v1-open-sso-acs
-        strip_path: true
-        paths:
-          - /sso/saml/acs
-    plugins:
-      - name: cors
-  - name: auth-v1-open-sso-metadata
-    url: http://auth:9999/sso/saml/metadata
-    routes:
-      - name: auth-v1-open-sso-metadata
-        strip_path: true
-        paths:
-          - /sso/saml/metadata
-    plugins:
-      - name: cors
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: functions
+    connect_timeout: 5s
+    type: STRICT_DNS
+    dns_refresh_rate: 5s
+    dns_failure_refresh_rate:
+      base_interval: 1s
+      max_interval: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: functions
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: functions
+                    port_value: 9000
+    health_checks:
+      - timeout: 2s
+        interval: 5s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        tcp_health_check: {}
+    circuit_breakers:
+      thresholds:
+        - priority: DEFAULT
+          max_connections: 10000
+          max_pending_requests: 10000
+          max_requests: 10000
 
-  ## Secure Auth routes
-  - name: auth-v1
-    _comment: 'GoTrue: /auth/v1/* -> http://auth:9999/*'
-    url: http://auth:9999/
-    routes:
-      - name: auth-v1-all
-        strip_path: true
-        paths:
-          - /auth/v1/
-    plugins:
-      - name: cors
-      - name: key-auth
-        config:
-          hide_credentials: false
-      - name: request-transformer
-        config:
-          add:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-          replace:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
-            - anon
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: meta
+    connect_timeout: 5s
+    type: STRICT_DNS
+    dns_refresh_rate: 5s
+    dns_failure_refresh_rate:
+      base_interval: 1s
+      max_interval: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: meta
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: meta
+                    port_value: 8080
+    health_checks:
+      - timeout: 2s
+        interval: 5s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: /health
+    circuit_breakers:
+      thresholds:
+        - priority: DEFAULT
+          max_connections: 10000
+          max_pending_requests: 10000
+          max_requests: 10000
 
-  ## OpenAPI root - admin only
-  - name: rest-v1-openapi
-    _comment: 'PostgREST OpenAPI root: /rest/v1/ -> http://rest:3000/ (admin only). See https://github.com/orgs/supabase/discussions/42949'
-    url: http://rest:3000/
-    routes:
-      - name: rest-v1-openapi-root
-        strip_path: true
-        expression: 'http.path == "/rest/v1/"'
-    plugins:
-      - name: cors
-      - name: key-auth
-        config:
-          hide_credentials: false
-      - name: request-transformer
-        config:
-          add:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-          replace:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    name: studio
+    connect_timeout: 5s
+    type: STRICT_DNS
+    dns_refresh_rate: 5s
+    dns_failure_refresh_rate:
+      base_interval: 1s
+      max_interval: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: studio
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: studio
+                    port_value: 3000
+    health_checks:
+      - timeout: 2s
+        interval: 5s
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        http_health_check:
+          path: /project/default
+    circuit_breakers:
+      thresholds:
+        - priority: DEFAULT
+          max_connections: 10000
+          max_pending_requests: 10000
+          max_requests: 10000
+'''
 
-  ## Secure PostgREST routes
-  - name: rest-v1
-    _comment: 'PostgREST: /rest/v1/* -> http://rest:3000/*'
-    url: http://rest:3000/
-    routes:
-      - name: rest-v1-all
-        strip_path: true
-        paths:
-          - /rest/v1/
-    plugins:
-      - name: cors
-      - name: key-auth
-        config:
-          hide_credentials: false
-      - name: request-transformer
-        config:
-          add:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-          replace:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
-            - anon
+[[config.mounts]]
+filePath = "/volumes/api/envoy/lds.template.yaml"
+content = '''resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    name: supabase
+    per_connection_buffer_limit_bytes: 32768  # 32 KiB
 
-  ## Secure GraphQL routes
-  - name: graphql-v1
-    _comment: 'PostgREST: /graphql/v1/* -> http://rest:3000/rpc/graphql'
-    url: http://rest:3000/rpc/graphql
-    routes:
-      - name: graphql-v1-all
-        strip_path: true
-        paths:
-          - /graphql/v1
-    plugins:
-      - name: cors
-      - name: key-auth
-        config:
-          hide_credentials: false
-      - name: request-transformer
-        config:
-          add:
-            headers:
-              - "Content-Profile: graphql_public"
-              - "Authorization: $LUA_AUTH_EXPR"
-          replace:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
-            - anon
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8000
 
-  ## Secure Realtime routes
-  - name: realtime-v1-ws
-    _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
-    url: http://realtime:4000/socket
-    protocol: ws
-    routes:
-      - name: realtime-v1-ws
-        strip_path: true
-        paths:
-          - /realtime/v1/
-    plugins:
-      - name: cors
-      - name: key-auth
-        config:
-          hide_credentials: false
-      - name: request-transformer
-        config:
-          add:
-            headers:
-              - "x-api-key:$LUA_RT_WS_EXPR"
-          replace:
-            querystring:
-              - "apikey:$LUA_RT_WS_EXPR"
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
-            - anon
+    filter_chains:
+      - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              '@type': >-
+                type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: ingress_http
+              normalize_path: true
+              merge_slashes: true
+              path_with_escaped_slashes_action: REJECT_REQUEST
+              use_remote_address: true
+              common_http_protocol_options:
+                headers_with_underscores_action: REJECT_REQUEST
+              upgrade_configs:
+                - upgrade_type: websocket
+              access_log:
+                - name: envoy.access_loggers.stdout
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% - - [%START_TIME(%d/%b/%Y:%H:%M:%S %z)%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %BYTES_SENT% \"%REQ(REFERER)%\" \"%REQ(USER-AGENT)%\"\n"
 
-  # Block access to /realtime/v1/api/openapi
-  - name: realtime-v1-rest-openapi
-    _comment: 'Realtime: /realtime/v1/api/openapi/* -> http://realtime:4000/api/openapi/* (blocked)'
-    url: http://realtime:4000/api/openapi
-    protocol: http
-    routes:
-      - name: realtime-v1-rest-openapi
-        strip_path: true
-        paths:
-          - /realtime/v1/api/openapi
-    plugins:
-      - name: request-termination
-        config:
-          status_code: 403
-          message: "Access is forbidden."
+              route_config:
+                name: supabase_route
+                virtual_hosts:
+                  - name: supabase_host
+                    domains:
+                      - '*'
+                    cors:
+                      allow_origin_string_match:
+                        - safe_regex:
+                            regex: ".*"
+                      allow_methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD,CONNECT,TRACE"
+                      allow_headers: "*"
+                      expose_headers: "*"
+                      max_age: "3600"
+                    request_headers_to_add:
+                      - header:
+                          key: X-Forwarded-Host
+                          value: "%REQ(:AUTHORITY)%"
+                        append_action: ADD_IF_ABSENT
+                      - header:
+                          key: X-Forwarded-Port
+                          value: "%DOWNSTREAM_LOCAL_PORT%"
+                        append_action: ADD_IF_ABSENT
+                    routes:
+                      - match:
+                          prefix: /auth/v1/verify
+                        route:
+                          cluster: auth
+                          prefix_rewrite: /verify
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /auth/v1/verify
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  # Block access to /realtime/v1/api/tenants
-  - name: realtime-v1-rest-tenants
-    _comment: 'Realtime: /realtime/v1/api/tenants/* -> http://realtime:4000/api/tenants/* (blocked)'
-    url: http://realtime:4000/api/tenants
-    protocol: http
-    routes:
-      - name: realtime-v1-rest-tenants
-        strip_path: true
-        paths:
-          - /realtime/v1/api/tenants
-    plugins:
-      - name: request-termination
-        config:
-          status_code: 403
-          message: "Access is forbidden."
+                      - match:
+                          prefix: /auth/v1/callback
+                        route:
+                          cluster: auth
+                          prefix_rewrite: /callback
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /auth/v1/callback
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  - name: realtime-v1-rest
-    _comment: 'Realtime: /realtime/v1/api/* -> http://realtime:4000/api/*'
-    url: http://realtime:4000/api
-    protocol: http
-    routes:
-      - name: realtime-v1-rest
-        strip_path: true
-        paths:
-          - /realtime/v1/api
-    plugins:
-      - name: cors
-      - name: key-auth
-        config:
-          hide_credentials: false
-      - name: request-transformer
-        config:
-          add:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-          replace:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
-            - anon
+                      - match:
+                          prefix: /auth/v1/authorize
+                        route:
+                          cluster: auth
+                          prefix_rewrite: /authorize
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /auth/v1/authorize
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  ## Storage routes
-  - name: storage-v1
-    _comment: 'Storage: /storage/v1/* -> http://storage:5000/*'
-    url: http://storage:5000/
-    routes:
-      - name: storage-v1-all
-        strip_path: true
-        paths:
-          - /storage/v1/
-    plugins:
-      - name: cors
-      - name: request-transformer
-        config:
-          add:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-          replace:
-            headers:
-              - "Authorization: $LUA_AUTH_EXPR"
-      - name: post-function
-        config:
-          access:
-            - |
-              local auth = kong.request.get_header("authorization")
-              if auth == nil or auth == "" or auth:find("^%s*$") then
-                kong.service.request.clear_header("authorization")
-              end
+                      - match:
+                          prefix: /auth/v1/.well-known/jwks.json
+                        route:
+                          cluster: auth
+                          prefix_rewrite: /.well-known/jwks.json
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /auth/v1/.well-known/jwks.json
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  ## Edge Functions routes
-  - name: functions-v1
-    _comment: 'Edge Functions: /functions/v1/* -> http://functions:9000/*'
-    url: http://functions:9000/
-    read_timeout: 150000
-    routes:
-      - name: functions-v1-all
-        strip_path: true
-        paths:
-          - /functions/v1/
-    plugins:
-      - name: cors
+                      - match:
+                          prefix: /.well-known/oauth-authorization-server
+                        route:
+                          cluster: auth
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /.well-known/oauth-authorization-server
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  ## OAuth 2.0 Authorization Server Metadata
-  - name: well-known-oauth
-    url: http://auth:9999/.well-known/oauth-authorization-server
-    routes:
-      - name: well-known-oauth
-        strip_path: true
-        paths:
-          - /.well-known/oauth-authorization-server
-    plugins:
-      - name: cors
+                      - match:
+                          prefix: /auth/v1/sso/saml/acs
+                        route:
+                          cluster: auth
+                          prefix_rewrite: /sso/saml/acs
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /auth/v1/sso/saml/acs
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  ## Secure Database routes
-  - name: meta
-    _comment: 'pg-meta: /pg/* -> http://pg-meta:8080/*'
-    url: http://meta:8080/
-    routes:
-      - name: meta-all
-        strip_path: true
-        paths:
-          - /pg/
-    plugins:
-      - name: key-auth
-        config:
-          hide_credentials: false
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
+                      - match:
+                          prefix: /auth/v1/sso/saml/metadata
+                        route:
+                          cluster: auth
+                          prefix_rewrite: /sso/saml/metadata
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /auth/v1/sso/saml/metadata
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  - name: mcp-blocker
-    url: http://studio:3000/api/mcp
-    routes:
-      - name: mcp-blocker-route
-        strip_path: true
-        paths:
-          - /api/mcp
-    plugins:
-      - name: request-termination
-        config:
-          status_code: 403
-          message: "Access is forbidden."
+                      - name: functions-v1-all
+                        match:
+                          prefix: /functions/v1/
+                        route:
+                          cluster: functions
+                          prefix_rewrite: /
+                          timeout: 150s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /functions/v1/
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  - name: mcp
-    url: http://studio:3000/api/mcp
-    routes:
-      - name: mcp
-        strip_path: true
-        paths:
-          - /mcp
-    plugins:
-      - name: request-termination
-        config:
-          status_code: 403
-          message: "Access is forbidden."
+                      - match:
+                          prefix: /storage/v1/
+                        route:
+                          cluster: storage
+                          prefix_rewrite: /
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /storage/v1
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
 
-  ## Protected Dashboard - catch all remaining routes
-  - name: dashboard
-    _comment: 'Studio: /* -> http://studio:3000/*'
-    url: http://studio:3000/
-    routes:
-      - name: dashboard-all
-        strip_path: true
-        paths:
-          - /
-    plugins:
-      - name: cors
-      - name: basic-auth
-        config:
-          hide_credentials: true
-"""
+                      - name: auth-v1-protected
+                        match:
+                          prefix: /auth/v1/
+                        route:
+                          cluster: auth
+                          prefix_rewrite: /
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /auth/v1/
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+
+                      - name: rest-v1-openapi-protected
+                        match:
+                          path: /rest/v1/
+                        route:
+                          cluster: rest
+                          prefix_rewrite: /
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /rest/v1/
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  admin:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - header:
+                                          name: apikey
+                                          string_match:
+                                            exact: '${SERVICE_ROLE_KEY}'
+                                      - header:
+                                          name: apikey
+                                          string_match:
+                                            exact: '${SERVICE_ROLE_KEY_ASYMMETRIC}'
+
+                      - name: rest-v1-protected
+                        match:
+                          prefix: /rest/v1/
+                        route:
+                          cluster: rest
+                          prefix_rewrite: /
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /rest/v1/
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+
+                      - name: graphql-v1-protected
+                        match:
+                          prefix: /graphql/v1
+                        route:
+                          cluster: rest
+                          prefix_rewrite: /rpc/graphql
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /graphql/v1
+                            append_action: ADD_IF_ABSENT
+                          - header:
+                              key: Content-Profile
+                              value: graphql_public
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+
+                      - name: realtime-v1-api-openapi-blocked
+                        match:
+                          prefix: /realtime/v1/api/openapi
+                        route:
+                          cluster: realtime
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /realtime/v1/api/openapi
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: DENY
+                                policies:
+                                  deny_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
+
+                      - name: realtime-v1-api-tenants-blocked
+                        match:
+                          prefix: /realtime/v1/api/tenants
+                        route:
+                          cluster: realtime
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /realtime/v1/api/tenants
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: DENY
+                                policies:
+                                  deny_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
+
+                      - name: realtime-v1-api-protected
+                        match:
+                          prefix: /realtime/v1/api
+                        route:
+                          cluster: realtime
+                          prefix_rewrite: /api
+                          timeout: 30s
+                          host_rewrite_literal: realtime-dev.supabase-realtime
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /realtime/v1/api
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+
+                      - name: realtime-v1-ws-protected
+                        match:
+                          prefix: /realtime/v1/
+                        route:
+                          cluster: realtime
+                          prefix_rewrite: /socket/
+                          timeout: 30s
+                          host_rewrite_literal: realtime-dev.supabase-realtime
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /realtime/v1/
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+
+                      - name: pg-protected
+                        match:
+                          prefix: /pg/
+                        route:
+                          cluster: meta
+                          prefix_rewrite: /
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /pg/
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.cors:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                            allow_origin_string_match:
+                              - exact: '${SUPABASE_PUBLIC_URL}'
+                              - safe_regex:
+                                  regex: 'https?://(localhost|127\.0\.0\.1)(:[0-9]+)?'
+                            allow_methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+                            allow_headers: "*"
+                            expose_headers: "*"
+                            max_age: "3600"
+
+                      - match:
+                          prefix: /api/mcp
+                        route:
+                          cluster: studio
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /api/mcp
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: DENY
+                                policies:
+                                  deny_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
+
+                      - match:
+                          prefix: /mcp
+                        route:
+                          cluster: studio
+                          prefix_rewrite: /api/mcp
+                          timeout: 30s
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /mcp
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.basic_auth:
+                            '@type': >-
+                              type.googleapis.com/envoy.config.route.v3.FilterConfig
+                            disabled: true
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            # Block access to /mcp by default
+                            rbac:
+                              rules:
+                                action: DENY
+                                policies:
+                                  deny_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
+                            # Enable local access (danger zone!)
+                            # 1. Comment out the 'rbac' block above.
+                            # 2. Uncomment and adjust the 'rbac' block below.
+                            # 3. Add or adjust your local IPs in 'principals'.
+                            #rbac:
+                            #  rules:
+                            #    action: ALLOW
+                            #    policies:
+                            #      allow_local:
+                            #        permissions:
+                            #          - any: true
+                            #        principals:
+                            #          - direct_remote_ip:
+                            #              address_prefix: 127.0.0.1
+                            #              prefix_len: 32
+                            #          - direct_remote_ip:
+                            #              address_prefix: ::1
+                            #              prefix_len: 128
+
+                      - match:
+                          prefix: /
+                        route:
+                          cluster: studio
+                          timeout: 30s
+                        request_headers_to_remove:
+                          - authorization
+                        request_headers_to_add:
+                          - header:
+                              key: X-Forwarded-Prefix
+                              value: /
+                            append_action: ADD_IF_ABSENT
+                        typed_per_filter_config:
+                          envoy.filters.http.rbac:
+                            '@type': >-
+                              type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+                            rbac:
+                              rules:
+                                action: ALLOW
+                                policies:
+                                  allow_all:
+                                    permissions:
+                                      - any: true
+                                    principals:
+                                      - any: true
+
+              http_filters:
+                - name: envoy.filters.http.cors
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+
+                - name: envoy.filters.http.basic_auth
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuth
+                    users:
+                      inline_string: '${DASHBOARD_BASIC_AUTH}'
+
+                # Copies ?apikey=... from the URL into the apikey header when clients omit the header.
+                - name: envoy.filters.http.lua
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                    inline_code: |
+                      local FUNCTIONS_ROUTE = "functions-v1-all"
+                      local FUNCTIONS_PREFIX = "/functions/v1/"
+
+                      local function is_functions_request(request_handle, headers)
+                        if request_handle:streamInfo():routeName() == FUNCTIONS_ROUTE then
+                          return true
+                        end
+
+                        local path = headers:get(":path")
+                        if path == nil then
+                          return false
+                        end
+
+                        return string.sub(path, 1, string.len(FUNCTIONS_PREFIX)) == FUNCTIONS_PREFIX
+                      end
+
+                      function envoy_on_request(request_handle)
+                        local headers = request_handle:headers()
+                        if is_functions_request(request_handle, headers) then
+                          return
+                        end
+
+                        if headers:get("apikey") ~= nil then
+                          return
+                        end
+
+                        local path = headers:get(":path")
+                        local query_start = string.find(path, "?", 1, true)
+                        if query_start == nil then
+                          return
+                        end
+
+                        local query = string.sub(path, query_start + 1)
+                        for key, value in string.gmatch(query, "([^&]+)=([^&]*)") do
+                          if key == "apikey" and value ~= "" then
+                            headers:add("apikey", value)
+                            return
+                          end
+                        end
+                      end
+
+                # Returns 401 for missing/invalid API keys on protected API routes.
+                - name: envoy.filters.http.lua
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                    inline_code: |
+                      local ANON_KEY = "${ANON_KEY}"
+                      local SERVICE_ROLE_KEY = "${SERVICE_ROLE_KEY}"
+                      local SUPABASE_PUBLISHABLE_KEY = "${SUPABASE_PUBLISHABLE_KEY}"
+                      local SUPABASE_SECRET_KEY = "${SUPABASE_SECRET_KEY}"
+                      local ANON_KEY_ASYMMETRIC = "${ANON_KEY_ASYMMETRIC}"
+                      local SERVICE_ROLE_KEY_ASYMMETRIC = "${SERVICE_ROLE_KEY_ASYMMETRIC}"
+                      local TRANSLATION_ENABLED = SUPABASE_SECRET_KEY ~= "" and SUPABASE_PUBLISHABLE_KEY ~= "" and SERVICE_ROLE_KEY_ASYMMETRIC ~= "" and ANON_KEY_ASYMMETRIC ~= ""
+
+                      local PROTECTED_ROUTES = {
+                        ["auth-v1-protected"] = true,
+                        ["rest-v1-openapi-protected"] = true,
+                        ["rest-v1-protected"] = true,
+                        ["graphql-v1-protected"] = true,
+                        ["realtime-v1-api-protected"] = true,
+                        ["realtime-v1-ws-protected"] = true,
+                        ["pg-protected"] = true,
+                      }
+
+                      local function is_protected_route(route_name)
+                        if route_name == nil or route_name == "" then
+                          return false
+                        end
+
+                        return PROTECTED_ROUTES[route_name] == true
+                      end
+
+                      local function is_valid_apikey(apikey)
+                        if apikey == nil or apikey == "" then
+                          return false
+                        end
+
+                        if SERVICE_ROLE_KEY ~= "" and apikey == SERVICE_ROLE_KEY then
+                          return true
+                        end
+
+                        if ANON_KEY ~= "" and apikey == ANON_KEY then
+                          return true
+                        end
+
+                        if TRANSLATION_ENABLED and apikey == SUPABASE_SECRET_KEY then
+                          return true
+                        end
+
+                        if TRANSLATION_ENABLED and apikey == SUPABASE_PUBLISHABLE_KEY then
+                          return true
+                        end
+
+                        return false
+                      end
+
+                      function envoy_on_request(request_handle)
+                        local headers = request_handle:headers()
+                        local route_name = request_handle:streamInfo():routeName()
+                        if not is_protected_route(route_name) then
+                          return
+                        end
+
+                        if is_valid_apikey(headers:get("apikey")) then
+                          return
+                        end
+
+                        request_handle:respond({
+                          [":status"] = "401",
+                          ["content-type"] = "text/plain",
+                        }, "Unauthorized")
+                      end
+
+                # Translates the query parameter apikey into the matching internal JWT and rewrites the URL so only JWTs propagate downstream.
+                - name: envoy.filters.http.lua
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                    inline_code: |
+                      local FUNCTIONS_ROUTE = "functions-v1-all"
+                      local FUNCTIONS_PREFIX = "/functions/v1/"
+                      local SECRET_KEY = "${SUPABASE_SECRET_KEY}"
+                      local PUBLISHABLE_KEY = "${SUPABASE_PUBLISHABLE_KEY}"
+                      local SERVICE_ROLE_JWT = "${SERVICE_ROLE_KEY_ASYMMETRIC}"
+                      local ANON_JWT = "${ANON_KEY_ASYMMETRIC}"
+                      local TRANSLATION_ENABLED = SECRET_KEY ~= "" and PUBLISHABLE_KEY ~= "" and SERVICE_ROLE_JWT ~= "" and ANON_JWT ~= ""
+
+                      local function is_functions_request(request_handle, headers)
+                        if request_handle:streamInfo():routeName() == FUNCTIONS_ROUTE then
+                          return true
+                        end
+
+                        local path = headers:get(":path")
+                        if path == nil then
+                          return false
+                        end
+
+                        return string.sub(path, 1, string.len(FUNCTIONS_PREFIX)) == FUNCTIONS_PREFIX
+                      end
+
+                      local function translate_apikey(apikey)
+                        if apikey == nil or apikey == "" then
+                          return nil
+                        end
+
+                        if not TRANSLATION_ENABLED then
+                          return nil
+                        end
+
+                        if apikey == SECRET_KEY then
+                          return SERVICE_ROLE_JWT
+                        end
+
+                        if apikey == PUBLISHABLE_KEY then
+                          return ANON_JWT
+                        end
+
+                        return nil
+                      end
+
+                      local function extract_query_apikey(path)
+                        if path == nil or path == "" then
+                          return nil
+                        end
+
+                        local query_start = string.find(path, "?", 1, true)
+                        if query_start == nil then
+                          return nil
+                        end
+
+                        local query = string.sub(path, query_start + 1)
+                        for key, value in string.gmatch(query, "([^&]+)=([^&]*)") do
+                          if key == "apikey" and value ~= "" then
+                            return value
+                          end
+                        end
+
+                        return nil
+                      end
+
+                      local function replace_query_apikey(path, new_value)
+                        if path == nil or path == "" or new_value == nil or new_value == "" then
+                          return nil
+                        end
+
+                        local query_start = string.find(path, "?", 1, true)
+                        if query_start == nil then
+                          return nil
+                        end
+
+                        local base = string.sub(path, 1, query_start)
+                        local query = string.sub(path, query_start + 1)
+                        local updated = {}
+                        local replaced = false
+
+                        for part in string.gmatch(query, "([^&]+)") do
+                          local key, value = string.match(part, "([^=]+)=(.*)")
+                          if key == "apikey" then
+                            part = key .. "=" .. new_value
+                            replaced = true
+                          end
+                          table.insert(updated, part)
+                        end
+
+                        if not replaced then
+                          return nil
+                        end
+
+                        return base .. table.concat(updated, "&")
+                      end
+
+                      function envoy_on_request(request_handle)
+                        local headers = request_handle:headers()
+                        if is_functions_request(request_handle, headers) then
+                          return
+                        end
+
+                        local path = headers:get(":path")
+                        local apikey = extract_query_apikey(path)
+                        local translated = translate_apikey(apikey)
+
+                        if translated == nil then
+                          return
+                        end
+
+                        headers:replace("apikey", translated)
+
+                        local rewritten_path = replace_query_apikey(path, translated)
+                        if rewritten_path ~= nil then
+                          headers:replace(":path", rewritten_path)
+                        end
+                      end
+
+                # Translates an apikey header into the appropriate internal JWT for downstream RBAC checks.
+                - name: envoy.filters.http.lua
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                    inline_code: |
+                      local FUNCTIONS_ROUTE = "functions-v1-all"
+                      local FUNCTIONS_PREFIX = "/functions/v1/"
+                      local SECRET_KEY = "${SUPABASE_SECRET_KEY}"
+                      local PUBLISHABLE_KEY = "${SUPABASE_PUBLISHABLE_KEY}"
+                      local SERVICE_ROLE_JWT = "${SERVICE_ROLE_KEY_ASYMMETRIC}"
+                      local ANON_JWT = "${ANON_KEY_ASYMMETRIC}"
+                      local TRANSLATION_ENABLED = SECRET_KEY ~= "" and PUBLISHABLE_KEY ~= "" and SERVICE_ROLE_JWT ~= "" and ANON_JWT ~= ""
+
+                      local function is_functions_request(request_handle, headers)
+                        if request_handle:streamInfo():routeName() == FUNCTIONS_ROUTE then
+                          return true
+                        end
+
+                        local path = headers:get(":path")
+                        if path == nil then
+                          return false
+                        end
+
+                        return string.sub(path, 1, string.len(FUNCTIONS_PREFIX)) == FUNCTIONS_PREFIX
+                      end
+
+                      local function translate_apikey(apikey)
+                        if apikey == nil or apikey == "" then
+                          return nil
+                        end
+
+                        if not TRANSLATION_ENABLED then
+                          return nil
+                        end
+
+                        if apikey == SECRET_KEY then
+                          return SERVICE_ROLE_JWT
+                        end
+
+                        if apikey == PUBLISHABLE_KEY then
+                          return ANON_JWT
+                        end
+
+                        return nil
+                      end
+
+                      function envoy_on_request(request_handle)
+                        local headers = request_handle:headers()
+                        if is_functions_request(request_handle, headers) then
+                          return
+                        end
+
+                        local translated = translate_apikey(headers:get("apikey"))
+                        if translated ~= nil and translated ~= "" then
+                          headers:replace("apikey", translated)
+                        end
+                      end
+
+                # Mirrors apikey into x-api-key for realtime WS compatibility.
+                - name: envoy.filters.http.lua
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                    inline_code: |
+                      local REALTIME_WS_ROUTE = "realtime-v1-ws-protected"
+
+                      function envoy_on_request(request_handle)
+                        local route_name = request_handle:streamInfo():routeName()
+                        if route_name ~= REALTIME_WS_ROUTE then
+                          return
+                        end
+
+                        local headers = request_handle:headers()
+                        local apikey = headers:get("apikey")
+                        if apikey == nil or apikey == "" then
+                          return
+                        end
+
+                        headers:replace("x-api-key", apikey)
+                      end
+
+                # Synthesizes an Authorization header (Bearer …) from apikey when callers don’t provide a real JWT header.
+                - name: envoy.filters.http.lua
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                    inline_code: |
+                      local FUNCTIONS_ROUTE = "functions-v1-all"
+                      local FUNCTIONS_PREFIX = "/functions/v1/"
+                      local REALTIME_WS_ROUTE = "realtime-v1-ws-protected"
+
+                      local function is_functions_request(request_handle, headers)
+                        if request_handle:streamInfo():routeName() == FUNCTIONS_ROUTE then
+                          return true
+                        end
+
+                        local path = headers:get(":path")
+                        if path == nil then
+                          return false
+                        end
+
+                        return string.sub(path, 1, string.len(FUNCTIONS_PREFIX)) == FUNCTIONS_PREFIX
+                      end
+
+                      local function has_real_jwt(auth_header)
+                        if auth_header == nil or auth_header == "" then
+                          return false
+                        end
+
+                        if string.sub(auth_header, 1, 7) ~= "Bearer " then
+                          return false
+                        end
+
+                        return string.sub(auth_header, 1, 10) ~= "Bearer sb_"
+                      end
+
+                      local function format_authorization(value)
+                        if value == nil or value == "" then
+                          return nil
+                        end
+
+                        if string.sub(value, 1, 7) == "Bearer " then
+                          return value
+                        end
+
+                        return "Bearer " .. value
+                      end
+
+                      function envoy_on_request(request_handle)
+                        local headers = request_handle:headers()
+                        if request_handle:streamInfo():routeName() == REALTIME_WS_ROUTE then
+                          return
+                        end
+
+                        if is_functions_request(request_handle, headers) then
+                          return
+                        end
+
+                        if has_real_jwt(headers:get("authorization")) then
+                          return
+                        end
+
+                        local apikey = headers:get("apikey")
+                        local authorization_value = format_authorization(apikey)
+                        if authorization_value ~= nil then
+                          headers:replace("authorization", authorization_value)
+                        end
+                      end
+
+                - name: envoy.filters.http.rbac
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+                    rules:
+                      action: ALLOW
+                      policies:
+                        admin:
+                          permissions:
+                            - url_path:
+                                path:
+                                  prefix: /pg/
+                          principals:
+                            - header:
+                                name: apikey
+                                string_match:
+                                  exact: '${SERVICE_ROLE_KEY}'
+                            - header:
+                                name: apikey
+                                string_match:
+                                  exact: '${SERVICE_ROLE_KEY_ASYMMETRIC}'
+                        apikey:
+                          permissions:
+                            - url_path:
+                                path:
+                                  prefix: /auth/v1/
+                            - url_path:
+                                path:
+                                  prefix: /rest/v1/
+                            - url_path:
+                                path:
+                                  prefix: /realtime/v1/api
+                            - url_path:
+                                path:
+                                  prefix: /realtime/v1/
+                            - url_path:
+                                path:
+                                  prefix: /graphql/v1
+                          principals:
+                            - header:
+                                name: apikey
+                                string_match:
+                                  exact: '${SERVICE_ROLE_KEY}'
+                            - header:
+                                name: apikey
+                                string_match:
+                                  exact: '${ANON_KEY}'
+                            - header:
+                                name: apikey
+                                string_match:
+                                  exact: '${SERVICE_ROLE_KEY_ASYMMETRIC}'
+                            - header:
+                                name: apikey
+                                string_match:
+                                  exact: '${ANON_KEY_ASYMMETRIC}'
+                - name: envoy.filters.http.router
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+'''
+
+[[config.mounts]]
+filePath = "/volumes/api/envoy/docker-entrypoint.sh"
+content = '''#!/bin/sh
+set -e
+
+# Generate SHA1 base64 hash for Envoy basic auth user list
+PASSWORD_HASH=$(printf '%s' "${DASHBOARD_PASSWORD}" | openssl sha1 -binary | openssl base64)
+DASHBOARD_BASIC_AUTH="${DASHBOARD_USERNAME}:{SHA}${PASSWORD_HASH}"
+
+echo "Generating Envoy configuration..."
+
+# Process the lds.yaml template with environment variables using sed
+# Using | as delimiter since JWT tokens contain /
+sed -e "s|\${ANON_KEY}|${ANON_KEY}|g" \
+    -e "s|\${ANON_KEY_ASYMMETRIC}|${ANON_KEY_ASYMMETRIC}|g" \
+    -e "s|\${SERVICE_ROLE_KEY}|${SERVICE_ROLE_KEY}|g" \
+    -e "s|\${SERVICE_ROLE_KEY_ASYMMETRIC}|${SERVICE_ROLE_KEY_ASYMMETRIC}|g" \
+    -e "s|\${SUPABASE_PUBLISHABLE_KEY}|${SUPABASE_PUBLISHABLE_KEY}|g" \
+    -e "s|\${SUPABASE_SECRET_KEY}|${SUPABASE_SECRET_KEY}|g" \
+    -e "s|\${SUPABASE_PUBLIC_URL}|${SUPABASE_PUBLIC_URL}|g" \
+    -e "s|\${DASHBOARD_BASIC_AUTH}|${DASHBOARD_BASIC_AUTH}|g" \
+    /etc/envoy/lds.template.yaml > /etc/envoy/lds.yaml
+
+if [ -n "$SUPABASE_SECRET_KEY" ] && \
+   [ -n "$SUPABASE_PUBLISHABLE_KEY" ] && \
+   [ -n "$SERVICE_ROLE_KEY_ASYMMETRIC" ] && \
+   [ -n "$ANON_KEY_ASYMMETRIC" ]; then
+  echo "Envoy sb_ key translation enabled"
+else
+  echo "Envoy running in legacy API key mode (sb_ keys disabled)"
+fi
+
+echo "Envoy configuration generated successfully"
+echo "Starting Envoy..."
+
+# Start Envoy
+exec envoy -c /etc/envoy/envoy.yaml "$@"
+'''
 
 [[config.mounts]]
 filePath = "/volumes/snippets/.gitkeep"
@@ -954,7 +1906,7 @@ serve(async () => {
 })
 
 // To invoke:
-// curl 'http://localhost:<KONG_HTTP_PORT>/functions/v1/hello' \
+// curl 'http://localhost:<API_GW_HTTP_PORT>/functions/v1/hello' \
 //   --header 'Authorization: Bearer <anon/service_role API key>'
 """
 


### PR DESCRIPTION
## What is this PR about?

Update `blueprints/supabase` to match official Supabase self-hosting, including the switch to **Envoy** as the API gateway.

Upstream made Envoy the default gateway on 2026-08-11 ([supabase#48153](https://github.com/supabase/supabase/pull/48153), self-hosted release 0.8.0) and shipped a **CORS fix for `/pg/` routes** on 2026-08-17 ([supabase#49136](https://github.com/supabase/supabase/pull/49136) that only Envoy carries. This blueprint still shipped Kong.

Three separable commits, kept in one PR because they touch overlapping lines in `template.toml`. Happy to split if you would rather review them apart.

---

### 1. `615f8d8` — Kong → Envoy

| Field | Was | Is |
|---|---|---|
| service key | `kong` | `api-gw` |
| `image` | `kong/kong:3.9.3` | `envoyproxy/envoy:v1.39.0` |
| `healthcheck` | `["CMD","kong","health"]` | TCP check — the Envoy image has no curl or wget |
| `expose` | `8000`, `8443` | `8000` only; Envoy has no 8443 listener |
| `volumes` | 2 Kong mounts | 4 `../files/volumes/api/envoy/*` mounts |
| `environment` | `SUPABASE_ANON_KEY`/`SUPABASE_SERVICE_KEY`, 10 `KONG_*` | `ANON_KEY`/`SERVICE_ROLE_KEY`, no `KONG_*`, **plus `SUPABASE_PUBLIC_URL`** (required by #49136) |

`serviceName` in `[[config.domains]]` follows to `api-gw`, `KONG_HTTP_PORT` becomes `API_GW_HTTP_PORT`, and `KONG_HTTPS_PORT` is dropped. `grep -i kong` returns zero hits across all four blueprint files.

**Two deliberate deviations from official, both required here:**

- **No `networks:` aliases block and no `ports:` mapping.** `build-scripts/validate-docker-compose.ts` rejects both. Official's `aliases: [envoy, kong]` exists only for backwards compatibility, and nothing in this blueprint still points at `kong`.
- **`cds.yaml` points the `realtime` cluster at `realtime`**, not official's `realtime-dev.supabase-realtime` — that is official's `container_name`, and this blueprint sets none, so upstream's address would not resolve. `lds.template.yaml` is left byte-identical, so the `host_rewrite_literal` realtime uses for tenant resolution is unchanged.

The other three envoy files are byte-identical to `supabase/supabase@master`. They are embedded as TOML **literal** multi-line strings (`'''`) rather than basic ones, so the sed-driven entrypoint and the 50 KB listener template survive byte-for-byte; parsing them back out returns 677 / 5879 / 50081 / 1366 bytes.

Also pulls in official's `functions` healthcheck, the one non-gateway addition this blueprint lacked.

### 2. `e309adc` — five parity gaps with official

These predate the Envoy work but sit on the same surface.

- **`API_EXTERNAL_URL` was missing `/auth/v1`.** Official changed this in [supabase@e7abda8d](https://github.com/supabase/supabase/commit/e7abda8d) ([#47640](https://github.com/supabase/supabase/pull/47640), 2026-07-07) and the blueprint never followed. Without the path, GoTrue advertises `https://<domain>/callback` as its OAuth `redirect_uri`, and `lds.template.yaml` routes a bare `/callback` to the `/` catch-all — **Studio**, not auth. Every social sign-in and SAML flow dead-ends on the dashboard login prompt. Email links keep working, because GoTrue resolves `/auth/v1/verify` as an absolute path, which is why this is easy to miss.
- **The edge-functions volume was still at the 2023 state.** `importMapPath = null` and a `deno.land/std@0.177.1` sample. Official shipped the `deno.jsonc` import map and the `withSupabase` sample in [9ef9f1b8](https://github.com/supabase/supabase/commit/9ef9f1b8) (2026-08-14) and `SUPABASE_FUNCTION_SLUG` in [f5f897a2](https://github.com/supabase/supabase/commit/f5f897a2) (2026-08-28). Without them, a function written against current Supabase docs cannot resolve `@supabase/server`.
- **`:Z` on the functions directory shared by two containers.** Official uses `:z`, and `:ro,z` on Studio's copy. `:Z` applies a private SELinux MCS label, so relabelling one host directory for a second container revokes the first container's access. Every other bind flag in the file already matched official; these three were the only drift.
- **`meta.json` version** advertised `2026.08.17` while every image is official's `2026.08.03` set. Now `2026.08.03-3`.
- **`API_GW_HTTP_PORT` is inert** — the port is pinned by `expose` and by the domain block — and the comment above it said the opposite.

### 3. `7fca984` — document the `https` assumption

The template generates `SUPABASE_PUBLIC_URL`, `API_EXTERNAL_URL` and `ADDITIONAL_REDIRECT_URLS` with `https://`, which is right for a public domain with a certificate. **Dokploy creates the template's domain with none**, so until one is enabled the domain answers on `http` only and those three values point at a scheme that does not respond — while the stack reports healthy and the gateway answers, so nothing looks broken. Studio's own calls fail, Envoy's CORS check compares `Origin` against the `https` string and refuses, and GoTrue builds its issuer, redirects and email links from the dead scheme.

`instructions.md` now says so, and notes that Let's Encrypt cannot rescue a privately-routed address.

## Checklist

- [x] I have read the suggestions in the README.md file
- [x] **I have tested the template in my instance** — see below
- [x] I have added tests that demonstrate that my correction works

## Testing

Tested twice: rendered locally the way Dokploy renders it, and then **deployed for real from a Dokploy v0.30.5 panel onto a remote server**. All 11 services reach `healthy` in both.

Ten checks against the deployed instance, through its public domain:

| Check | Result |
|---|---|
| Studio basic auth | 401 + `WWW-Authenticate` with no creds, 307 with correct, 401 with a wrong password |
| Legacy keys | `ANON_KEY` 200 on `/auth/v1/settings`; `SERVICE_ROLE_KEY` 200 on `/rest/v1/`; no key 401 |
| Opaque `sb_` key translation | against an RLS table, `sb_publishable_…` returns `[]` and `sb_secret_…` returns the row; on the service-role-only `/rest/v1/` root, 403 vs 200 |
| Blocked routes | `/realtime/v1/api/tenants` and `/realtime/v1/api/openapi` both 403; `/rest/v1/` root anon 403 |
| Auth routing | `/auth/v1/authorize` returns GoTrue's 400; bare `/callback` returns Studio's 401 — the `/auth/v1` fix above |
| **CORS `/pg/` (#49136)** | `OPTIONS` returns `access-control-allow-origin` matching `SUPABASE_PUBLIC_URL`; a foreign origin gets 401 |
| Realtime websocket | 101 upgrade with `?apikey=sb_publishable_…` and with a legacy anon key; 401 with a bogus key; a `phx_join` replies `{"status":"ok"}` |
| Edge function | `/functions/v1/hello` returns 200 `{"message":"Hello from Edge Functions!"}` for both `sb_publishable_` and `sb_secret_` |

Repo validators pass: `generate-meta.js --check` (532 templates), `validate-docker-compose.ts`, `validate-template.ts` (domain `api-gw:8000`).

## Notes for reviewers

- **One deliberate behaviour change, from official.** The new `hello` sample declares `auth: ["publishable","secret"]`, so a legacy anon JWT now gets a 401 with an explanatory `INVALID_API_KEY` body where the old sample accepted `Authorization: Bearer`. That is upstream's design, not a regression here, but it is visible to anyone copying the old sample.
- **`template.toml` grows 35 KB → 83 KB**, almost all of it official's `lds.template.yaml`. This does not affect the panel's deploy path — `deployTemplate` fetches the file server-side rather than through the BASE64 import.
- **Existing Kong-era deployments need one manual step** before redeploying: edit the domain's Service Name from `kong` to `api-gw`, or Dokploy rejects the deploy because the domain names a service that is no longer in the compose. Documented in `instructions.md`.
- `blueprints/pre0.22.5-supabase` is untouched.
