### PR TITLE
libredb-studio: bump version to 0.16.1 and add healthcheck

### DIFF
--- a/blueprints/libredb-studio/docker-compose.yml
+++ b/blueprints/libredb-studio/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   libredb-studio:
-    image: ghcr.io/libredb/libredb-studio:0.9.59
+    image: ghcr.io/libredb/libredb-studio:0.14.1
     restart: unless-stopped
     environment:
       - ADMIN_EMAIL=admin@libredb.org

--- a/blueprints/libredb-studio/docker-compose.yml
+++ b/blueprints/libredb-studio/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   libredb-studio:
-    image: ghcr.io/libredb/libredb-studio:0.14.1
+    image: ghcr.io/libredb/libredb-studio:0.15.0
     restart: unless-stopped
     environment:
       - ADMIN_EMAIL=admin@libredb.org

--- a/blueprints/libredb-studio/meta.json
+++ b/blueprints/libredb-studio/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "libredb-studio",
   "name": "LibreDB Studio",
-  "version": "0.9.59",
+  "version": "0.14.1",
   "description": "The modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
   "logo": "libredb-studio.svg",
   "links": {

--- a/blueprints/libredb-studio/meta.json
+++ b/blueprints/libredb-studio/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "libredb-studio",
   "name": "LibreDB Studio",
-  "version": "0.14.1",
-  "description": "The modern, AI-powered open-source SQL IDE. Query PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from your browser.",
+  "version": "0.15.0",
+  "description": "The open-source SQL IDE you host yourself. Query PostgreSQL, MySQL, Oracle, SQL Server, MongoDB, Redis, ClickHouse, Cassandra and more from your browser, 16 engines in one interface.",
   "logo": "libredb-studio.svg",
   "links": {
     "github": "https://github.com/libredb/libredb-studio",


### PR DESCRIPTION
## What is this PR about?

Bumps the LibreDB Studio blueprint from the published 0.9.59 to 0.16.1, the current release, and adds the healthcheck @nktnet1 asked for in review.

Three changes:

- `docker-compose.yml`: image tag moves to 0.16.1
- `docker-compose.yml`: adds the healthcheck from the review suggestion, unchanged
- `docker-compose.yml`: adds `AUTH_COOKIE_SECURE=false`
- `meta.json`: version field moves to 0.16.1

On `AUTH_COOKIE_SECURE`: Dokploy generates an HTTP `sslip.io` domain by default. The app marks its auth cookie Secure in production on any non-loopback host, so on a plain HTTP domain the browser drops the cookie and login silently loops. 0.16.1 is the first release that lets the operator override it. Four blueprints already in this repo do the same thing for the same reason, including `inkvoice`, which carries the same comment. Without this line the template installs fine and then fails at first login, and an API level check cannot see it because it is browser behaviour.

Tested before pushing, per the contributing guide. I brought this exact compose up against `ghcr.io/libredb/libredb-studio:0.16.1`:

- container reached `Up (healthy)`, so the healthcheck passes against this version
- `/api/db/health` answered `{"status":"healthy","service":"libredb-studio"}`
- `/api/storage/config` answered `{"provider":"sqlite","serverMode":true}`
- admin login with `ADMIN_PASSWORD` returned `{"success":true,"role":"admin"}`, and a wrong password returned HTTP 401
- the login `set-cookie` header carries `HttpOnly; SameSite=lax` and no `Secure` flag, which is what makes login work on an HTTP domain
- `/app/data` was written on the `libredb-data` volume
- after `docker compose restart` the container returned to healthy and login still worked

Environment variable names, the port and the `/app/data` mount path are unchanged from 0.9.59, so existing deployments keep their data across the upgrade.

This PR was opened on 8 September for 0.14.1. Newer releases shipped while it was open, so the branch is updated in place rather than replaced with a new PR. That is why the branch name still says 0.14.1.

## Checklist

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works. Not applicable: there is no test suite for blueprints. The repository validators pass and the deployment test is listed above.

## Issues related (if applicable)

None.
