### PR TITLE
chore: update Windshift to v0.8.8

### DIFF
--- a/blueprints/windshift/docker-compose.yml
+++ b/blueprints/windshift/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   windshift:
-    image: ghcr.io/windshiftapp/windshift:v0.8.5
+    image: ghcr.io/windshiftapp/windshift:v0.8.8
     restart: unless-stopped
     environment:
       - BASE_URL=https://${DOMAIN}

--- a/blueprints/windshift/meta.json
+++ b/blueprints/windshift/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "windshift",
   "name": "Windshift",
-  "version": "v0.8.5",
+  "version": "v0.8.8",
   "description": "Self-hosted work management platform with projects, tasks, sprints, and team collaboration.",
   "logo": "windshift.png",
   "links": {


### PR DESCRIPTION
## What is this PR about?

Updates the Windshift template from v0.8.5 to v0.8.8 (follow-up to #1090).

- `blueprints/windshift/docker-compose.yml`: image `ghcr.io/windshiftapp/windshift:v0.8.5` → `v0.8.8`
- `blueprints/windshift/meta.json`: version `v0.8.5` → `v0.8.8`

No compose structure changes; only the image tag and displayed version move.

## Checklist

Before submitting this PR, please make sure that:

- [x] I have read the suggestions in the README.md file https://github.com/Dokploy/templates?tab=readme-ov-file#general-requirements-when-creating-a-template
- [x] I have tested the template in my instance, so the maintainers don't spend time trying to figure out what's wrong.
- [x] I have added tests that demonstrate that my correction works or that my new feature works.

## Issues related (if applicable)

None.

## Screenshots or Videos

Not needed for a version bump; the compose config validates cleanly and the `v0.8.8` image is published on ghcr.