### PR TITLE
feat(appwrite): update template to 2.2.0

### DIFF
--- a/blueprints/appwrite/docker-compose.yml
+++ b/blueprints/appwrite/docker-compose.yml
@@ -6,14 +6,14 @@ x-logging: &x-logging
     options:
       max-file: "5"
       max-size: "10m"
+
 services:
   appwrite:
-    image: appwrite/appwrite:1.9.5
+    image: appwrite/appwrite:2.0.0
     <<: *x-logging
     restart: unless-stopped
     labels:
       - traefik.enable=true
-      - traefik.constraint-label-stack=appwrite
       - 'traefik.http.routers.appwrite-sites-wildcard.rule=HostRegexp(`^.+\.${_APP_DOMAIN_SITES}$$`)'
       - traefik.http.routers.appwrite-sites-wildcard.entrypoints=web
       - traefik.http.routers.appwrite-sites-wildcard.service=appwrite-wildcard
@@ -31,11 +31,12 @@ services:
       - traefik.http.services.appwrite-wildcard.loadbalancer.server.port=80
     healthcheck:
       test:
-        - CMD
-        - doctor
+        - CMD-SHELL
+        - 'curl -fsS -o /dev/null -H "Host: $${_APP_DOMAIN:-localhost}" http://localhost/v1/health/version'
       interval: 5s
       timeout: 5s
       retries: 12
+      start_period: 120s
     volumes:
       - appwrite-uploads:/storage/uploads:rw
       - appwrite-imports:/storage/imports:rw
@@ -46,8 +47,12 @@ services:
       - appwrite-sites:/storage/sites:rw
       - appwrite-builds:/storage/builds:rw
     depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
+      redis:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
+      appwrite-geo:
+        condition: service_started
     environment:
       - _APP_ENV
       - _APP_EDITION
@@ -62,18 +67,31 @@ services:
       - _APP_CONSOLE_WHITELIST_IPS
       - _APP_CONSOLE_HOSTNAMES
       - _APP_CONSOLE_SCHEMA
+      - _APP_CONSOLE_GITHUB_APP_ID
+      - _APP_CONSOLE_GITHUB_SECRET
+      - _APP_CONSOLE_GITLAB_APP_ID
+      - _APP_CONSOLE_GITLAB_SECRET
+      - _APP_CONSOLE_GITLAB_ENDPOINT
+      - _APP_CONSOLE_BITBUCKET_APP_ID
+      - _APP_CONSOLE_BITBUCKET_SECRET
+      - _APP_CONSOLE_GOOGLE_APP_ID
+      - _APP_CONSOLE_GOOGLE_SECRET
       - _APP_SYSTEM_EMAIL_NAME
       - _APP_SYSTEM_EMAIL_ADDRESS
       - _APP_SYSTEM_TEAM_EMAIL
       - _APP_EMAIL_SECURITY
       - _APP_SYSTEM_RESPONSE_FORMAT
       - _APP_OPTIONS_ABUSE
+      - _APP_OPTIONS_ABUSE_INCREASED_LIMIT_PROJECTS
       - _APP_OPTIONS_ROUTER_PROTECTION
       - _APP_OPTIONS_FORCE_HTTPS
       - _APP_OPTIONS_ROUTER_FORCE_HTTPS
+      - _APP_ROUTER_AUTO_CERTIFICATES
       - _APP_OPENSSL_KEY_V1
+      - _APP_NOTIFICATIONS_TRACKING_SECRET
       - _APP_DOMAIN
       - _APP_CONSOLE_DOMAIN
+      - _APP_CONSOLE_URL_SCHEME=root
       - _APP_CONSOLE_TRUSTED_PROJECTS
       - _APP_DOMAIN_TARGET_CNAME
       - _APP_DOMAIN_TARGET_AAAA
@@ -81,6 +99,9 @@ services:
       - _APP_DOMAIN_TARGET_CAA
       - _APP_DNS
       - _APP_DOMAIN_FUNCTIONS
+      - _APP_DOMAIN_SITES
+      - _APP_CUSTOM_DOMAIN_DENY_LIST
+      - _APP_TRUSTED_HEADERS
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
@@ -91,18 +112,45 @@ services:
       - _APP_DB_SCHEMA
       - _APP_DB_USER
       - _APP_DB_PASS
+      - _APP_DATABASE_SHARED_TABLES
+      - _APP_DATABASE_SHARED_NAMESPACE
+      - _APP_LIMIT_DATABASE_BATCH
+      - _APP_LOCKING_ENABLED
+      - _APP_DOCUMENTSDB
+      - _APP_DB_ADAPTER_DOCUMENTSDB
+      - _APP_DB_HOST_DOCUMENTSDB
+      - _APP_DB_PORT_DOCUMENTSDB
+      - _APP_DB_SCHEMA_DOCUMENTSDB
+      - _APP_DB_USER_DOCUMENTSDB
+      - _APP_DB_PASS_DOCUMENTSDB
+      - _APP_CONNECTIONS_DATABASE_DOCUMENTSDB
+      - _APP_VECTORSDB
       - _APP_DB_ADAPTER_VECTORSDB
       - _APP_DB_HOST_VECTORSDB
       - _APP_DB_PORT_VECTORSDB
       - _APP_DB_SCHEMA_VECTORSDB
       - _APP_DB_USER_VECTORSDB
       - _APP_DB_PASS_VECTORSDB
+      - _APP_CONNECTIONS_DATABASE_VECTORSDB
+      - _APP_EMBEDDING
+      - _APP_USAGE_STATS
+      - _APP_USAGE_PASS
+      - _APP_CONNECTIONS_DB_USAGE
+      - _APP_POOL_SIZE_USAGE
+      - _APP_EXECUTIONS_DUAL_WRITE
+      - _APP_CONNECTIONS_DB_EXECUTIONS
+      - _APP_POOL_SIZE_EXECUTIONS
+      - _APP_MAINTENANCE_RETENTION_USAGE_TTL
+      - _APP_STATS_USAGE_QUEUE_NAME
+      - _APP_STATS_RESOURCES_QUEUE_NAME
+      - _APP_STATS_RESOURCES_INTERVAL
       - _APP_SMTP_HOST
       - _APP_SMTP_PORT
       - _APP_SMTP_SECURE
       - _APP_SMTP_USERNAME
       - _APP_SMTP_PASSWORD
-      - _APP_USAGE_STATS
+      - _APP_SMS_PROVIDER
+      - _APP_SMS_FROM
       - _APP_STORAGE_LIMIT
       - _APP_STORAGE_PREVIEW_LIMIT
       - _APP_STORAGE_ANTIVIRUS
@@ -131,17 +179,26 @@ services:
       - _APP_STORAGE_WASABI_REGION
       - _APP_STORAGE_WASABI_BUCKET
       - _APP_COMPUTE_SIZE_LIMIT
-      - _APP_FUNCTIONS_TIMEOUT
-      - _APP_SITES_TIMEOUT
       - _APP_COMPUTE_BUILD_TIMEOUT
       - _APP_COMPUTE_CPUS
       - _APP_COMPUTE_MEMORY
+      - _APP_FUNCTIONS_TIMEOUT
       - _APP_FUNCTIONS_RUNTIMES
+      - _APP_FUNCTIONS_CREATION_ABUSE_LIMIT
+      - _APP_SITES_TIMEOUT
       - _APP_SITES_RUNTIMES
-      - _APP_DOMAIN_SITES
       - _APP_EXECUTOR_SECRET
       - _APP_EXECUTOR_HOST
+      - _APP_BUILDS_VOLUME=${COMPOSE_PROJECT_NAME:-appwrite}_appwrite-builds
+      - _APP_JOBS_HOST
+      - _APP_JOBS_SECRET
+      - _APP_JOBS_ENDPOINT
+      - _APP_GEO_SECRET
+      - _APP_GEO_ENDPOINT
       - _APP_LOGGING_CONFIG
+      - _APP_LOGGING_FORMAT
+      - _APP_EXPERIMENT_LOGGING_PROVIDER
+      - _APP_EXPERIMENT_LOGGING_CONFIG
       - _APP_MAINTENANCE_INTERVAL
       - _APP_MAINTENANCE_RETENTION_EXECUTION
       - _APP_MAINTENANCE_RETENTION_CACHE
@@ -150,8 +207,6 @@ services:
       - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
       - _APP_MAINTENANCE_RETENTION_USAGE_HOURLY
       - _APP_MAINTENANCE_RETENTION_SCHEDULES
-      - _APP_SMS_PROVIDER
-      - _APP_SMS_FROM
       - _APP_GRAPHQL_INTROSPECTION
       - _APP_GRAPHQL_MAX_BATCH_SIZE
       - _APP_GRAPHQL_MAX_COMPLEXITY
@@ -162,43 +217,53 @@ services:
       - _APP_VCS_GITHUB_WEBHOOK_SECRET
       - _APP_VCS_GITHUB_CLIENT_SECRET
       - _APP_VCS_GITHUB_CLIENT_ID
+      - _APP_VCS_GITEA_ENDPOINT
+      - _APP_VCS_GITEA_BROWSER_ENDPOINT
+      - _APP_VCS_GITEA_CLIENT_ID
+      - _APP_VCS_GITEA_CLIENT_SECRET
+      - _APP_VCS_GITEA_WEBHOOK_SECRET
+      - _APP_VCS_GITLAB_ENDPOINT
+      - _APP_VCS_GITLAB_CLIENT_ID
+      - _APP_VCS_GITLAB_CLIENT_SECRET
+      - _APP_VCS_GITLAB_WEBHOOK_SECRET
+      - _APP_VCS_BITBUCKET_CLIENT_ID
+      - _APP_VCS_BITBUCKET_CLIENT_SECRET
+      - _APP_VCS_BITBUCKET_WEBHOOK_SECRET
+      - _APP_VCS_ORIGIN_CLIENT_ID
+      - _APP_VCS_ORIGIN_PRIVATE_KEY
+      - _APP_VCS_WEBHOOK_URL
+      - _APP_MIGRATION_HOST
       - _APP_MIGRATIONS_FIREBASE_CLIENT_ID
       - _APP_MIGRATIONS_FIREBASE_CLIENT_SECRET
       - _APP_ASSISTANT_OPENAI_API_KEY
       - _APP_CONSOLE_COUNTRIES_DENYLIST
-      - _APP_EXPERIMENT_LOGGING_PROVIDER
-      - _APP_EXPERIMENT_LOGGING_CONFIG
-      - _APP_DATABASE_SHARED_TABLES
-      - _APP_DATABASE_SHARED_NAMESPACE
-      - _APP_FUNCTIONS_CREATION_ABUSE_LIMIT
-      - _APP_CUSTOM_DOMAIN_DENY_LIST
-      - _APP_TRUSTED_HEADERS
-      - _APP_MIGRATION_HOST
 
   appwrite-console:
+    image: appwrite/new:1.1.16
     <<: *x-logging
-    image: appwrite/console:8.7.5
     restart: unless-stopped
-    labels:
-      - "traefik.enable=true"
-      - "traefik.constraint-label-stack=appwrite"
+    environment:
+      - VITE_CONSOLE_PROFILE=self-hosted
+      - APPWRITE_ENDPOINT_SAME_ORIGIN=true
+      - VITE_GROWTH_ENDPOINT=https://growth.appwrite.io/v1
 
   appwrite-realtime:
-    image: appwrite/appwrite:1.9.5
+    image: appwrite/appwrite:2.0.0
     entrypoint: realtime
     <<: *x-logging
     restart: unless-stopped
-    labels:
-      - "traefik.enable=true"
-      - "traefik.constraint-label-stack=appwrite"
     depends_on:
-      - ${_APP_DB_HOST:-mongodb}
-      - redis
+      redis:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
     environment:
       - _APP_ENV
       - _APP_WORKER_PER_CORE
       - _APP_OPTIONS_ABUSE
       - _APP_OPTIONS_ROUTER_PROTECTION
+      - _APP_CONSOLE_HOSTNAMES
+      - _APP_REALTIME_TAIL_RATE
       - _APP_OPENSSL_KEY_V1
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
@@ -210,84 +275,42 @@ services:
       - _APP_DB_SCHEMA
       - _APP_DB_USER
       - _APP_DB_PASS
+      - _APP_DATABASE_SHARED_TABLES
+      - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_DB_ADAPTER_DOCUMENTSDB
+      - _APP_DB_HOST_DOCUMENTSDB
+      - _APP_DB_PORT_DOCUMENTSDB
+      - _APP_DB_SCHEMA_DOCUMENTSDB
+      - _APP_DB_USER_DOCUMENTSDB
+      - _APP_DB_PASS_DOCUMENTSDB
+      - _APP_CONNECTIONS_DATABASE_DOCUMENTSDB
+      - _APP_VECTORSDB
       - _APP_DB_ADAPTER_VECTORSDB
       - _APP_DB_HOST_VECTORSDB
       - _APP_DB_PORT_VECTORSDB
       - _APP_DB_SCHEMA_VECTORSDB
       - _APP_DB_USER_VECTORSDB
       - _APP_DB_PASS_VECTORSDB
+      - _APP_CONNECTIONS_DATABASE_VECTORSDB
+      - _APP_EMBEDDING
       - _APP_USAGE_STATS
+      - _APP_STATS_USAGE_QUEUE_NAME
       - _APP_LOGGING_CONFIG
+      - _APP_LOGGING_FORMAT
       - _APP_LOGGING_CONFIG_REALTIME
-      - _APP_DATABASE_SHARED_TABLES
       - _APP_POOL_ADAPTER=swoole
 
-  appwrite-worker-audits:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-audits
+  appwrite-worker:
+    image: appwrite/appwrite:2.0.0
+    entrypoint: worker
     <<: *x-logging
     restart: unless-stopped
     depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_LOGGING_CONFIG
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-worker-webhooks:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-webhooks
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=8
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_EMAIL_SECURITY
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_LOGGING_CONFIG
-      - _APP_WEBHOOK_MAX_FAILED_ATTEMPTS
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-worker-deletes:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-deletes
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
+      redis:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
     volumes:
       - appwrite-uploads:/storage/uploads:rw
       - appwrite-cache:/storage/cache:rw
@@ -295,68 +318,21 @@ services:
       - appwrite-sites:/storage/sites:rw
       - appwrite-builds:/storage/builds:rw
       - appwrite-certificates:/storage/certificates:rw
+      - appwrite-config:/storage/config:rw
+      - appwrite-imports:/storage/imports:rw
+    extra_hosts:
+      - host.docker.internal:host-gateway
     environment:
       - _APP_ENV
       - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=8
+      # Pool sizing only (sum of per-queue caps). Each queue keeps its own maxCoroutines in PHP; databases stays at 1.
+      - _APP_WORKER_MAX_COROUTINES=78
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_STORAGE_DEVICE
-      - _APP_STORAGE_S3_ACCESS_KEY
-      - _APP_STORAGE_S3_SECRET
-      - _APP_STORAGE_S3_REGION
-      - _APP_STORAGE_S3_BUCKET
-      - _APP_STORAGE_S3_ENDPOINT
-      - _APP_STORAGE_DO_SPACES_ACCESS_KEY
-      - _APP_STORAGE_DO_SPACES_SECRET
-      - _APP_STORAGE_DO_SPACES_REGION
-      - _APP_STORAGE_DO_SPACES_BUCKET
-      - _APP_STORAGE_BACKBLAZE_ACCESS_KEY
-      - _APP_STORAGE_BACKBLAZE_SECRET
-      - _APP_STORAGE_BACKBLAZE_REGION
-      - _APP_STORAGE_BACKBLAZE_BUCKET
-      - _APP_STORAGE_LINODE_ACCESS_KEY
-      - _APP_STORAGE_LINODE_SECRET
-      - _APP_STORAGE_LINODE_REGION
-      - _APP_STORAGE_LINODE_BUCKET
-      - _APP_STORAGE_WASABI_ACCESS_KEY
-      - _APP_STORAGE_WASABI_SECRET
-      - _APP_STORAGE_WASABI_REGION
-      - _APP_STORAGE_WASABI_BUCKET
-      - _APP_LOGGING_CONFIG
-      - _APP_EXECUTOR_SECRET
-      - _APP_EXECUTOR_HOST
-      - _APP_DATABASE_SHARED_TABLES
+      - _APP_NOTIFICATIONS_TRACKING_SECRET
+      - _APP_EMAIL_SECURITY
       - _APP_EMAIL_CERTIFICATES
-      - _APP_MAINTENANCE_RETENTION_AUDIT
-      - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
-
-  appwrite-worker-databases:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-databases
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
@@ -367,165 +343,43 @@ services:
       - _APP_DB_SCHEMA
       - _APP_DB_USER
       - _APP_DB_PASS
+      - _APP_DATABASE_SHARED_TABLES
+      - _APP_LIMIT_DATABASE_BATCH
+      - _APP_DOCUMENTSDB
+      - _APP_DB_ADAPTER_DOCUMENTSDB
+      - _APP_DB_HOST_DOCUMENTSDB
+      - _APP_DB_PORT_DOCUMENTSDB
+      - _APP_DB_SCHEMA_DOCUMENTSDB
+      - _APP_DB_USER_DOCUMENTSDB
+      - _APP_DB_PASS_DOCUMENTSDB
+      - _APP_CONNECTIONS_DATABASE_DOCUMENTSDB
+      - _APP_VECTORSDB
       - _APP_DB_ADAPTER_VECTORSDB
       - _APP_DB_HOST_VECTORSDB
       - _APP_DB_PORT_VECTORSDB
       - _APP_DB_SCHEMA_VECTORSDB
       - _APP_DB_USER_VECTORSDB
       - _APP_DB_PASS_VECTORSDB
+      - _APP_CONNECTIONS_DATABASE_VECTORSDB
+      - _APP_EMBEDDING
+      - _APP_USAGE_STATS
+      - _APP_USAGE_PASS
+      - _APP_CONNECTIONS_DB_USAGE
+      - _APP_POOL_SIZE_USAGE
+      - _APP_EXECUTIONS_DUAL_WRITE
+      - _APP_CONNECTIONS_DB_EXECUTIONS
+      - _APP_POOL_SIZE_EXECUTIONS
+      - _APP_MAINTENANCE_RETENTION_USAGE_TTL
+      - _APP_STATS_USAGE_QUEUE_NAME
+      - _APP_STATS_RESOURCES_QUEUE_NAME
+      - _APP_STATS_RESOURCES_INTERVAL
       - _APP_LOGGING_CONFIG
+      - _APP_LOGGING_FORMAT
+      - _APP_LOGGING_PROVIDER
       - _APP_QUEUE_NAME
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-worker-builds:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-builds
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    volumes:
-      - appwrite-functions:/storage/functions:rw
-      - appwrite-sites:/storage/sites:rw
-      - appwrite-builds:/storage/builds:rw
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=8
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_EXECUTOR_SECRET
-      - _APP_EXECUTOR_HOST
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_LOGGING_CONFIG
-      - _APP_VCS_GITHUB_APP_NAME
-      - _APP_VCS_GITHUB_PRIVATE_KEY
-      - _APP_VCS_GITHUB_APP_ID
-      - _APP_FUNCTIONS_TIMEOUT
-      - _APP_SITES_TIMEOUT
-      - _APP_COMPUTE_BUILD_TIMEOUT
-      - _APP_COMPUTE_CPUS
-      - _APP_COMPUTE_MEMORY
-      - _APP_OPEN_RUNTIMES_NFT
-      - _APP_COMPUTE_SIZE_LIMIT
-      - _APP_OPTIONS_FORCE_HTTPS
-      - _APP_OPTIONS_ROUTER_FORCE_HTTPS
-      - _APP_DOMAIN
+      - _APP_CONSOLE_URL_SCHEME=root
       - _APP_CONSOLE_DOMAIN
       - _APP_CONSOLE_TRUSTED_PROJECTS
-      - _APP_STORAGE_DEVICE
-      - _APP_STORAGE_S3_ACCESS_KEY
-      - _APP_STORAGE_S3_SECRET
-      - _APP_STORAGE_S3_REGION
-      - _APP_STORAGE_S3_BUCKET
-      - _APP_STORAGE_S3_ENDPOINT
-      - _APP_STORAGE_DO_SPACES_ACCESS_KEY
-      - _APP_STORAGE_DO_SPACES_SECRET
-      - _APP_STORAGE_DO_SPACES_REGION
-      - _APP_STORAGE_DO_SPACES_BUCKET
-      - _APP_STORAGE_BACKBLAZE_ACCESS_KEY
-      - _APP_STORAGE_BACKBLAZE_SECRET
-      - _APP_STORAGE_BACKBLAZE_REGION
-      - _APP_STORAGE_BACKBLAZE_BUCKET
-      - _APP_STORAGE_LINODE_ACCESS_KEY
-      - _APP_STORAGE_LINODE_SECRET
-      - _APP_STORAGE_LINODE_REGION
-      - _APP_STORAGE_LINODE_BUCKET
-      - _APP_STORAGE_WASABI_ACCESS_KEY
-      - _APP_STORAGE_WASABI_SECRET
-      - _APP_STORAGE_WASABI_REGION
-      - _APP_STORAGE_WASABI_BUCKET
-      - _APP_DATABASE_SHARED_TABLES
-      - _APP_DOMAIN_SITES
-    extra_hosts:
-      - host.docker.internal:host-gateway
-
-  appwrite-worker-screenshots:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-screenshots
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    volumes:
-      - appwrite-uploads:/storage/uploads:rw
-    environment:
-      - _APP_BROWSER_HOST
-      - _APP_WORKER_SCREENSHOTS_ROUTER
-      - _APP_OPTIONS_FORCE_HTTPS
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=8
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_LOGGING_CONFIG
-      - _APP_OPENSSL_KEY_V1
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_DATABASE_SHARED_TABLES
-      - _APP_STORAGE_DEVICE
-      - _APP_STORAGE_S3_ACCESS_KEY
-      - _APP_STORAGE_S3_SECRET
-      - _APP_STORAGE_S3_REGION
-      - _APP_STORAGE_S3_BUCKET
-      - _APP_STORAGE_S3_ENDPOINT
-      - _APP_STORAGE_DO_SPACES_ACCESS_KEY
-      - _APP_STORAGE_DO_SPACES_SECRET
-      - _APP_STORAGE_DO_SPACES_REGION
-      - _APP_STORAGE_DO_SPACES_BUCKET
-      - _APP_STORAGE_BACKBLAZE_ACCESS_KEY
-      - _APP_STORAGE_BACKBLAZE_SECRET
-      - _APP_STORAGE_BACKBLAZE_REGION
-      - _APP_STORAGE_BACKBLAZE_BUCKET
-      - _APP_STORAGE_LINODE_ACCESS_KEY
-      - _APP_STORAGE_LINODE_SECRET
-      - _APP_STORAGE_LINODE_REGION
-      - _APP_STORAGE_LINODE_BUCKET
-      - _APP_STORAGE_WASABI_ACCESS_KEY
-      - _APP_STORAGE_WASABI_SECRET
-      - _APP_STORAGE_WASABI_REGION
-      - _APP_STORAGE_WASABI_BUCKET
-    extra_hosts:
-      - host.docker.internal:host-gateway
-
-  appwrite-worker-certificates:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-certificates
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    volumes:
-      - appwrite-config:/storage/config:rw
-      - appwrite-certificates:/storage/certificates:rw
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=8
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
       - _APP_DOMAIN
       - _APP_DOMAIN_TARGET_CNAME
       - _APP_DOMAIN_TARGET_AAAA
@@ -534,204 +388,107 @@ services:
       - _APP_DNS
       - _APP_DOMAIN_FUNCTIONS
       - _APP_DOMAIN_SITES
-      - _APP_EMAIL_CERTIFICATES
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_LOGGING_CONFIG
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-worker-executions:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-executions
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=8
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_LOGGING_CONFIG
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-worker-functions:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-functions
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - ${_APP_DB_HOST:-mongodb}
-      - redis
-      - openruntimes-executor
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=8
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_DOMAIN
       - _APP_OPTIONS_FORCE_HTTPS
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
+      - _APP_OPTIONS_ROUTER_FORCE_HTTPS
+      - _APP_WEBHOOK_MAX_FAILED_ATTEMPTS
+      - _APP_STORAGE_DEVICE
+      - _APP_STORAGE_S3_ACCESS_KEY
+      - _APP_STORAGE_S3_SECRET
+      - _APP_STORAGE_S3_REGION
+      - _APP_STORAGE_S3_BUCKET
+      - _APP_STORAGE_S3_ENDPOINT
+      - _APP_STORAGE_DO_SPACES_ACCESS_KEY
+      - _APP_STORAGE_DO_SPACES_SECRET
+      - _APP_STORAGE_DO_SPACES_REGION
+      - _APP_STORAGE_DO_SPACES_BUCKET
+      - _APP_STORAGE_BACKBLAZE_ACCESS_KEY
+      - _APP_STORAGE_BACKBLAZE_SECRET
+      - _APP_STORAGE_BACKBLAZE_REGION
+      - _APP_STORAGE_BACKBLAZE_BUCKET
+      - _APP_STORAGE_LINODE_ACCESS_KEY
+      - _APP_STORAGE_LINODE_SECRET
+      - _APP_STORAGE_LINODE_REGION
+      - _APP_STORAGE_LINODE_BUCKET
+      - _APP_STORAGE_WASABI_ACCESS_KEY
+      - _APP_STORAGE_WASABI_SECRET
+      - _APP_STORAGE_WASABI_REGION
+      - _APP_STORAGE_WASABI_BUCKET
+      - _APP_EXECUTOR_SECRET
+      - _APP_EXECUTOR_HOST
+      - _APP_BUILDS_VOLUME=${COMPOSE_PROJECT_NAME:-appwrite}_appwrite-builds
+      - _APP_JOBS_HOST
+      - _APP_JOBS_SECRET
+      - _APP_JOBS_ENDPOINT
+      - _APP_BROWSER_HOST
+      - _APP_WORKER_SCREENSHOTS_ROUTER
+      - _APP_DOCKER_HUB_USERNAME
+      - _APP_DOCKER_HUB_PASSWORD
       - _APP_FUNCTIONS_TIMEOUT
       - _APP_SITES_TIMEOUT
       - _APP_COMPUTE_BUILD_TIMEOUT
       - _APP_COMPUTE_CPUS
       - _APP_COMPUTE_MEMORY
-      - _APP_EXECUTOR_SECRET
-      - _APP_EXECUTOR_HOST
-      - _APP_USAGE_STATS
-      - _APP_DOCKER_HUB_USERNAME
-      - _APP_DOCKER_HUB_PASSWORD
-      - _APP_LOGGING_CONFIG
-      - _APP_LOGGING_PROVIDER
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-worker-mails:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-mails
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
+      - _APP_COMPUTE_SIZE_LIMIT
+      - _APP_OPEN_RUNTIMES_NFT
+      - _APP_VCS_GITHUB_APP_NAME
+      - _APP_VCS_GITHUB_PRIVATE_KEY
+      - _APP_VCS_GITHUB_APP_ID
+      - _APP_VCS_GITEA_ENDPOINT
+      - _APP_VCS_GITEA_BROWSER_ENDPOINT
+      - _APP_VCS_GITEA_CLIENT_ID
+      - _APP_VCS_GITEA_CLIENT_SECRET
+      - _APP_VCS_GITEA_WEBHOOK_SECRET
+      - _APP_VCS_GITLAB_ENDPOINT
+      - _APP_VCS_GITLAB_CLIENT_ID
+      - _APP_VCS_GITLAB_CLIENT_SECRET
+      - _APP_VCS_GITLAB_WEBHOOK_SECRET
+      - _APP_VCS_BITBUCKET_CLIENT_ID
+      - _APP_VCS_BITBUCKET_CLIENT_SECRET
+      - _APP_VCS_BITBUCKET_WEBHOOK_SECRET
+      - _APP_VCS_ORIGIN_CLIENT_ID
+      - _APP_VCS_ORIGIN_PRIVATE_KEY
+      - _APP_VCS_WEBHOOK_URL
       - _APP_SYSTEM_EMAIL_NAME
       - _APP_SYSTEM_EMAIL_ADDRESS
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_DB_ADAPTER
       - _APP_SMTP_HOST
       - _APP_SMTP_PORT
       - _APP_SMTP_SECURE
       - _APP_SMTP_USERNAME
       - _APP_SMTP_PASSWORD
-      - _APP_LOGGING_CONFIG
-      - _APP_DOMAIN
-      - _APP_OPTIONS_FORCE_HTTPS
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-worker-messaging:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-messaging
-    <<: *x-logging
-    restart: unless-stopped
-    volumes:
-      - appwrite-uploads:/storage/uploads:rw
-    depends_on:
-      - redis
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_LOGGING_CONFIG
       - _APP_SMS_FROM
       - _APP_SMS_PROVIDER
       - _APP_SMS_PROJECTS_DENY_LIST
-      - _APP_STORAGE_DEVICE
-      - _APP_STORAGE_S3_ACCESS_KEY
-      - _APP_STORAGE_S3_SECRET
-      - _APP_STORAGE_S3_REGION
-      - _APP_STORAGE_S3_BUCKET
-      - _APP_STORAGE_S3_ENDPOINT
-      - _APP_STORAGE_DO_SPACES_ACCESS_KEY
-      - _APP_STORAGE_DO_SPACES_SECRET
-      - _APP_STORAGE_DO_SPACES_REGION
-      - _APP_STORAGE_DO_SPACES_BUCKET
-      - _APP_STORAGE_BACKBLAZE_ACCESS_KEY
-      - _APP_STORAGE_BACKBLAZE_SECRET
-      - _APP_STORAGE_BACKBLAZE_REGION
-      - _APP_STORAGE_BACKBLAZE_BUCKET
-      - _APP_STORAGE_LINODE_ACCESS_KEY
-      - _APP_STORAGE_LINODE_SECRET
-      - _APP_STORAGE_LINODE_REGION
-      - _APP_STORAGE_LINODE_BUCKET
-      - _APP_STORAGE_WASABI_ACCESS_KEY
-      - _APP_STORAGE_WASABI_SECRET
-      - _APP_STORAGE_WASABI_REGION
-      - _APP_STORAGE_WASABI_BUCKET
-      - _APP_DATABASE_SHARED_TABLES
+      - _APP_MIGRATIONS_FIREBASE_CLIENT_ID
+      - _APP_MIGRATIONS_FIREBASE_CLIENT_SECRET
+      - _APP_MIGRATION_HOST
+      - _APP_MAINTENANCE_RETENTION_AUDIT
+      - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
 
-  appwrite-worker-migrations:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-migrations
+  appwrite-task-scheduler:
+    image: appwrite/appwrite:2.0.0
+    entrypoint: schedule
     <<: *x-logging
     restart: unless-stopped
-    volumes:
-      - appwrite-imports:/storage/imports:rw
-      - appwrite-uploads:/storage/uploads:rw
     depends_on:
-      - ${_APP_DB_HOST:-mongodb}
+      redis:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
     environment:
       - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
+      # Combined mode runs functions/executions/messages timers + enqueue coroutines
+      # against shared console/cache pools; floor must cover concurrent ticks.
+      - _APP_WORKER_MAX_COROUTINES=8
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_OPENSSL_KEY_V1
+      - _APP_OPTIONS_FORCE_HTTPS
       - _APP_DOMAIN
-      - _APP_DOMAIN_TARGET_CNAME
-      - _APP_DOMAIN_TARGET_AAAA
-      - _APP_DOMAIN_TARGET_A
-      - _APP_DOMAIN_TARGET_CAA
-      - _APP_DNS
-      - _APP_EMAIL_SECURITY
+      - _APP_CONSOLE_DOMAIN
+      - _APP_CONSOLE_SCHEMA
+      - _APP_DOMAIN_FUNCTIONS
+      - _APP_DOMAIN_SITES
+      - _APP_MIGRATION_HOST
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
       - _APP_REDIS_USER
@@ -742,23 +499,34 @@ services:
       - _APP_DB_SCHEMA
       - _APP_DB_USER
       - _APP_DB_PASS
-      - _APP_LOGGING_CONFIG
-      - _APP_MIGRATIONS_FIREBASE_CLIENT_ID
-      - _APP_MIGRATIONS_FIREBASE_CLIENT_SECRET
       - _APP_DATABASE_SHARED_TABLES
-      - _APP_OPTIONS_FORCE_HTTPS
-      - _APP_MIGRATION_HOST
+      - _APP_USAGE_STATS
+      - _APP_USAGE_PASS
+      - _APP_CONNECTIONS_DB_USAGE
+      - _APP_POOL_SIZE_USAGE
+      - _APP_EXECUTIONS_DUAL_WRITE
+      - _APP_CONNECTIONS_DB_EXECUTIONS
+      - _APP_POOL_SIZE_EXECUTIONS
+      - _APP_MAINTENANCE_RETENTION_USAGE_TTL
+      - _APP_STATS_USAGE_QUEUE_NAME
+      - _APP_STATS_RESOURCES_QUEUE_NAME
+      - _APP_STATS_RESOURCES_INTERVAL
+      - _APP_FUNCTIONS_SCHEDULE_SPREAD
+      - _APP_LOGGING_FORMAT
 
   appwrite-task-maintenance:
-    image: appwrite/appwrite:1.9.5
+    image: appwrite/appwrite:2.0.0
     entrypoint: maintenance
     <<: *x-logging
     restart: unless-stopped
     depends_on:
-      - ${_APP_DB_HOST:-mongodb}
-      - redis
+      redis:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
     environment:
       - _APP_ENV
+      - _APP_EDITION
       - _APP_WORKER_PER_CORE
       - _APP_POOL_ADAPTER
       - _APP_DOMAIN
@@ -768,6 +536,7 @@ services:
       - _APP_DOMAIN_TARGET_CAA
       - _APP_DNS
       - _APP_DOMAIN_FUNCTIONS
+      - _APP_ROUTER_AUTO_CERTIFICATES
       - _APP_OPENSSL_KEY_V1
       - _APP_REDIS_HOST
       - _APP_REDIS_PORT
@@ -779,7 +548,9 @@ services:
       - _APP_DB_SCHEMA
       - _APP_DB_USER
       - _APP_DB_PASS
+      - _APP_DATABASE_SHARED_TABLES
       - _APP_MAINTENANCE_INTERVAL
+      - _APP_MAINTENANCE_START_TIME
       - _APP_MAINTENANCE_RETENTION_EXECUTION
       - _APP_MAINTENANCE_RETENTION_CACHE
       - _APP_MAINTENANCE_RETENTION_ABUSE
@@ -787,17 +558,18 @@ services:
       - _APP_MAINTENANCE_RETENTION_AUDIT_CONSOLE
       - _APP_MAINTENANCE_RETENTION_USAGE_HOURLY
       - _APP_MAINTENANCE_RETENTION_SCHEDULES
-      - _APP_MAINTENANCE_START_TIME
-      - _APP_DATABASE_SHARED_TABLES
+      - _APP_LOGGING_FORMAT
 
   appwrite-task-interval:
-    image: appwrite/appwrite:1.9.5
+    image: appwrite/appwrite:2.0.0
     entrypoint: interval
     <<: *x-logging
     restart: unless-stopped
     depends_on:
-      - ${_APP_DB_HOST:-mongodb}
-      - redis
+      redis:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
     environment:
       - _APP_ENV
       - _APP_WORKER_PER_CORE
@@ -824,202 +596,57 @@ services:
       - _APP_DATABASE_SHARED_TABLES
       - _APP_INTERVAL_DOMAIN_VERIFICATION
       - _APP_INTERVAL_CLEANUP_STALE_EXECUTIONS
-
-  appwrite-task-stats-resources:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: stats-resources
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    environment:
-      - _APP_ENV
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_USAGE_STATS
-      - _APP_LOGGING_CONFIG
-      - _APP_DATABASE_SHARED_TABLES
-      - _APP_STATS_RESOURCES_INTERVAL
-
-  appwrite-worker-stats-resources:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-stats-resources
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_USAGE_STATS
-      - _APP_LOGGING_CONFIG
-      - _APP_USAGE_AGGREGATION_INTERVAL
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-worker-stats-usage:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: worker-stats-usage
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - ${_APP_DB_HOST:-mongodb}
-    environment:
-      - _APP_ENV
-      - _APP_WORKERS_NUM=1
-      - _APP_WORKER_MAX_COROUTINES=1
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_USAGE_STATS
-      - _APP_LOGGING_CONFIG
-      - _APP_USAGE_AGGREGATION_INTERVAL
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-task-scheduler-functions:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: schedule-functions
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - ${_APP_DB_HOST:-mongodb}
-      - redis
-    environment:
-      - _APP_ENV
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_OPTIONS_FORCE_HTTPS
-      - _APP_DOMAIN
-      - _APP_CONSOLE_DOMAIN
-      - _APP_DOMAIN_FUNCTIONS
-      - _APP_DOMAIN_SITES
-      - _APP_MIGRATION_HOST
-      - _APP_CONSOLE_SCHEMA
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-task-scheduler-executions:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: schedule-executions
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - ${_APP_DB_HOST:-mongodb}
-      - redis
-    environment:
-      - _APP_ENV
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_OPTIONS_FORCE_HTTPS
-      - _APP_DOMAIN
-      - _APP_CONSOLE_DOMAIN
-      - _APP_DOMAIN_FUNCTIONS
-      - _APP_DOMAIN_SITES
-      - _APP_MIGRATION_HOST
-      - _APP_CONSOLE_SCHEMA
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-task-scheduler-messages:
-    image: appwrite/appwrite:1.9.5
-    entrypoint: schedule-messages
-    <<: *x-logging
-    restart: unless-stopped
-    depends_on:
-      - ${_APP_DB_HOST:-mongodb}
-      - redis
-    environment:
-      - _APP_ENV
-      - _APP_WORKER_PER_CORE
-      - _APP_POOL_ADAPTER
-      - _APP_OPENSSL_KEY_V1
-      - _APP_REDIS_HOST
-      - _APP_REDIS_PORT
-      - _APP_REDIS_USER
-      - _APP_REDIS_PASS
-      - _APP_DB_ADAPTER
-      - _APP_DB_HOST
-      - _APP_DB_PORT
-      - _APP_DB_SCHEMA
-      - _APP_DB_USER
-      - _APP_DB_PASS
-      - _APP_DATABASE_SHARED_TABLES
-
-  appwrite-assistant:
-    image: appwrite/assistant:0.8.4
-    <<: *x-logging
-    restart: unless-stopped
-    environment:
-      - _APP_ASSISTANT_OPENAI_API_KEY
+      - _APP_LOGGING_FORMAT
 
   appwrite-browser:
-    image: appwrite/browser:0.3.2
+    image: appwrite/browser:0.3.4
     <<: *x-logging
     restart: unless-stopped
 
+  appwrite-geo:
+    image: appwrite/geo:0.3.1
+    <<: *x-logging
+    restart: unless-stopped
+    environment:
+      - GEO_SECRET=$_APP_GEO_SECRET
+    healthcheck:
+      test: 'php -r "exit(json_decode(file_get_contents(''http://localhost/v1/health''))->status === ''ok'' ? 0 : 1);"'
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.4.3-alpine
+    <<: *x-logging
+    restart: unless-stopped
+    environment:
+      - CLICKHOUSE_DB=appwrite
+      - CLICKHOUSE_USER=appwrite
+      - CLICKHOUSE_PASSWORD=${_APP_USAGE_PASS:-appwrite}
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    volumes:
+      - appwrite-clickhouse:/var/lib/clickhouse:rw
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'clickhouse-client --user "$$CLICKHOUSE_USER" --password "$$CLICKHOUSE_PASSWORD" --query "SELECT 1" >/dev/null'
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
   openruntimes-executor:
+    image: openruntimes/executor:0.29.0
+    # The executor looks up its own container by hostname to join the runtimes network.
     hostname: openruntimes-executor
     <<: *x-logging
     restart: unless-stopped
     stop_signal: SIGINT
-    image: openruntimes/executor:0.25.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - appwrite-builds:/storage/builds:rw
@@ -1029,12 +656,11 @@ services:
       # It's not possible to share mount file between 2 containers without host mount (copying is too slow)
       - /tmp:/tmp:rw
     environment:
-      - OPR_EXECUTOR_CONNECTION_STORAGE=local://localhost
-      - OPR_EXECUTOR_CONNECTION_BUILD_CACHE_STORAGE=
       - OPR_EXECUTOR_IMAGES=$_APP_EXECUTOR_IMAGES
       - OPR_EXECUTOR_INACTIVE_THRESHOLD=$_APP_COMPUTE_INACTIVE_THRESHOLD
       - OPR_EXECUTOR_MAINTENANCE_INTERVAL=$_APP_COMPUTE_MAINTENANCE_INTERVAL
-      - OPR_EXECUTOR_NETWORK=$_APP_COMPUTE_RUNTIMES_NETWORK
+      # Runtime containers join this stack's default Compose network so they can reach the API and executor.
+      - OPR_EXECUTOR_NETWORK=${COMPOSE_PROJECT_NAME:-appwrite}_default
       - OPR_EXECUTOR_DOCKER_HUB_USERNAME=$_APP_DOCKER_HUB_USERNAME
       - OPR_EXECUTOR_DOCKER_HUB_PASSWORD=$_APP_DOCKER_HUB_PASSWORD
       - OPR_EXECUTOR_ENV=$_APP_ENV
@@ -1043,28 +669,8 @@ services:
       - OPR_EXECUTOR_RUNTIME_VERSIONS=v5
       - OPEN_RUNTIMES_NFT=$_APP_OPEN_RUNTIMES_NFT
       - OPR_EXECUTOR_LOGGING_CONFIG=$_APP_LOGGING_CONFIG
-      - OPR_EXECUTOR_STORAGE_DEVICE=$_APP_STORAGE_DEVICE
-      - OPR_EXECUTOR_STORAGE_S3_ACCESS_KEY=$_APP_STORAGE_S3_ACCESS_KEY
-      - OPR_EXECUTOR_STORAGE_S3_SECRET=$_APP_STORAGE_S3_SECRET
-      - OPR_EXECUTOR_STORAGE_S3_REGION=$_APP_STORAGE_S3_REGION
-      - OPR_EXECUTOR_STORAGE_S3_BUCKET=$_APP_STORAGE_S3_BUCKET
-      - OPR_EXECUTOR_STORAGE_S3_ENDPOINT=$_APP_STORAGE_S3_ENDPOINT
-      - OPR_EXECUTOR_STORAGE_DO_SPACES_ACCESS_KEY=$_APP_STORAGE_DO_SPACES_ACCESS_KEY
-      - OPR_EXECUTOR_STORAGE_DO_SPACES_SECRET=$_APP_STORAGE_DO_SPACES_SECRET
-      - OPR_EXECUTOR_STORAGE_DO_SPACES_REGION=$_APP_STORAGE_DO_SPACES_REGION
-      - OPR_EXECUTOR_STORAGE_DO_SPACES_BUCKET=$_APP_STORAGE_DO_SPACES_BUCKET
-      - OPR_EXECUTOR_STORAGE_BACKBLAZE_ACCESS_KEY=$_APP_STORAGE_BACKBLAZE_ACCESS_KEY
-      - OPR_EXECUTOR_STORAGE_BACKBLAZE_SECRET=$_APP_STORAGE_BACKBLAZE_SECRET
-      - OPR_EXECUTOR_STORAGE_BACKBLAZE_REGION=$_APP_STORAGE_BACKBLAZE_REGION
-      - OPR_EXECUTOR_STORAGE_BACKBLAZE_BUCKET=$_APP_STORAGE_BACKBLAZE_BUCKET
-      - OPR_EXECUTOR_STORAGE_LINODE_ACCESS_KEY=$_APP_STORAGE_LINODE_ACCESS_KEY
-      - OPR_EXECUTOR_STORAGE_LINODE_SECRET=$_APP_STORAGE_LINODE_SECRET
-      - OPR_EXECUTOR_STORAGE_LINODE_REGION=$_APP_STORAGE_LINODE_REGION
-      - OPR_EXECUTOR_STORAGE_LINODE_BUCKET=$_APP_STORAGE_LINODE_BUCKET
-      - OPR_EXECUTOR_STORAGE_WASABI_ACCESS_KEY=$_APP_STORAGE_WASABI_ACCESS_KEY
-      - OPR_EXECUTOR_STORAGE_WASABI_SECRET=$_APP_STORAGE_WASABI_SECRET
-      - OPR_EXECUTOR_STORAGE_WASABI_REGION=$_APP_STORAGE_WASABI_REGION
-      - OPR_EXECUTOR_STORAGE_WASABI_BUCKET=$_APP_STORAGE_WASABI_BUCKET
+      - OPR_EXECUTOR_CONNECTION_STORAGE=${_APP_EXECUTOR_CONNECTION_STORAGE:-local://localhost}
+      - OPR_EXECUTOR_CONNECTION_BUILD_CACHE_STORAGE=
     healthcheck:
       test:
         - CMD-SHELL
@@ -1074,60 +680,45 @@ services:
       retries: 20
       start_period: 5s
 
-  mongodb:
-    image: mongo:8.2.5
+  orchestrator:
+    image: ghcr.io/open-runtimes/orchestrator/orchestrator:1.9.2
+    hostname: orchestrator
+    <<: *x-logging
+    restart: unless-stopped
+    user: root
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - ORCHESTRATOR_BACKEND=docker
+      # Build job containers join this stack's default Compose network so they can reach the API and orchestrator.
+      - ORCHESTRATOR_NETWORK=${COMPOSE_PROJECT_NAME:-appwrite}_default
+      - DOCKER_NETWORK=${COMPOSE_PROJECT_NAME:-appwrite}_default
+      - ARTIFACT_ENDPOINT=http://orchestrator:8080
+      - S3_ENDPOINT=${_APP_STORAGE_S3_ENDPOINT:-}
+      - S3_REGION=${_APP_STORAGE_S3_REGION:-us-east-1}
+      - S3_ACCESS_KEY_ID=${_APP_STORAGE_S3_ACCESS_KEY:-}
+      - S3_SECRET_ACCESS_KEY=${_APP_STORAGE_S3_SECRET:-}
+
+  postgresql:
+    image: appwrite/postgres:0.1.0
     <<: *x-logging
     restart: unless-stopped
     volumes:
-      - appwrite-mongodb:/data/db
-      - appwrite-mongodb-keyfile:/data/keyfile
-      - ../files/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
-      - ../files/mongo-entrypoint.sh:/mongo-entrypoint.sh:ro
+      - appwrite-postgresql:/var/lib/postgresql:rw
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=root
-      - MONGO_INITDB_ROOT_PASSWORD=${_APP_DB_ROOT_PASS}
-      - MONGO_INITDB_DATABASE=${_APP_DB_SCHEMA}
-      - MONGO_INITDB_USERNAME=${_APP_DB_USER}
-      - MONGO_INITDB_PASSWORD=${_APP_DB_PASS}
-    entrypoint:
-      - /bin/bash
-      - /mongo-entrypoint.sh
+      - POSTGRES_DB=${_APP_DB_SCHEMA}
+      - POSTGRES_USER=${_APP_DB_USER}
+      - POSTGRES_PASSWORD=${_APP_DB_PASS}
+    command:
+      - postgres
     healthcheck:
-      test: |
-        bash -c "
-          mongosh -u root -p \"$$MONGO_INITDB_ROOT_PASSWORD\" --authenticationDatabase admin --quiet --eval \"
-            try {
-              const hello = db.adminCommand({hello: 1});
-              if (hello.isWritablePrimary) {
-                quit(0);
-              }
-            } catch (e) {}
-
-            try {
-              rs.initiate({_id: 'rs0', members: [{_id: 0, host: 'mongodb:27017'}]});
-            } catch (e) {}
-
-            quit(1);
-          \" 2>/dev/null
-        "
-      interval: 10s
-      timeout: 10s
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${_APP_DB_USER} -d ${_APP_DB_SCHEMA}
+      interval: 5s
+      timeout: 5s
       retries: 10
-      start_period: 30s
-
-  mariadb:
-    image: mariadb:10.11 # fix issues when upgrading using: mysql_upgrade -u root -p
-    <<: *x-logging
-    restart: unless-stopped
-    volumes:
-      - appwrite-mariadb:/var/lib/mysql:rw
-    environment:
-      - MYSQL_ROOT_PASSWORD=${_APP_DB_ROOT_PASS}
-      - MYSQL_DATABASE=${_APP_DB_SCHEMA}
-      - MYSQL_USER=${_APP_DB_USER}
-      - MYSQL_PASSWORD=${_APP_DB_PASS}
-      - MARIADB_AUTO_UPGRADE=1
-    command: "mysqld --innodb-flush-method=fsync"
+      start_period: 10s
 
   redis:
     image: redis:7.4.7-alpine
@@ -1140,6 +731,32 @@ services:
       --maxmemory-samples    5
     volumes:
       - appwrite-redis:/data:rw
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  # Appwrite Assistant (optional): set _APP_ASSISTANT_OPENAI_API_KEY and uncomment.
+  # appwrite-assistant:
+  #   image: appwrite/assistant:0.8.4
+  #   <<: *x-logging
+  #   restart: unless-stopped
+  #   environment:
+  #     - _APP_ASSISTANT_OPENAI_API_KEY
+
+  # Embeddings API (optional, resource heavy): set _APP_EMBEDDING=enabled and uncomment.
+  # appwrite-embedding:
+  #   image: appwrite/embedding:0.3.1
+  #   <<: *x-logging
+  #   restart: unless-stopped
+  #   environment:
+  #     - EMBEDDING_MODELS=nomic-embed-text
+  #   volumes:
+  #     - appwrite-models:/home/embedder/models
 
   # clamav:
   #   image: appwrite/clamav:1.2.0
@@ -1148,15 +765,17 @@ services:
   #     - appwrite-uploads:/storage/uploads
 
 volumes:
-  appwrite-mariadb:
-  appwrite-mongodb:
-  appwrite-mongodb-keyfile:
+  appwrite-postgresql:
   appwrite-redis:
+  appwrite-clickhouse:
   appwrite-cache:
   appwrite-uploads:
   appwrite-imports:
   appwrite-certificates:
   appwrite-functions:
   appwrite-sites:
+  # Pinned name so the orchestrator can attach it to build workers by a stable name (see _APP_BUILDS_VOLUME).
   appwrite-builds:
+    name: ${COMPOSE_PROJECT_NAME:-appwrite}_appwrite-builds
   appwrite-config:
+  # appwrite-models:

--- a/blueprints/appwrite/meta.json
+++ b/blueprints/appwrite/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "appwrite",
   "name": "Appwrite",
-  "version": "1.9.5",
+  "version": "2.0.0",
   "description": "Appwrite is an end-to-end platform for building Web, Mobile, Native, or Backend apps, packaged as a set of Docker microservices. It includes both a backend server and a fully integrated hosting solution for deploying static and server-side rendered frontends. Appwrite abstracts the complexity and repetitiveness required to build modern apps from scratch and allows you to build secure, full-stack applications faster.\nUsing Appwrite, you can easily integrate your app with user authentication and multiple sign-in methods, a database for storing and querying users and team data, storage and file management, image manipulation, Cloud Functions, messaging, and more services.",
   "links": {
     "github": "https://github.com/appwrite/appwrite",
@@ -12,8 +12,7 @@
   "tags": [
     "database",
     "firebase",
-    "mariadb",
-    "mongodb",
+    "postgresql",
     "hosting",
     "self-hosted"
   ]

--- a/blueprints/appwrite/template.toml
+++ b/blueprints/appwrite/template.toml
@@ -3,9 +3,12 @@ main_domain = "${domain}"
 functions_domain = "functions.${main_domain}"
 sites_domain = "sites.${main_domain}"
 openssl_key = "${password:32}"
-db_root_pw = "${password:32}"
-db_user_pw = "${password:32}"
+notifications_tracking_secret = "${password:32}"
+db_pw = "${password:32}"
+usage_pw = "${password:32}"
 executor_secret = "${password:32}"
+jobs_secret = "${password:32}"
+geo_secret = "${password:32}"
 
 [config]
 env = [
@@ -15,13 +18,14 @@ env = [
   "_APP_POOL_ADAPTER=stack",
   "_APP_WORKER_PER_CORE=6",
   "_APP_OPTIONS_ABUSE=enabled",
-  # Requires HTTPS to be enabled on the main domain in Dokploy (Domains tab).
-  # Makes Appwrite generate https:// URLs (e.g. APPWRITE_FUNCTION_API_ENDPOINT for
-  # Functions) and reject plain-HTTP API calls; over plain HTTP the console cannot log in.
-  "_APP_OPTIONS_FORCE_HTTPS=enabled",
+  "_APP_OPTIONS_ABUSE_INCREASED_LIMIT_PROJECTS=",
+  "_APP_OPTIONS_FORCE_HTTPS=disabled",
   "_APP_OPTIONS_ROUTER_FORCE_HTTPS=disabled",
   "_APP_OPTIONS_ROUTER_PROTECTION=disabled",
+  "_APP_ROUTER_AUTO_CERTIFICATES=enabled",
+  "_APP_LOCKING_ENABLED=enabled",
   "_APP_OPENSSL_KEY_V1=${openssl_key}",
+  "_APP_NOTIFICATIONS_TRACKING_SECRET=${notifications_tracking_secret}",
   "_APP_DOMAIN=${main_domain}",
   "_APP_CONSOLE_DOMAIN=${main_domain}",
   "_APP_CONSOLE_TRUSTED_PROJECTS=",
@@ -41,6 +45,15 @@ env = [
   "_APP_CONSOLE_SCHEMA=appwriteio",
   "_APP_CONSOLE_SESSION_ALERTS=disabled",
   "_APP_CONSOLE_COUNTRIES_DENYLIST=",
+  "_APP_CONSOLE_GITHUB_APP_ID=",
+  "_APP_CONSOLE_GITHUB_SECRET=",
+  "_APP_CONSOLE_GITLAB_APP_ID=",
+  "_APP_CONSOLE_GITLAB_SECRET=",
+  "_APP_CONSOLE_GITLAB_ENDPOINT=",
+  "_APP_CONSOLE_BITBUCKET_APP_ID=",
+  "_APP_CONSOLE_BITBUCKET_SECRET=",
+  "_APP_CONSOLE_GOOGLE_APP_ID=",
+  "_APP_CONSOLE_GOOGLE_SECRET=",
   "_APP_SYSTEM_EMAIL_NAME=Appwrite",
   "_APP_SYSTEM_EMAIL_ADDRESS=noreply@appwrite.io",
   "_APP_SYSTEM_TEAM_EMAIL=team@appwrite.io",
@@ -49,33 +62,55 @@ env = [
   "_APP_EMAIL_CERTIFICATES=",
   "_APP_COMPRESSION_ENABLED=enabled",
   "_APP_COMPRESSION_MIN_SIZE_BYTES=1024",
-  "_APP_USAGE_STATS=enabled",
-  "_APP_USAGE_AGGREGATION_INTERVAL=30",
-  "_APP_STATS_RESOURCES_INTERVAL=30",
   "_APP_LOGGING_PROVIDER=",
   "_APP_LOGGING_CONFIG=",
   "_APP_LOGGING_CONFIG_REALTIME=",
+  "_APP_LOGGING_FORMAT=pretty",
   "_APP_EXPERIMENT_LOGGING_PROVIDER=",
   "_APP_EXPERIMENT_LOGGING_CONFIG=",
+  "_APP_GEO_ENDPOINT=http://appwrite-geo/v1",
+  "_APP_GEO_SECRET=${geo_secret}",
   "_APP_REDIS_HOST=redis",
   "_APP_REDIS_PORT=6379",
   "_APP_REDIS_USER=",
   "_APP_REDIS_PASS=",
-  "_APP_DB_ADAPTER=mongodb",
-  "_APP_DB_HOST=mongodb",
-  "_APP_DB_PORT=27017",
+  "_APP_DB_ADAPTER=postgresql",
+  "_APP_DB_HOST=postgresql",
+  "_APP_DB_PORT=5432",
   "_APP_DB_SCHEMA=appwrite",
   "_APP_DB_USER=user",
-  "_APP_DB_PASS=${db_user_pw}",
-  "_APP_DB_ROOT_PASS=${db_root_pw}",
+  "_APP_DB_PASS=${db_pw}",
   "_APP_DATABASE_SHARED_TABLES=",
   "_APP_DATABASE_SHARED_NAMESPACE=",
-  "_APP_DB_ADAPTER_VECTORSDB=",
-  "_APP_DB_HOST_VECTORSDB=",
-  "_APP_DB_PORT_VECTORSDB=",
+  "_APP_LIMIT_DATABASE_BATCH=100",
+  "_APP_DOCUMENTSDB=disabled",
+  "_APP_DB_ADAPTER_DOCUMENTSDB=mongodb",
+  "_APP_DB_HOST_DOCUMENTSDB=mongodb",
+  "_APP_DB_PORT_DOCUMENTSDB=27017",
+  "_APP_DB_SCHEMA_DOCUMENTSDB=",
+  "_APP_DB_USER_DOCUMENTSDB=",
+  "_APP_DB_PASS_DOCUMENTSDB=",
+  "_APP_CONNECTIONS_DATABASE_DOCUMENTSDB=",
+  "_APP_VECTORSDB=disabled",
+  "_APP_DB_ADAPTER_VECTORSDB=postgresql",
+  "_APP_DB_HOST_VECTORSDB=postgresql",
+  "_APP_DB_PORT_VECTORSDB=5432",
   "_APP_DB_SCHEMA_VECTORSDB=",
   "_APP_DB_USER_VECTORSDB=",
   "_APP_DB_PASS_VECTORSDB=",
+  "_APP_CONNECTIONS_DATABASE_VECTORSDB=",
+  "_APP_EMBEDDING=disabled",
+  "_APP_USAGE_STATS=enabled",
+  "_APP_USAGE_PASS=${usage_pw}",
+  "_APP_CONNECTIONS_DB_USAGE=http://appwrite:${usage_pw}@clickhouse:8123/appwrite",
+  "_APP_POOL_SIZE_USAGE=2",
+  "_APP_EXECUTIONS_DUAL_WRITE=enabled",
+  "_APP_CONNECTIONS_DB_EXECUTIONS=http://appwrite:${usage_pw}@clickhouse:8123/appwrite",
+  "_APP_POOL_SIZE_EXECUTIONS=2",
+  "_APP_MAINTENANCE_RETENTION_USAGE_TTL=180",
+  "_APP_STATS_USAGE_QUEUE_NAME=v1-stats-usage",
+  "_APP_STATS_RESOURCES_QUEUE_NAME=v1-stats-resources",
+  "_APP_STATS_RESOURCES_INTERVAL=3600",
   "_APP_SMTP_HOST=",
   "_APP_SMTP_PORT=",
   "_APP_SMTP_SECURE=",
@@ -112,21 +147,25 @@ env = [
   "_APP_STORAGE_WASABI_REGION=eu-central-1",
   "_APP_STORAGE_WASABI_BUCKET=",
   "_APP_COMPUTE_SIZE_LIMIT=30000000",
-  "_APP_COMPUTE_BUILD_TIMEOUT=900",
+  "_APP_COMPUTE_BUILD_TIMEOUT=2700",
   "_APP_COMPUTE_CPUS=0",
   "_APP_COMPUTE_MEMORY=0",
   "_APP_COMPUTE_INACTIVE_THRESHOLD=60",
   "_APP_COMPUTE_MAINTENANCE_INTERVAL=3600",
-  "_APP_COMPUTE_RUNTIMES_NETWORK=dokploy-network",
+  "_APP_OPEN_RUNTIMES_NFT=enabled",
   "_APP_FUNCTIONS_TIMEOUT=900",
   "_APP_FUNCTIONS_CREATION_ABUSE_LIMIT=5000",
+  "_APP_FUNCTIONS_SCHEDULE_SPREAD=0",
   "_APP_FUNCTIONS_RUNTIMES=node-22,python-3.12,php-8.3,ruby-3.3,dart-3.5,go-1.23,rust-1.83,bun-1.1,deno-1.46,java-21.0,dotnet-8.0",
   "_APP_SITES_TIMEOUT=900",
   "_APP_SITES_RUNTIMES=static-1,node-22",
   "_APP_EXECUTOR_SECRET=${executor_secret}",
   "_APP_EXECUTOR_HOST=http://openruntimes-executor/v1",
   "_APP_EXECUTOR_IMAGES=openruntimes/node:v5-22,openruntimes/python:v5-3.12,openruntimes/php:v5-8.3,openruntimes/static:v5-1",
-  "_APP_OPEN_RUNTIMES_NFT=enabled",
+  "_APP_EXECUTOR_CONNECTION_STORAGE=local://localhost",
+  "_APP_JOBS_HOST=http://orchestrator:8080",
+  "_APP_JOBS_SECRET=${jobs_secret}",
+  "_APP_JOBS_ENDPOINT=http://appwrite",
   "_APP_BROWSER_HOST=http://appwrite-browser:3000/v1",
   "_APP_WORKER_SCREENSHOTS_ROUTER=http://appwrite",
   "_APP_DOCKER_HUB_USERNAME=",
@@ -153,60 +192,50 @@ env = [
   "_APP_VCS_GITHUB_CLIENT_ID=",
   "_APP_VCS_GITHUB_CLIENT_SECRET=",
   "_APP_VCS_GITHUB_WEBHOOK_SECRET=",
+  "_APP_VCS_GITEA_ENDPOINT=",
+  "_APP_VCS_GITEA_BROWSER_ENDPOINT=",
+  "_APP_VCS_GITEA_CLIENT_ID=",
+  "_APP_VCS_GITEA_CLIENT_SECRET=",
+  "_APP_VCS_GITEA_WEBHOOK_SECRET=",
+  "_APP_VCS_GITLAB_ENDPOINT=",
+  "_APP_VCS_GITLAB_CLIENT_ID=",
+  "_APP_VCS_GITLAB_CLIENT_SECRET=",
+  "_APP_VCS_GITLAB_WEBHOOK_SECRET=",
+  "_APP_VCS_BITBUCKET_CLIENT_ID=",
+  "_APP_VCS_BITBUCKET_CLIENT_SECRET=",
+  "_APP_VCS_BITBUCKET_WEBHOOK_SECRET=",
+  "_APP_VCS_ORIGIN_CLIENT_ID=",
+  "_APP_VCS_ORIGIN_PRIVATE_KEY=",
+  "_APP_VCS_WEBHOOK_URL=",
   "_APP_MIGRATION_HOST=appwrite",
   "_APP_MIGRATIONS_FIREBASE_CLIENT_ID=",
   "_APP_MIGRATIONS_FIREBASE_CLIENT_SECRET=",
   "_APP_ASSISTANT_OPENAI_API_KEY=",
 ]
 
-[[config.mounts]]
-filePath = "mongo-init.js"
-content = """// mongo-init.js
-
-// Switch to the admin database
-const adminDb = db.getSiblingDB('admin');
-
-// Get username and password from environment variables
-const username = process.env.MONGO_INITDB_USERNAME;
-const password = process.env.MONGO_INITDB_PASSWORD;
-const database = process.env.MONGO_INITDB_DATABASE;
-
-// Create the user
-adminDb.createUser({
-  user: username,
-  pwd: password,
-  roles: [
-    { role: 'readWrite', db: database }
-  ]
-});
-"""
-
-[[config.mounts]]
-filePath = "mongo-entrypoint.sh"
-content = """#!/bin/bash
-set -e
-
-# Fix keyfile permissions if mounted from volume
-KEYFILE_PATH="/data/keyfile/mongo-keyfile"
-
-if [ ! -f "$KEYFILE_PATH" ]; then
-  echo "Generating random MongoDB keyfile..."
-  mkdir -p /data/keyfile
-  openssl rand -base64 756 > "$KEYFILE_PATH"
-fi
-
-chmod 400 "$KEYFILE_PATH"
-chown mongodb:mongodb "$KEYFILE_PATH" 2>/dev/null || chown 999:999 "$KEYFILE_PATH"
-
-# Use MongoDB's standard entrypoint with our command
-exec docker-entrypoint.sh mongod --replSet rs0 --bind_ip_all --auth --keyFile "$KEYFILE_PATH"
-"""
+[[config.domains]]
+serviceName = "appwrite-console"
+port = 3000
+host = "${main_domain}"
+path = "/"
 
 [[config.domains]]
 serviceName = "appwrite"
 port = 80
 host = "${main_domain}"
-path = "/"
+path = "/v1"
+
+[[config.domains]]
+serviceName = "appwrite"
+port = 80
+host = "${main_domain}"
+path = "/.well-known"
+
+[[config.domains]]
+serviceName = "appwrite-realtime"
+port = 80
+host = "${main_domain}"
+path = "/v1/realtime"
 
 [[config.domains]]
 serviceName = "appwrite"
@@ -219,15 +248,3 @@ serviceName = "appwrite"
 port = 80
 host = "${functions_domain}"
 path = "/"
-
-[[config.domains]]
-serviceName = "appwrite-console"
-port = 80
-host = "${main_domain}"
-path = "/console"
-
-[[config.domains]]
-serviceName = "appwrite-realtime"
-port = 80
-host = "${main_domain}"
-path = "/v1/realtime"


### PR DESCRIPTION
## What

Updates the **Appwrite** template from `1.9.5` to `2.2.0` ([2.0.0](https://github.com/appwrite/appwrite/releases/tag/2.0.0) · [2.1.0](https://github.com/appwrite/appwrite/releases/tag/2.1.0) · [2.2.0](https://github.com/appwrite/appwrite/releases/tag/2.2.0)). 2.x is a new major: new root-path Console, PostgreSQL by default, builds on a new orchestrator, executions and usage in ClickHouse. The template mirrors what a stock `appwrite/appwrite:2.2.0 install` generates (I diffed the installer output for 2.0.0 and 2.2.0 to derive the delta), adapted for Dokploy routing.

### Changes vs 1.9.5

- **Images:** `appwrite/appwrite:2.2.0`, console `appwrite/new:1.1.96-self-hosted` (dedicated self-hosted build, no cloud CDN origin), `ghcr.io/open-runtimes/orchestrator/orchestrator:2.2.0`, `openruntimes/executor:0.29.0`, `appwrite/browser:0.3.4`, `appwrite/geo:0.3.1`, `ghcr.io/appwrite/autogravity:0.0.10`.
- **Database:** PostgreSQL (`appwrite/postgres:0.1.0`) replaces MongoDB/MariaDB and the Mongo init mounts.
- **New services:** `orchestrator` (function and site builds), `clickhouse` (usage and execution logs; executions are ClickHouse-only since 2.2), `appwrite-geo`, `appwrite-autogravity` (2.1: `gravity=auto` on image previews, wired via `_APP_AUTOGRAVITY_HOST`).
- **Combined worker topology:** `appwrite-worker` + `appwrite-task-scheduler` replace 13 per-queue containers (29 → 15 containers).
- **Routing:** console at `/`, API on `/v1` and `/.well-known` (ACME challenges, same split as the stock Traefik rules), realtime on `/v1/realtime`; `_APP_CONSOLE_URL_SCHEME=root`. Wildcard `*.sites` / `*.functions` routers unchanged.
- **Networking:** runtimes and build jobs join the stack's own `${COMPOSE_PROJECT_NAME}_default` network and the builds volume is pinned to `${COMPOSE_PROJECT_NAME}_appwrite-builds` (`_APP_BUILDS_VOLUME`), so the orchestrator can reach `appwrite`/`orchestrator` and mount builds without a custom `networks:` block or `dokploy-network` reference.
- **Env:** parity with the 2.2.0 installer. Added `_APP_AUTOGRAVITY_HOST`, `_APP_COMPUTE_BUILD_SIZE_LIMIT`. Removed the variables 2.1/2.2 dropped: `_APP_POOL_ADAPTER`, `_APP_LOGGING_PROVIDER`, `_APP_LOGGING_CONFIG_REALTIME`, `_APP_EXPERIMENT_LOGGING_*`, `_APP_EXECUTIONS_DUAL_WRITE`, `_APP_MAINTENANCE_RETENTION_USAGE_HOURLY`. New secrets generated per deployment; DocumentsDB/VectorsDB/embeddings present but `disabled` like the stock install. `appwrite-assistant` / `appwrite-embedding` left commented out.
- `meta.json`: `2.2.0`, tags `mariadb`/`mongodb` → `postgresql`.

## Testing

Rendered the template exactly as Dokploy does (resolved `.env` with `COMPOSE_PROJECT_NAME`, Dokploy's Traefik labels and `dokploy-network` attachment for the `[[config.domains]]` services) and ran it locally behind Traefik 3.6 on `aw22.localhost`.

**Static checks**
- ✅ `generate-meta.js --check`, `validate-docker-compose.ts`, `validate-template.ts`, `docker compose config`
- ✅ Per-service env set matches the stock 2.2.0 installer compose for every service

**Stack**
- ✅ 15 containers up, all healthchecks passing, 0 restarts; no errors in worker, scheduler, maintenance, interval, realtime, orchestrator, autogravity logs
- ✅ `/v1/health/version` → `2.2.0`; `/v1/health/{db,cache,storage,time}` pass
- ✅ Console at `/` (200), `/.well-known/*` → API, `/v1/realtime` → `101`, unknown `*.sites`/`*.functions` hosts → API router 404

**Console**
- ✅ Root sign-up, login, organization, project, API key. A second sign-up is rejected by `_APP_CONSOLE_WHITELIST_ROOT=enabled`, and a second organization by the 2.1 single-organization rule (both expected)
- ✅ 2.2 email policies: `GET /v1/project/policies`, `PATCH .../deny-disposable-email` and the Auth → Policies → Emails page

**Products**
- ✅ TablesDB on PostgreSQL: database, table, column, row create/update/query/delete
- ✅ Storage: upload, preview with `gravity=auto` served through the new autogravity service (200 `image/jpeg`)
- ✅ 2.1 S3-compatible API at `/v1/s3` with the AWS CLI (SigV4): `s3 ls`, `s3 cp` up and down, `head-object`; the object is visible through the Storage API
- ✅ `node-22` function: manual `tar.gz` deployment → orchestrator build job (`job-*-build-worker` + sidecar containers on `<app>_default`) → executor runtime → sync execution `200`, async execution `completed`, executions listed from ClickHouse, production `*.functions.<domain>` rule → `200`
- ✅ Static site: build → active deployment with preview screenshot; preview URL redirects to console auth (`/auth/preview`), production `*.sites.<domain>` rule serves `index.html`
- ✅ ClickHouse: `executions` and `projects_usage_events` tables populated

<img src="https://raw.githubusercontent.com/ChiragAgg5k/templates/assets/appwrite-2.2.0/01-console-organization.png" width="800" alt="New console at root path after sign-up">

<img src="https://raw.githubusercontent.com/ChiragAgg5k/templates/assets/appwrite-2.2.0/02-function-executions.png" width="800" alt="Function built by the orchestrator and executed with 200">

<img src="https://raw.githubusercontent.com/ChiragAgg5k/templates/assets/appwrite-2.2.0/03-site-deployments.png" width="800" alt="Static site deployment active with preview and production domain">

<img src="https://raw.githubusercontent.com/ChiragAgg5k/templates/assets/appwrite-2.2.0/04-auth-policies.png" width="800" alt="2.2 email policies working on self-hosted">

Wildcard HTTPS notes from #970 still apply.
