### PR TITLE
chore(inkvoice): bump to 0.3.0 and cap memory at 512M

### DIFF
--- a/blueprints/inkvoice/docker-compose.yml
+++ b/blueprints/inkvoice/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   inkvoice:
-    image: ghcr.io/pigontech/inkvoice:0.1.0
+    image: ghcr.io/pigontech/inkvoice:0.3.0
     restart: unless-stopped
     environment:
       - ADMIN_USER=${ADMIN_USER}
@@ -17,6 +17,12 @@ services:
       - inkvoice-data:/app/data
     expose:
       - 3000
+    # Bun sizes its heap to the memory it can see. The cap keeps Inkvoice
+    # around 60 MB instead of ~120 MB uncapped.
+    deploy:
+      resources:
+        limits:
+          memory: 512M
 
 volumes:
   inkvoice-data:

--- a/blueprints/inkvoice/meta.json
+++ b/blueprints/inkvoice/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "inkvoice",
   "name": "Inkvoice",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Open-source invoicing for freelancers and small teams: invoices, online payments (Stripe & PayPal), expenses, multi-currency and reports.",
   "logo": "inkvoice.svg",
   "links": {


### PR DESCRIPTION
## What is this PR about?

Update of the Inkvoice template. I maintain Inkvoice and contributed the original template in #958.

- Bumps the image from `0.1.0` to `0.3.0` ([release notes](https://github.com/pigontech/inkvoice/releases/tag/v0.3.0)) and `version` in `blueprints/inkvoice/meta.json` to match.
- Adds a 512M memory limit through `deploy.resources.limits`. Inkvoice runs on Bun, which sizes its heap to the memory it can see, so without a cap it sits around 120 MB instead of about 60 MB.

`template.toml` is unchanged: same variables, env and domain mapping. Existing deployments keep their data volume, and database migrations run automatically on boot.

Validation so far:

- `node build-scripts/generate-meta.js --check` passes (518 templates)
- `validate-docker-compose.ts` and `validate-template.ts` pass for `blueprints/inkvoice`
- `docker compose config` resolves the new image and the 512M limit
- `ghcr.io/pigontech/inkvoice:0.3.0` is public and resolves anonymously for linux/amd64 and linux/arm64

## Checklist

Before submitting this PR, please make sure that:

- [ ] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [ ] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [ ] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

None.

## Screenshots or Videos

None.
